### PR TITLE
feat(MultiSelect): add smaller variant

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -3,13 +3,14 @@
 import { Meta, Story } from '@storybook/react';
 import React, { useState } from 'react';
 import { FormControl } from '@components/FormControl';
-import { MultiSelect as MultiSelectComponent, MultiSelectProps, MultiSelectType } from './MultiSelect';
+import { MultiSelect as MultiSelectComponent, MultiSelectProps, MultiSelectSize, MultiSelectType } from './MultiSelect';
 
 export default {
     title: 'Components/Multi Select',
     component: MultiSelectComponent,
     args: {
         type: MultiSelectType.Default,
+        size: MultiSelectSize.Medium,
         activeItemKeys: ['Short tag', 'Tag 74'],
         items: [
             {
@@ -35,6 +36,10 @@ export default {
     argTypes: {
         type: {
             options: Object.keys(MultiSelectType),
+            control: { type: 'select' },
+        },
+        size: {
+            options: Object.keys(MultiSelectSize),
             control: { type: 'select' },
         },
     },

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,18 +1,25 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Checklist, ChecklistDirection } from '@components/Checklist/Checklist';
-import { Tag, TagType } from '@components/Tag/Tag';
+import { Tag, TagSize, TagType } from '@components/Tag/Tag';
 import { Trigger } from '@components/Trigger/Trigger';
 import { useButton } from '@react-aria/button';
 import { FocusScope, useFocusRing } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import { mergeProps } from '@react-aria/utils';
+import { merge } from '@utilities/merge';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { FC, useRef, useState } from 'react';
+import { getSizeClasses } from './helpers';
 
 export enum MultiSelectType {
     Default = 'Default',
     Summarized = 'Summarized',
+}
+
+export enum MultiSelectSize {
+    Small = 'Small',
+    Medium = 'Medium',
 }
 
 export type MultiSelectItem = {
@@ -28,6 +35,7 @@ export type MultiSelectProps = {
     ariaLabel?: string;
     placeholder?: string;
     type?: MultiSelectType;
+    size?: MultiSelectSize;
 };
 
 export const MultiSelect: FC<MultiSelectProps> = ({
@@ -38,6 +46,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
     disabled = false,
     placeholder,
     type = MultiSelectType.Default,
+    size = MultiSelectSize.Medium,
 }) => {
     const [open, setOpen] = useState(false);
     const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -94,7 +103,10 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 <div
                     {...mergeProps(buttonProps, focusProps)}
                     ref={triggerRef}
-                    className="tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-pl-[19px] tw-py-[11px] tw-min-h-[34px] tw-outline-none tw-pr-7"
+                    className={merge([
+                        'tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-pl-[19px] tw-min-h-[34px] tw-outline-none tw-pr-7',
+                        getSizeClasses(size, activeItemKeys.length > 0),
+                    ])}
                 >
                     {type === MultiSelectType.Default &&
                         activeItemKeys.map((key) => (
@@ -102,6 +114,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                                 key={key}
                                 type={open ? TagType.SelectedWithFocus : TagType.Selected}
                                 label={key.toString()}
+                                size={size === MultiSelectSize.Small ? TagSize.Small : TagSize.Medium}
                                 onClick={() => toggleSelection(key)}
                             />
                         ))}
@@ -110,6 +123,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                         <Tag
                             type={open ? TagType.SelectedWithFocus : TagType.Selected}
                             label={summarizedLabel}
+                            size={size === MultiSelectSize.Small ? TagSize.Small : TagSize.Medium}
                             onClick={() => onSelectionChange([])}
                         />
                     )}

--- a/src/components/MultiSelect/helpers.ts
+++ b/src/components/MultiSelect/helpers.ts
@@ -1,0 +1,12 @@
+import { MultiSelectSize } from './MultiSelect';
+
+export const getSizeClasses = (size: MultiSelectSize, hasActiveKeys: boolean) => {
+    if (size === MultiSelectSize.Small) {
+        if (hasActiveKeys) {
+            return 'tw-py-1';
+        } else {
+            return 'tw-py-2';
+        }
+    }
+    return 'tw-py-[11px]';
+};

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -3,17 +3,22 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
-import { Tag, TagProps, TagType } from './Tag';
+import { Tag, TagProps, TagSize, TagType } from './Tag';
 
 export default {
     title: 'Components/Tag',
     component: Tag,
     args: {
         label: 'Label',
+        size: TagSize.Medium,
     },
     argTypes: {
         type: {
             options: Object.keys(TagType),
+            control: { type: 'select' },
+        },
+        size: {
+            options: Object.keys(TagSize),
             control: { type: 'select' },
         },
     },

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -6,7 +6,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, MouseEvent, useRef } from 'react';
+import React, { MouseEvent, useRef } from 'react';
 import { IconCross } from '@foundation/Icon';
 
 export enum TagType {
@@ -14,6 +14,11 @@ export enum TagType {
     Selected = 'Selected',
     SelectedWithFocus = 'SelectedWithFocus',
     PreviouslySelected = 'PreviouslySelected',
+}
+
+export enum TagSize {
+    Small = 'Small',
+    Medium = 'Medium',
 }
 
 export const tagStyles: Record<TagType, string> = {
@@ -33,15 +38,17 @@ type TagPropsSelected = {
     type: TagType.Selected | TagType.SelectedWithFocus;
     label: string;
     onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
+    size?: TagSize;
 };
 
 type TagPropsUnselected = {
     type: TagType.Suggested | TagType.PreviouslySelected;
     label: string;
     onClick?: null;
+    size?: TagSize;
 };
 
-export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
+export const Tag = ({ type, label, onClick, size = TagSize.Medium }: TagProps) => {
     const ref = useRef<HTMLButtonElement | null>(null);
     const { isFocusVisible, focusProps } = useFocusRing();
     const isClickable = (type === TagType.Selected || type === TagType.SelectedWithFocus) && onClick;
@@ -56,7 +63,8 @@ export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
         <button
             data-test-id="tag"
             className={merge([
-                'tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1 tw-break-word',
+                'tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group  tw-break-word',
+                size === TagSize.Small ? 'tw-px-[6px] tw-py-[2px]' : 'tw-px-2.5 tw-py-1',
                 tagStyles[type],
                 isClickable ? 'tw-cursor-pointer' : 'tw-cursor-default',
                 isFocusVisible && FOCUS_STYLE,


### PR DESCRIPTION
Add a smaller version to keep MultiSelect in line with other form components.

Before:
![image](https://user-images.githubusercontent.com/30796791/182114684-443944f0-f440-4630-8fb2-bec01b06d3d6.png)
![image](https://user-images.githubusercontent.com/30796791/182114849-290ebfd0-7143-4511-ac84-3cccae5b4c50.png)


After:
![image](https://user-images.githubusercontent.com/30796791/182114505-00b71e92-b334-4de8-973b-fe45d00d8c95.png)
![image](https://user-images.githubusercontent.com/30796791/182322826-482888fc-5114-4cc0-8fa0-70219c7ce1b8.png)

