### PR TITLE
fix: Optimize checkbox styling

### DIFF
--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -58,7 +58,7 @@ export const Checkbox: FC<CheckboxProps> = (props) => {
 
     return (
         <div className="tw-flex tw-flex-col tw-gap-1 tw-transition-colors" data-test-id="checkbox">
-            <label className="tw-group tw-flex tw-items-center tw-gap-2 tw-select-none">
+            <label className="tw-group tw-flex tw-items-center tw-gap-2 tw-select-none tw-outline-none hover:tw-cursor-pointer">
                 <input
                     {...mergeProps(inputProps, focusProps)}
                     id={id}
@@ -84,7 +84,6 @@ export const Checkbox: FC<CheckboxProps> = (props) => {
                                       "tw-border-black-80 tw-bg-white hover:tw-border-black dark:tw-border-white dark:tw-bg-black dark:hover:tw-border-black-20 dark:hover:tw-bg-black-90 group-hover:tw-bg-white group-hover:tw-border-black dark:group-hover:tw-border-black-20 dark:group-hover:tw-bg-black-90",
                                   isCheckedOrMixed(state) &&
                                       "tw-border-violet-60 tw-bg-violet-60 tw-text-white hover:tw-border-violet-70 hover:tw-bg-violet-70 dark:tw-border-violet-50 dark:tw-bg-violet-50 dark:hover:tw-border-violet-60 dark:hover:tw-bg-violet-60 group-hover:tw-text-white group-hover:tw-border-violet-70 group-hover:tw-bg-violet-70 dark:group-hover:tw-border-violet-60 dark:group-hover:tw-bg-violet-60",
-                                  "hover:tw-cursor-pointer",
                               ]),
                     ])}
                 >


### PR DESCRIPTION
Display pointer cursor for the whole width of the label (instead of only the length of the label text) and remove outline of the label