### PR TITLE
fix(Tree): Item multiselect bug

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -99,6 +99,8 @@ export const Tree: FC<TreeProps> = ({
     const downKeyHandler = (event: KeyboardEvent) => {
         if (event.key === 'Meta' || event.ctrlKey) {
             setMultiSelectMode(true);
+        } else {
+            setMultiSelectMode(false);
         }
     };
 
@@ -111,6 +113,7 @@ export const Tree: FC<TreeProps> = ({
     useEffect(() => {
         window.addEventListener('keydown', downKeyHandler);
         window.addEventListener('keyup', upKeyHandler);
+
         return () => {
             window.removeEventListener('keydown', downKeyHandler);
             window.removeEventListener('keyup', upKeyHandler);


### PR DESCRIPTION
There is currently a minor bug when selecting multiple items in the tree.

Since the code was only checking if the `command` or `control` key were pressed, there was some unexpected behavior when doing something like `command+tab` or `command+f` on the page. You can reproduce it on the [fondue-components](https://fondue-components.frontify.com/?path=/story/components-tree--tree), press `command+f` for example, and the multi-select will always be on. This PR fixes it.