### PR TITLE
style: hide overflow from image

### DIFF
--- a/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -59,7 +59,7 @@ export const SelectedAsset: FC<Required<SelectedAssetProps>> = ({ asset, size, a
                 {...mergeProps(buttonProps, focusProps)}
                 ref={buttonRef}
                 className={merge([
-                    "tw-w-full tw-flex tw-border tw-rounded hover:tw-border-black-90 dark:hover:tw-border-black-40 focus-visible:tw-outline-none",
+                    "tw-w-full tw-flex tw-border tw-rounded tw-overflow-hidden hover:tw-border-black-90 dark:hover:tw-border-black-40 focus-visible:tw-outline-none",
                     isFocusVisible && FOCUS_STYLE,
                     size === AssetInputSize.Large ? "tw-h-[11.5rem] tw-flex-col" : "tw-h-14",
                     isOpen || isFocusVisible


### PR DESCRIPTION
Prevent overflow from thumbnail in asset input
<img width="228" alt="Screenshot 2022-04-29 at 14 48 24" src="https://user-images.githubusercontent.com/6846950/165947916-22fc4d19-9455-4c7c-ba53-b9625b6a1eb4.png">
