### PR TITLE
Demo: useContainScroll

### DIFF
--- a/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
@@ -13,30 +13,40 @@ export default {
         disabled: false,
         currentColor: null,
         clearable: false,
+        closeOnScroll: false,
     },
     argTypes: {
         onDelete: { action: 'onDelete' },
     },
 } as Meta<ColorPickerFlyoutProps>;
 
-export const Flyout: Story<ColorPickerFlyoutProps> = ({ disabled, currentColor, clearable, onDelete }) => {
+export const Flyout: Story<ColorPickerFlyoutProps> = ({
+    disabled,
+    currentColor,
+    clearable,
+    onDelete,
+    closeOnScroll,
+}) => {
     const [temporaryColor, setTemporaryColor] = useState<Color | null>(null);
     const [selectedColor, setSelectedColor] = useState<Color | null>(currentColor);
 
     return (
-        <ColorPickerFlyoutComponent
-            disabled={disabled}
-            clearable={clearable}
-            currentColor={temporaryColor ?? selectedColor}
-            onClick={() => setSelectedColor(temporaryColor)}
-            onClose={() => setTemporaryColor(null)}
-            onSelect={(color) => setTemporaryColor(color)}
-            palettes={EXAMPLE_PALETTES}
-            onClear={() => {
-                setTemporaryColor(null);
-                setSelectedColor(null);
-            }}
-            onDelete={onDelete}
-        />
+        <div className="tw-h-[1500px] tw-pt-[400px]">
+            <ColorPickerFlyoutComponent
+                disabled={disabled}
+                clearable={clearable}
+                currentColor={temporaryColor ?? selectedColor}
+                onClick={() => setSelectedColor(temporaryColor)}
+                onClose={() => setTemporaryColor(null)}
+                onSelect={(color) => setTemporaryColor(color)}
+                palettes={EXAMPLE_PALETTES}
+                onClear={() => {
+                    setTemporaryColor(null);
+                    setSelectedColor(null);
+                }}
+                closeOnScroll={closeOnScroll}
+                onDelete={onDelete}
+            />
+        </div>
     );
 };

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -16,6 +16,8 @@ export type ColorPickerFlyoutProps = Pick<ColorPickerProps, 'palettes' | 'onSele
     clearable?: boolean;
     onClear?: () => void;
     onDelete?: () => void;
+    // For demo purposes
+    closeOnScroll: boolean;
 };
 
 export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
@@ -29,6 +31,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
     clearable = false,
     onClear,
     onDelete,
+    closeOnScroll,
 }) => {
     const [open, setOpen] = useState(false);
     const [currentFormat, setCurrentFormat] = useState(ColorFormat.Hex);
@@ -49,6 +52,8 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
         <Flyout
             hug={false}
             onConfirm={handleClick}
+            // For demo purposes
+            closeOnScroll={closeOnScroll}
             isOpen={open}
             onCancel={() => handleOpenChange(false)}
             fixedHeader={<ColorPreview color={currentColor || { r: 255, g: 255, b: 255 }} />}

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -66,6 +66,8 @@ export type FlyoutProps = PropsWithChildren<{
     placement?: FlyoutPlacement;
     offset?: number;
     updatePositionOnContentChange?: boolean;
+    // For demo purposes
+    closeOnScroll: boolean;
 }>;
 
 export const Flyout: FC<FlyoutProps> = ({
@@ -87,6 +89,7 @@ export const Flyout: FC<FlyoutProps> = ({
     placement = FlyoutPlacement.BottomLeft,
     offset,
     updatePositionOnContentChange = false,
+    closeOnScroll,
 }) => {
     const state = useOverlayTriggerState({ isOpen, onOpenChange });
     const { toggle, close } = state;
@@ -119,7 +122,12 @@ export const Flyout: FC<FlyoutProps> = ({
         return () => revert();
     }, []);
 
-    useContainScroll(overlayRef, { isDisabled: !isOpen });
+    useContainScroll(overlayRef, {
+        isDisabled:
+            !isOpen ||
+            // For demo purposes
+            closeOnScroll,
+    });
 
     const combinedTriggerProps = mergeProps(buttonProps, triggerProps, focusProps, {
         'aria-label': 'Toggle Flyout Menu',

--- a/src/components/Flyout/Overlay.tsx
+++ b/src/components/Flyout/Overlay.tsx
@@ -9,7 +9,10 @@ import { merge } from '@utilities/merge';
 import React, { Children, ForwardRefRenderFunction, HTMLAttributes, RefObject, forwardRef } from 'react';
 import { FlyoutProps } from '.';
 
-type OverlayProps = Omit<FlyoutProps, 'trigger' | 'onOpenChange' | 'onConfirm' | 'legacyFooter' | 'onCancel'> & {
+type OverlayProps = Omit<
+    FlyoutProps,
+    'trigger' | 'onOpenChange' | 'onConfirm' | 'legacyFooter' | 'onCancel' | 'closeOnScroll'
+> & {
     positionProps: HTMLAttributes<Element>;
     overlayTriggerProps: HTMLAttributes<Element>;
     scrollRef: RefObject<HTMLDivElement>;


### PR DESCRIPTION
An example of how the useContainScroll hook is used inside of the overlay. A new prop has been added to the color picker flyout to easily test the difference between having it and not having it enabled.

Root cause:
The [useOverlayTrigger](https://github.com/adobe/react-spectrum/blob/5d6e7ed6f3f6fc5ba381fc0e5a775b318e797140/packages/%40react-aria/overlays/src/useOverlayTrigger.ts#L44) passes a close handler to the useOverlayPosition hook. Internally the useOverlayPosition hook uses a [useCloseOnScroll](https://github.com/adobe/react-spectrum/blob/5d6e7ed6f3f6fc5ba381fc0e5a775b318e797140/packages/%40react-aria/overlays/src/useOverlayPosition.ts#L170) hook, which checks to see if the trigger of the overlay has moved (which it does if the body is scrollable and so closes the overlay to avoid it being misplaced).

This [issue](https://github.com/adobe/react-spectrum/issues/1852) has been opened on the react-spectrum github, but it does not look like there will be any workarounds available. One possible workaround would be to pass the updatePosition from the useOverlayPosition to the useOverlayTrigger as the `state.close` function (hacky but possible), however then we should probably find a way to remove the useOverlayPositionWithBottomMargin hook (used to make sure overlays don't get overlapped by the intercom button as this bug is currently preventing from using the [boundaryElement](https://github.com/adobe/react-spectrum/issues/2874) prop. Maybe this should be changed anyway since it is clarify logic really.)