### PR TITLE
fix: HMR is not working when linked to other project

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "build:library": "vite build",
         "build:storybook": "build-storybook",
         "dev": "cross-env NODE_ENV=development npm run dev:library",
-        "dev:library": "vite build --watch",
+        "dev:library": "vite build --emptyOutDir false --watch",
         "clean": "rimraf dist",
         "component:create": "esno scripts/createNewComponent.ts",
         "generate:icons": "npm run generate:reactIcons && npm run generate:iconsMap",


### PR DESCRIPTION
HMR is not working when `@frontify/arcade` is linked to another project and we make modifications to `@frontify/arcade` while running `npm run dev`.
This is because Vite defaults to deleting the dist folder and recreating it every time a change happens. For some reason this behaviour makes webpack stuck until the development server is restarted. We get this error message:

![Screenshot 2022-04-29 at 14 22 12](https://user-images.githubusercontent.com/30796791/165945304-59b3a0a1-af61-4e27-9358-4b77776f1e4b.png)

This PR flips a flag that the dist folder should not be deleted during development.
