### PR TITLE
fix: increase z-index for dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -112,7 +112,7 @@ export const Dropdown: FC<DropdownProps> = ({
             <AnimatePresence>
                 {isOpen && (
                     <motion.div
-                        className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-10"
+                        className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-20"
                         key="content"
                         initial={{ height: 0 }}
                         animate={{ height: "auto" }}


### PR DESCRIPTION
This should fix the following problem. Labels in the Slider component had the same z-index value as the dropdown. This caused them to be visible when the dropdown is open.

<img width="301" alt="Bildschirmfoto 2021-10-26 um 07 54 36" src="https://user-images.githubusercontent.com/11270687/138817541-37a5a97e-4690-4011-adfc-c1dd571d2857.png">
