### PR TITLE
chore: update fondue-tokens to v3.1.0-next.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@frontify/fondue",
             "version": "9.9.0",
             "dependencies": {
-                "@frontify/fondue-tokens": "^3.0.1",
+                "@frontify/fondue-tokens": "^3.1.0-next.1",
                 "@popperjs/core": "^2.11.5",
                 "@react-aria/accordion": "3.0.0-alpha.9",
                 "@react-aria/aria-modal-polyfill": "^3.4.3",
@@ -2446,9 +2446,9 @@
             }
         },
         "node_modules/@frontify/fondue-tokens": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@frontify/fondue-tokens/-/fondue-tokens-3.0.1.tgz",
-            "integrity": "sha512-r4EODHmTs2SKayUl+WoMmozTVoBqpP9rzKeToVGlvuUS0NizSIKazib4pgW2z6jmsALvPGYFQvtVi2Mmmwlj9w==",
+            "version": "3.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/@frontify/fondue-tokens/-/fondue-tokens-3.1.0-next.1.tgz",
+            "integrity": "sha512-ZPeS2qZd1bhA7v5GKSuraCK2gsZ6a0YtoOUWpVIOkd5BVLHcgMYNp2dZ/LIe+mw3f1BHKpii1qaHOAMZ2+wH1A==",
             "dependencies": {
                 "tailwindcss": "^3.0.15"
             }
@@ -28681,9 +28681,9 @@
             }
         },
         "@frontify/fondue-tokens": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@frontify/fondue-tokens/-/fondue-tokens-3.0.1.tgz",
-            "integrity": "sha512-r4EODHmTs2SKayUl+WoMmozTVoBqpP9rzKeToVGlvuUS0NizSIKazib4pgW2z6jmsALvPGYFQvtVi2Mmmwlj9w==",
+            "version": "3.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/@frontify/fondue-tokens/-/fondue-tokens-3.1.0-next.1.tgz",
+            "integrity": "sha512-ZPeS2qZd1bhA7v5GKSuraCK2gsZ6a0YtoOUWpVIOkd5BVLHcgMYNp2dZ/LIe+mw3f1BHKpii1qaHOAMZ2+wH1A==",
             "requires": {
                 "tailwindcss": "^3.0.15"
             }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "vite-plugin-dts": "1.0.5"
     },
     "dependencies": {
-        "@frontify/fondue-tokens": "^3.0.1",
+        "@frontify/fondue-tokens": "^3.1.0-next.1",
         "@popperjs/core": "^2.11.5",
         "@react-aria/accordion": "3.0.0-alpha.9",
         "@react-aria/aria-modal-polyfill": "^3.4.3",


### PR DESCRIPTION
Update to use the new tokens in fondue