### PR TITLE
feat(Textarea): added autosize property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "react-dnd-html5-backend": "^15.1.2",
                 "react-is": "^18.1.0",
                 "react-popper": "^2.2.5",
+                "react-textarea-autosize": "^8.3.4",
                 "slate": "^0.78.0",
                 "slate-history": "^0.66.0",
                 "slate-hyperscript": "^0.77.0",
@@ -21185,19 +21186,19 @@
             }
         },
         "node_modules/react-textarea-autosize": {
-            "version": "8.3.3",
-            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-            "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+            "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
             "dependencies": {
                 "@babel/runtime": "^7.10.2",
-                "use-composed-ref": "^1.0.0",
-                "use-latest": "^1.0.0"
+                "use-composed-ref": "^1.3.0",
+                "use-latest": "^1.2.1"
             },
             "engines": {
                 "node": ">=10"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/react-universal-interface": {
@@ -42604,13 +42605,13 @@
             }
         },
         "react-textarea-autosize": {
-            "version": "8.3.3",
-            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-            "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+            "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
             "requires": {
                 "@babel/runtime": "^7.10.2",
-                "use-composed-ref": "^1.0.0",
-                "use-latest": "^1.0.0"
+                "use-composed-ref": "^1.3.0",
+                "use-latest": "^1.2.1"
             }
         },
         "react-universal-interface": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
         "react-dnd-html5-backend": "^15.1.2",
         "react-is": "^18.1.0",
         "react-popper": "^2.2.5",
+        "react-textarea-autosize": "^8.3.4",
         "slate": "^0.78.0",
         "slate-history": "^0.66.0",
         "slate-hyperscript": "^0.77.0",

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -9,46 +9,47 @@ const PLACEHOLDER = 'This is the placeholder';
 const DECORATOR_TEXT = 'And also a decorator';
 const DECORATOR = <span>{DECORATOR_TEXT}</span>;
 const INPUT_TEXT = 'some text';
+const ROW_HEIGHT = 16;
+const TEXTAREA_ID = 'textarea.tw-border';
 
 describe('Textarea component', () => {
     it('renders', () => {
         mount(<Textarea></Textarea>);
-        cy.get('textarea').as('textarea');
-        cy.get('@textarea').should('not.have.attr', 'value');
-        cy.get('@textarea').should('not.have.attr', 'required');
-        cy.get('@textarea').should('not.have.attr', 'placeholder');
-        cy.get('@textarea').should('not.have.attr', 'disabled');
-        cy.get('@textarea').find('[data-test-id="decorator"]').should('have.length', 0);
+        cy.get(TEXTAREA_ID).should('not.have.attr', 'value');
+        cy.get(TEXTAREA_ID).should('not.have.attr', 'required');
+        cy.get(TEXTAREA_ID).should('not.have.attr', 'placeholder');
+        cy.get(TEXTAREA_ID).should('not.have.attr', 'disabled');
+        cy.get(TEXTAREA_ID).find('[data-test-id="decorator"]').should('have.length', 0);
     });
 
     it('sets and gets the value', () => {
         mount(<Textarea value={DEFAULT_TEXT}></Textarea>);
-        cy.get('textarea').should('have.value', DEFAULT_TEXT);
+        cy.get(TEXTAREA_ID).should('have.value', DEFAULT_TEXT);
     });
 
     it('has the required attribute', () => {
         mount(<Textarea required={true}></Textarea>);
-        cy.get('textarea').should('have.attr', 'required');
+        cy.get(TEXTAREA_ID).should('have.attr', 'required');
     });
 
     it('does not have the required attribute', () => {
         mount(<Textarea required={false}></Textarea>);
-        cy.get('textarea').should('not.have.attr', 'required');
+        cy.get(TEXTAREA_ID).should('not.have.attr', 'required');
     });
 
     it('has the disabled attribute', () => {
         mount(<Textarea disabled={true}></Textarea>);
-        cy.get('textarea').should('have.attr', 'disabled');
+        cy.get(TEXTAREA_ID).should('have.attr', 'disabled');
     });
 
     it('does not have the disabled attribute', () => {
         mount(<Textarea disabled={false}></Textarea>);
-        cy.get('textarea').should('not.have.attr', 'disabled');
+        cy.get(TEXTAREA_ID).should('not.have.attr', 'disabled');
     });
 
     it('renders the placeholder', () => {
         mount(<Textarea placeholder={PLACEHOLDER}></Textarea>);
-        cy.get('textarea').should('have.attr', 'placeholder').and('eq', PLACEHOLDER);
+        cy.get(TEXTAREA_ID).should('have.attr', 'placeholder').and('eq', PLACEHOLDER);
     });
 
     it('renders the decorator', () => {
@@ -59,14 +60,48 @@ describe('Textarea component', () => {
     it('calls the onInput event', () => {
         const onInputStub = cy.stub().as('onInputStub');
         mount(<Textarea onInput={onInputStub}></Textarea>);
-        cy.get('textarea').type(INPUT_TEXT);
+        cy.get(TEXTAREA_ID).type(INPUT_TEXT);
         cy.get('@onInputStub').should('to.have.always.been.callCount', INPUT_TEXT.length);
     });
 
     it('calls the onBlur event', () => {
         const onBlurStub = cy.stub().as('onBlurStub');
         mount(<Textarea onBlur={onBlurStub}></Textarea>);
-        cy.get('textarea').type(INPUT_TEXT).blur();
+        cy.get(TEXTAREA_ID).type(INPUT_TEXT).blur();
         cy.get('@onBlurStub').should('be.calledOnce');
+    });
+
+    it('starts with the minimum number of rows', () => {
+        mount(<Textarea minRows={4} autosize />);
+        cy.get(TEXTAREA_ID).should(($textarea) => {
+            const height = $textarea.height() ?? 0;
+            expect(Math.round(height)).to.equal(ROW_HEIGHT * 4);
+        });
+    });
+
+    it('automatically grows in height', () => {
+        mount(<Textarea minRows={1} autosize />);
+        cy.get(TEXTAREA_ID).should(($textarea) => {
+            const height = $textarea.height() ?? 0;
+            expect(Math.round(height)).to.equal(ROW_HEIGHT);
+        });
+        cy.get(TEXTAREA_ID).type('{enter}{enter}');
+        cy.get(TEXTAREA_ID).should(($textarea) => {
+            const height = $textarea.height() ?? 0;
+            expect(Math.round(height)).to.equal(ROW_HEIGHT * 3);
+        });
+    });
+
+    it('does not grow more than max height', () => {
+        mount(<Textarea minRows={1} maxRows={2} autosize />);
+        cy.get(TEXTAREA_ID).should(($textarea) => {
+            const height = $textarea.height() ?? 0;
+            expect(Math.round(height)).to.equal(ROW_HEIGHT);
+        });
+        cy.get(TEXTAREA_ID).type('{enter}{enter}');
+        cy.get(TEXTAREA_ID).should(($textarea) => {
+            const height = $textarea.height() ?? 0;
+            expect(Math.round(height)).to.equal(ROW_HEIGHT * 2);
+        });
     });
 });

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -10,7 +10,7 @@ const DECORATOR_TEXT = 'And also a decorator';
 const DECORATOR = <span>{DECORATOR_TEXT}</span>;
 const INPUT_TEXT = 'some text';
 const ROW_HEIGHT = 16;
-const TEXTAREA_ID = 'textarea.tw-border';
+const TEXTAREA_ID = '[data-test-id=textarea]';
 
 describe('Textarea component', () => {
     it('renders', () => {

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -104,4 +104,17 @@ describe('Textarea component', () => {
             expect(Math.round(height)).to.equal(ROW_HEIGHT * 2);
         });
     });
+
+    it('uses min-rows as rows if autosize is false', () => {
+        mount(<Textarea minRows={10} />);
+        cy.get(TEXTAREA_ID).should(($textarea) => {
+            const height = $textarea.height() ?? 0;
+            expect(Math.round(height)).to.equal(ROW_HEIGHT * 10);
+        });
+    });
+
+    it('removes resize handler', () => {
+        mount(<Textarea resizeable={false} />);
+        cy.get(TEXTAREA_ID).should('have.css', 'resize', 'none');
+    });
 });

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -12,6 +12,7 @@ export default {
         disabled: false,
         required: false,
         autosize: false,
+        resizeable: true,
         validation: Validation.Default,
     },
     argTypes: {

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -11,6 +11,7 @@ export default {
     args: {
         disabled: false,
         required: false,
+        autosize: false,
         validation: Validation.Default,
     },
     argTypes: {
@@ -24,6 +25,8 @@ export default {
             options: Object.values(Validation),
             control: { type: 'select' },
         },
+        minRows: { type: 'number' },
+        maxRows: { type: 'number' },
     },
 } as Meta<TextareaProps>;
 

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -65,6 +65,7 @@ export const Textarea: FC<TextareaProps> = ({
                     onInput: (event: FormEvent<HTMLTextAreaElement>) =>
                         onInput && onInput((event.target as HTMLTextAreaElement).value),
                 }) as TextareaAutosizeProps)}
+                {...(autosize ? autosizeProps : { rows: minRows })}
                 id={useMemoizedId(propId)}
                 value={value}
                 placeholder={placeholder}
@@ -80,7 +81,7 @@ export const Textarea: FC<TextareaProps> = ({
                     !resizeable && 'tw-resize-none',
                 ])}
                 disabled={disabled}
-                {...(autosize ? autosizeProps : { rows: minRows })}
+                data-test-id="textarea"
             />
             {validation === Validation.Loading && (
                 <span className="tw-absolute tw-top-[-0.55rem] tw-right-[-0.55rem] tw-bg-white tw-rounded-full tw-p-[2px] tw-border tw-border-black-10">

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -8,6 +8,7 @@ import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
 import { LoadingCircle, LoadingCircleSize } from '@components/LoadingCircle';
 import React, { FC, FocusEvent, FormEvent, ReactNode } from 'react';
+import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize';
 
 export type TextareaProps = {
     id?: string;
@@ -19,6 +20,9 @@ export type TextareaProps = {
     onInput?: (value: string) => void;
     onBlur?: (value: string) => void;
     validation?: Validation;
+    minRows?: number;
+    maxRows?: number;
+    autosize?: boolean;
 };
 
 export const Textarea: FC<TextareaProps> = ({
@@ -31,8 +35,15 @@ export const Textarea: FC<TextareaProps> = ({
     onInput,
     onBlur,
     validation = Validation.Default,
+    minRows,
+    maxRows,
+    autosize = false,
 }) => {
+    const Component = autosize ? TextareaAutosize : 'textarea';
+
     const { isFocusVisible, focusProps } = useFocusRing({ isTextInput: true });
+
+    const autosizeProps = { maxRows, minRows };
 
     return (
         <div className="tw-relative">
@@ -44,12 +55,12 @@ export const Textarea: FC<TextareaProps> = ({
                     {decorator}
                 </div>
             )}
-            <textarea
-                {...mergeProps(focusProps, {
+            <Component
+                {...(mergeProps(focusProps, {
                     onBlur: (event: FocusEvent<HTMLTextAreaElement>) => onBlur && onBlur(event.target.value),
                     onInput: (event: FormEvent<HTMLTextAreaElement>) =>
                         onInput && onInput((event.target as HTMLTextAreaElement).value),
-                })}
+                }) as TextareaAutosizeProps)}
                 id={useMemoizedId(propId)}
                 value={value}
                 placeholder={placeholder}
@@ -62,9 +73,11 @@ export const Textarea: FC<TextareaProps> = ({
                         : 'tw-text-black tw-border-black-20 hover:tw-border-black-90',
                     isFocusVisible && FOCUS_STYLE,
                     validationClassMap[validation],
+                    autosize && 'tw-resize-none',
                 ])}
                 disabled={disabled}
-            ></textarea>
+                {...(autosize ? autosizeProps : {})}
+            />
             {validation === Validation.Loading && (
                 <span className="tw-absolute tw-top-[-0.55rem] tw-right-[-0.55rem] tw-bg-white tw-rounded-full tw-p-[2px] tw-border tw-border-black-10">
                     <LoadingCircle size={LoadingCircleSize.ExtraSmall} />

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -20,9 +20,12 @@ export type TextareaProps = {
     onInput?: (value: string) => void;
     onBlur?: (value: string) => void;
     validation?: Validation;
+    /** When autosize if false, this is used as 'rows' property for standard textarea */
     minRows?: number;
+    /** When autosize if false, this property is ignored */
     maxRows?: number;
     autosize?: boolean;
+    resizeable?: boolean;
 };
 
 export const Textarea: FC<TextareaProps> = ({
@@ -38,6 +41,7 @@ export const Textarea: FC<TextareaProps> = ({
     minRows,
     maxRows,
     autosize = false,
+    resizeable = true,
 }) => {
     const Component = autosize ? TextareaAutosize : 'textarea';
 
@@ -73,10 +77,10 @@ export const Textarea: FC<TextareaProps> = ({
                         : 'tw-text-black tw-border-black-20 hover:tw-border-black-90',
                     isFocusVisible && FOCUS_STYLE,
                     validationClassMap[validation],
-                    autosize && 'tw-resize-none',
+                    !resizeable && 'tw-resize-none',
                 ])}
                 disabled={disabled}
-                {...(autosize ? autosizeProps : {})}
+                {...(autosize ? autosizeProps : { rows: minRows })}
             />
             {validation === Validation.Loading && (
                 <span className="tw-absolute tw-top-[-0.55rem] tw-right-[-0.55rem] tw-bg-white tw-rounded-full tw-p-[2px] tw-border tw-border-black-10">


### PR DESCRIPTION
Added a new feature to the Textarea component to be able to autosize when necessary. This component now has 3 new properties: autosize, minRows and maxRows. When setting the autosize to true (false by default) the textarea will automatically grow to max the size of the text until it hits the maxRow boundary. Since sizing is done computationally the resize handle for the textarea is removed for autosizing textareas.