### PR TITLE
fix(Tree): Badge on editable tree node item

### DIFF
--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -170,7 +170,12 @@ export const Node = ({
                             </span>
                             {icon && <span className="tw-flex tw-justify-center tw-items-center tw-w-5">{icon}</span>}
                             {editable && onEditableSave ? (
-                                <EditableNodeItem name={name} targetItemId={node.id} onEditableSave={onEditableSave} />
+                                <EditableNodeItem
+                                    name={name}
+                                    targetItemId={node.id}
+                                    badge={badge && insertBadge()}
+                                    onEditableSave={onEditableSave}
+                                />
                             ) : (
                                 <span className="tw-flex tw-items-center" data-test-id="node-link-name">
                                     {name}

--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -170,12 +170,9 @@ export const Node = ({
                             </span>
                             {icon && <span className="tw-flex tw-justify-center tw-items-center tw-w-5">{icon}</span>}
                             {editable && onEditableSave ? (
-                                <EditableNodeItem
-                                    name={name}
-                                    targetItemId={node.id}
-                                    badge={badge && insertBadge()}
-                                    onEditableSave={onEditableSave}
-                                />
+                                <EditableNodeItem name={name} targetItemId={node.id} onEditableSave={onEditableSave}>
+                                    {badge && insertBadge()}
+                                </EditableNodeItem>
                             ) : (
                                 <span className="tw-flex tw-items-center" data-test-id="node-link-name">
                                     {name}

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -158,6 +158,10 @@ describe('Editable Tree Component', () => {
         cy.get(`${NODE_EDITABLE_ID}`).should('not.exist');
     });
 
+    it('renders the badge or icon on editable node', () => {
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(3) ${BADGE_ID}`).should('exist');
+    });
+
     it('renders the editable input on double click', () => {
         cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(3) ${NODE_LINK_NAME_ID}`).dblclick();
         cy.get(`${NODE_EDITABLE_ID}`).should('exist');
@@ -181,7 +185,7 @@ describe('Editable Tree Component', () => {
         cy.get('@onEditableSaveStub').should('be.called');
     });
 
-    it('calls the onEditableSave on blue', () => {
+    it('calls the onEditableSave on blur', () => {
         cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(3) ${NODE_LINK_NAME_ID}`).dblclick();
         cy.get(`${SUB_TREE_ID}  > ${NODE_ID}:first`).click();
         cy.get('@onEditableSaveStub').should('be.called');

--- a/src/components/Tree/components/EditableNodeItem.tsx
+++ b/src/components/Tree/components/EditableNodeItem.tsx
@@ -4,21 +4,19 @@ import React, {
     FocusEventHandler,
     KeyboardEvent,
     KeyboardEventHandler,
-    ReactElement,
+    ReactNode,
     useRef,
     useState,
 } from 'react';
 
-import { BadgeProps, IconProps } from '../../..';
-
 export interface EditableNodeItem {
     name: string;
     targetItemId: string;
-    badge?: ReactElement<IconProps> | ReactElement<BadgeProps>;
     onEditableSave: (targetItemId: string, value: string) => void;
+    children: ReactNode;
 }
 
-export const EditableNodeItem = ({ name, targetItemId, badge, onEditableSave }: EditableNodeItem) => {
+export const EditableNodeItem = ({ name, targetItemId, onEditableSave, children }: EditableNodeItem) => {
     const [inputValue, setInputValue] = useState(name);
     const [showInput, setShowInput] = useState<boolean>(false);
 
@@ -51,19 +49,23 @@ export const EditableNodeItem = ({ name, targetItemId, badge, onEditableSave }: 
     return (
         <div>
             {showInput ? (
-                <div
-                    data-test-id="node-editable"
-                    className="tw-flex tw-items-center tw-h-6 tw-gap-2 tw-px-3 tw-border tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent"
-                >
-                    <input
-                        ref={inputRef}
-                        type="text"
-                        className="tw-w-full tw-grow tw-border-none tw-outline-none tw-bg-transparent tw-hide-input-arrows tw-text-black tw-placeholder-black-60 dark:tw-text-white"
-                        value={inputValue}
-                        onChange={handleInputChange}
-                        onKeyDown={handleKeyDown}
-                        onBlur={handleBlur}
-                    />
+                <div className="tw-flex tw-items-center">
+                    <div
+                        data-test-id="node-editable"
+                        className="tw-flex tw-items-center tw-h-6 tw-gap-2 tw-px-3 tw-border tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent"
+                    >
+                        <input
+                            ref={inputRef}
+                            type="text"
+                            className="tw-w-full tw-grow tw-border-none tw-outline-none tw-bg-transparent tw-hide-input-arrows tw-text-black tw-placeholder-black-60 dark:tw-text-white"
+                            value={inputValue}
+                            onChange={handleInputChange}
+                            onKeyDown={handleKeyDown}
+                            onBlur={handleBlur}
+                        />
+                    </div>
+
+                    {children}
                 </div>
             ) : (
                 <div
@@ -72,7 +74,7 @@ export const EditableNodeItem = ({ name, targetItemId, badge, onEditableSave }: 
                     onDoubleClick={handleDoubleClick}
                 >
                     {name}
-                    {badge}
+                    {children}
                 </div>
             )}
         </div>

--- a/src/components/Tree/components/EditableNodeItem.tsx
+++ b/src/components/Tree/components/EditableNodeItem.tsx
@@ -4,17 +4,21 @@ import React, {
     FocusEventHandler,
     KeyboardEvent,
     KeyboardEventHandler,
+    ReactElement,
     useRef,
     useState,
 } from 'react';
 
+import { BadgeProps, IconProps } from '../../..';
+
 export interface EditableNodeItem {
     name: string;
     targetItemId: string;
+    badge?: ReactElement<IconProps> | ReactElement<BadgeProps>;
     onEditableSave: (targetItemId: string, value: string) => void;
 }
 
-export const EditableNodeItem = ({ name, targetItemId, onEditableSave }: EditableNodeItem) => {
+export const EditableNodeItem = ({ name, targetItemId, badge, onEditableSave }: EditableNodeItem) => {
     const [inputValue, setInputValue] = useState(name);
     const [showInput, setShowInput] = useState<boolean>(false);
 
@@ -62,8 +66,13 @@ export const EditableNodeItem = ({ name, targetItemId, onEditableSave }: Editabl
                     />
                 </div>
             ) : (
-                <div data-test-id="node-link-name" onDoubleClick={handleDoubleClick}>
+                <div
+                    data-test-id="node-link-name"
+                    className="tw-flex tw-items-center"
+                    onDoubleClick={handleDoubleClick}
+                >
                     {name}
+                    {badge}
                 </div>
             )}
         </div>

--- a/src/components/Tree/utils/mocks.tsx
+++ b/src/components/Tree/utils/mocks.tsx
@@ -97,6 +97,7 @@ const testCategoryNodes = [
         value: 'https://weare.frontify.com/page/4',
         icon: <IconDocument size={IconSize.Size16} />,
         sort: null,
+        badge: <Badge icon={<IconFaceExtraHappy size={IconSize.Size16} />}></Badge>,
         editable: true,
     },
     {
@@ -107,8 +108,6 @@ const testCategoryNodes = [
         value: 'https://weare.frontify.com/page/5',
         icon: <IconDocument size={IconSize.Size16} />,
         sort: null,
-        badge: <Badge icon={<IconFaceExtraHappy size={IconSize.Size16} />}></Badge>,
-        editable: true,
     },
     {
         id: '1-2-3',

--- a/src/components/Tree/utils/mocks.tsx
+++ b/src/components/Tree/utils/mocks.tsx
@@ -108,6 +108,7 @@ const testCategoryNodes = [
         icon: <IconDocument size={IconSize.Size16} />,
         sort: null,
         badge: <Badge icon={<IconFaceExtraHappy size={IconSize.Size16} />}></Badge>,
+        editable: true,
     },
     {
         id: '1-2-3',


### PR DESCRIPTION
There was a use case that I missed when developing the badge and editable feature, they didn't work together.

This is basically just adding a prop to the `EditableNodeItem` component so it also includes the badge (or icon) if it exists.