### PR TITLE
fix(build): add back dependencies installation

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -67,6 +67,10 @@ jobs:
                   key: node_modules-${{ hashFiles('package-lock.json') }}
                   restore-keys: node_modules-
 
+            - name: Install dependencies
+              if: steps.npm_cache.outputs.cache-hit != 'true'
+              run: npm ci
+
             - name: Build Fondue
               run: npm run build
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,6 +33,10 @@ jobs:
                   key: node_modules-${{ hashFiles('package-lock.json') }}
                   restore-keys: node_modules-
 
+            - name: Install dependencies
+              if: steps.npm_cache.outputs.cache-hit != 'true'
+              run: npm ci
+
             - name: Component Tests
               run: npm run test
               env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,6 +33,10 @@ jobs:
                   key: node_modules-${{ hashFiles('package-lock.json') }}
                   restore-keys: node_modules-
 
+            - name: Install dependencies
+              if: steps.npm_cache.outputs.cache-hit != 'true'
+              run: npm ci
+
             - name: Component Tests
               run: npm run test
               env:


### PR DESCRIPTION
### Issue
Component tests fail sometimes with missing npm dependencies when running them via GitHub Workflows

### Solution
Add back the installation of dependencies, as we miss packages when the NPM cache does not provide them.