### PR TITLE
feat(ColorPicker)!: change color format

### DIFF
--- a/src/components/Badge/Badge.cy.tsx
+++ b/src/components/Badge/Badge.cy.tsx
@@ -94,12 +94,12 @@ describe('Badge component', () => {
     });
 
     it('should display custom status dot with Color value', () => {
-        const r = 30;
-        const g = 40;
-        const b = 50;
-        const a = 0.2;
+        const red = 30;
+        const green = 40;
+        const blue = 50;
+        const alpha = 0.2;
 
-        const DOT_COLOR = { r, g, b, a };
+        const DOT_COLOR = { red, green, blue, alpha };
 
         cy.mount(
             <Badge icon={<IconDocumentText />} status={DOT_COLOR}>
@@ -107,7 +107,7 @@ describe('Badge component', () => {
             </Badge>,
         );
 
-        cy.get(BADGE_STATUS_ID).should('have.css', 'backgroundColor', `rgba(${r}, ${g}, ${b}, ${a})`);
+        cy.get(BADGE_STATUS_ID).should('have.css', 'backgroundColor', `rgba(${red}, ${green}, ${blue}, ${alpha})`);
     });
 
     it('should display custom status dot with string value', () => {

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { getColorDisplayValue } from '@utilities/colors';
+import { getColorDisplayValue, toShortRgb } from '@utilities/colors';
 import React, { FC } from 'react';
 import tinycolor from 'tinycolor2';
 import { Color, ColorFormat } from '../../types/colors';
@@ -11,14 +11,14 @@ type Props = {
 };
 
 export const ColorInputTitle: FC<Props> = ({ currentColor, format }) => {
-    const { name, a } = currentColor;
-    const parsedColor = tinycolor(currentColor);
+    const { name, alpha } = currentColor;
+    const parsedColor = tinycolor(toShortRgb(currentColor));
     const colorValue = getColorDisplayValue(currentColor, format, false);
 
     return (
         <div className="tw-text-black-100">
             {name || colorValue}
-            {format === ColorFormat.Hex && a && a < 1 && (
+            {format === ColorFormat.Hex && alpha && alpha < 1 && (
                 <span className="tw-text-black-60">{` ${Math.trunc(parsedColor.getAlpha() * 100)} %`}</span>
             )}
         </div>

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.cy.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.cy.tsx
@@ -6,7 +6,7 @@ import { EXAMPLE_PALETTES } from '../ColorPicker/example-palettes';
 import { ColorPickerFlyout } from './ColorPickerFlyout';
 
 const TRIGGER_ID = '[data-test-id=trigger]';
-const TEST_COLOR = { r: 0, g: 133, b: 255 };
+const TEST_COLOR = { red: 0, green: 133, blue: 255 };
 const TEST_COLOR_HEX = '#0085ff';
 const TEST_COLOR_RGB = 'rgb(0, 133, 255)';
 const BUTTON_ID = '[data-test-id=button]';

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -51,7 +51,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
             onConfirm={handleClick}
             isOpen={open}
             onCancel={() => handleOpenChange(false)}
-            fixedHeader={<ColorPreview color={currentColor || { r: 255, g: 255, b: 255 }} />}
+            fixedHeader={<ColorPreview color={currentColor || { red: 255, green: 255, blue: 255 }} />}
             onOpenChange={handleOpenChange}
             trigger={
                 <ColorInputTrigger
@@ -81,7 +81,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
                 setFormat={setCurrentFormat}
                 palettes={palettes}
                 showPreview={false}
-                currentColor={currentColor || { r: 255, g: 255, b: 255 }}
+                currentColor={currentColor || { red: 255, green: 255, blue: 255 }}
                 onSelect={onSelect}
             />
         </Flyout>

--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -6,6 +6,7 @@ import IconDroplet from '@foundation/Icon/Generated/IconDroplet';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { useFocusRing } from '@react-aria/focus';
+import { toShortRgb } from '@utilities/colors';
 import { merge } from '@utilities/merge';
 import React, { FC } from 'react';
 import tinycolor from 'tinycolor2';
@@ -32,7 +33,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
     onDelete,
 }) => {
     const { isFocusVisible, focusProps } = useFocusRing();
-    const backgroundColor = currentColor ? tinycolor(currentColor).toRgbString() : '';
+    const backgroundColor = currentColor ? tinycolor(toShortRgb(currentColor)).toRgbString() : '';
 
     return (
         <Trigger

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -4,7 +4,7 @@ import { Slider } from '@components/Slider/Slider';
 import { TextInput } from '@components/TextInput/TextInput';
 import { IconCheckMark, IconGridRegular, IconMagnifier, IconStackVertical } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
-import { isColorLight } from '@utilities/colors';
+import { isColorLight, toShortRgb } from '@utilities/colors';
 import { merge } from '@utilities/merge';
 import React, { FC, useEffect, useState } from 'react';
 import tinycolor from 'tinycolor2';
@@ -92,12 +92,12 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                                                       'tw-h-6 tw-w-6 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center tw-ring-1 tw-ring-black-10 tw-ring-offset-1',
                                                       isColorLight(color) ? 'tw-text-black' : 'tw-text-white',
                                                   ])}
-                                                  style={{ background: tinycolor(color).toRgbString() }}
+                                                  style={{ background: tinycolor(toShortRgb(color)).toRgbString() }}
                                               >
-                                                  {color.r === currentColor.r &&
-                                                      color.g === currentColor.g &&
-                                                      color.b === currentColor.b &&
-                                                      color.a === currentColor.a && (
+                                                  {color.red === currentColor.red &&
+                                                      color.green === currentColor.green &&
+                                                      color.blue === currentColor.blue &&
+                                                      color.alpha === currentColor.alpha && (
                                                           <IconCheckMark size={IconSize.Size20} />
                                                       )}
                                               </span>

--- a/src/components/ColorPicker/ColorPicker.cy.tsx
+++ b/src/components/ColorPicker/ColorPicker.cy.tsx
@@ -21,7 +21,7 @@ type Props = {
     currentColor?: Color;
 };
 
-const Component: FC<Props> = ({ palettes, currentColor = { r: 255, g: 0, b: 0 } }) => {
+const Component: FC<Props> = ({ palettes, currentColor = { red: 255, green: 0, blue: 0 } }) => {
     const [selectedColor, setSelectedColor] = useState<Color>(currentColor);
     const [currentFormat, setCurrentFormat] = useState(ColorFormat.Hex);
 

--- a/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -10,7 +10,7 @@ export default {
     title: 'Components/Color Picker',
     component: ColorPicker,
     args: {
-        currentColor: { r: 85, g: 102, b: 255 },
+        currentColor: { red: 85, green: 102, blue: 255 },
     },
     argTypes: {
         onSelect: { action: 'Select Color' },

--- a/src/components/ColorPicker/ColorPreview.tsx
+++ b/src/components/ColorPicker/ColorPreview.tsx
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { toShortRgb } from '@utilities/colors';
 import React, { FC } from 'react';
 import tinycolor from 'tinycolor2';
 import { Color } from '../../types/colors';
@@ -9,7 +10,7 @@ type ColorPreviewProps = {
 };
 
 export const ColorPreview: FC<ColorPreviewProps> = ({ color }) => {
-    const parsedColor = tinycolor(color);
+    const parsedColor = tinycolor(toShortRgb(color));
     const backgroundColor = parsedColor.toRgbString();
 
     return (

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -70,7 +70,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                                 size={3}
                                 type={TextInputType.Number}
                                 value={red.toString()}
-                                onChange={(red) => onSelect({ ...currentColor, red: parseInt(red) })}
+                                onChange={(value) => onSelect({ ...currentColor, red: parseInt(value) })}
                             />
                         </div>
                         <div className="tw-flex-1">
@@ -80,7 +80,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                                 size={3}
                                 type={TextInputType.Number}
                                 value={green.toString()}
-                                onChange={(green) => onSelect({ ...currentColor, green: parseInt(green) })}
+                                onChange={(value) => onSelect({ ...currentColor, green: parseInt(value) })}
                             />
                         </div>
                         <div className="tw-flex-1">
@@ -90,7 +90,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                                 size={3}
                                 type={TextInputType.Number}
                                 value={blue.toString()}
-                                onChange={(blue) => onSelect({ ...currentColor, blue: parseInt(blue) })}
+                                onChange={(value) => onSelect({ ...currentColor, blue: parseInt(value) })}
                             />
                         </div>
                     </>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -104,9 +104,9 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                     decorator="%"
                     decoratorPosition={DecoratorPosition.Right}
                     onChange={(value) => {
-                        const alpha = parseInt(value || '0', 10) / 100;
-                        setAlphaValue(alpha);
-                        onSelect({ ...currentColor, alpha });
+                        const a = parseInt(value || '0', 10) / 100;
+                        setAlphaValue(a);
+                        onSelect({ ...currentColor, alpha: a });
                     }}
                 />
             </div>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -2,6 +2,7 @@
 
 import { Dropdown } from '@components/Dropdown/Dropdown';
 import { TextInputType } from '@components/TextInput/TextInput';
+import { toLongRgb, toShortRgb } from '@utilities/colors';
 import React, { FC, useEffect, useState } from 'react';
 import { RgbaColorPicker } from 'react-colorful';
 import tinycolor from 'tinycolor2';
@@ -9,7 +10,7 @@ import { Color, ColorFormat } from '../../types/colors';
 import { ColorInput, DecoratorPosition } from './ColorInput';
 import { ColorPickerProps } from './ColorPicker';
 
-const convertToHex = (color: Color) => tinycolor(color).toHex();
+const convertToHex = (color: Color) => tinycolor(toShortRgb(color)).toHex();
 
 export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
     currentColor,
@@ -23,19 +24,19 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
             menuItems: Object.values(ColorFormat).map((id) => ({ id, title: id.toLocaleUpperCase() })),
         },
     ];
-    const { r, g, b, a = 1 } = currentColor;
+    const { red, green, blue, alpha = 1 } = currentColor;
     const [hexInput, setHexInput] = useState(convertToHex(currentColor));
-    const [alpha, setAlpha] = useState(a);
+    const [alphaValue, setAlphaValue] = useState(alpha);
 
     const handleHexChange = () => {
         const parsedHex = tinycolor(hexInput);
         if (parsedHex.isValid()) {
-            onSelect(parsedHex.toRgb());
+            onSelect(toLongRgb(parsedHex.toRgb()));
         }
     };
 
     useEffect(() => {
-        setAlpha(a);
+        setAlphaValue(alpha);
         setHexInput(convertToHex(currentColor));
     }, [currentColor]);
 
@@ -68,8 +69,8 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                                 max={255}
                                 size={3}
                                 type={TextInputType.Number}
-                                value={r.toString()}
-                                onChange={(r) => onSelect({ ...currentColor, r: parseInt(r) })}
+                                value={red.toString()}
+                                onChange={(red) => onSelect({ ...currentColor, red: parseInt(red) })}
                             />
                         </div>
                         <div className="tw-flex-1">
@@ -78,8 +79,8 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                                 max={255}
                                 size={3}
                                 type={TextInputType.Number}
-                                value={g.toString()}
-                                onChange={(g) => onSelect({ ...currentColor, g: parseInt(g) })}
+                                value={green.toString()}
+                                onChange={(green) => onSelect({ ...currentColor, green: parseInt(green) })}
                             />
                         </div>
                         <div className="tw-flex-1">
@@ -88,8 +89,8 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                                 max={255}
                                 size={3}
                                 type={TextInputType.Number}
-                                value={b.toString()}
-                                onChange={(b) => onSelect({ ...currentColor, b: parseInt(b) })}
+                                value={blue.toString()}
+                                onChange={(blue) => onSelect({ ...currentColor, blue: parseInt(blue) })}
                             />
                         </div>
                     </>
@@ -99,19 +100,30 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
                     max={100}
                     size={3}
                     type={TextInputType.Number}
-                    value={Math.trunc(alpha * 100).toString()}
+                    value={Math.trunc(alphaValue * 100).toString()}
                     decorator="%"
                     decoratorPosition={DecoratorPosition.Right}
                     onChange={(value) => {
-                        const a = parseInt(value || '0', 10) / 100;
-                        setAlpha(a);
-                        onSelect({ ...currentColor, a });
+                        const alpha = parseInt(value || '0', 10) / 100;
+                        setAlphaValue(alpha);
+                        onSelect({ ...currentColor, alpha });
                     }}
                 />
             </div>
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
                 <div className="tw-relative tw-grow tw-rounded">
-                    <RgbaColorPicker color={{ ...currentColor, a }} onChange={onSelect} style={{ width: '100%' }} />
+                    <RgbaColorPicker
+                        color={{ r: red, g: green, b: blue, a: alpha }}
+                        onChange={(color) =>
+                            onSelect({
+                                red: color.r,
+                                green: color.g,
+                                blue: color.b,
+                                alpha: color.a,
+                            })
+                        }
+                        style={{ width: '100%' }}
+                    />
                 </div>
             </div>
         </div>

--- a/src/components/ColorPicker/example-palettes.ts
+++ b/src/components/ColorPicker/example-palettes.ts
@@ -9,7 +9,10 @@ const generatePalette = (color: string, amount: number): Color[] => {
         const name = (90 - index * 10).toString();
         const lightColor = sourceColor.lighten(index * 3).toRgb();
         return {
-            ...lightColor,
+            red: lightColor.r,
+            green: lightColor.g,
+            blue: lightColor.b,
+            alpha: lightColor.a,
             name,
         };
     });

--- a/src/types/colors.ts
+++ b/src/types/colors.ts
@@ -1,11 +1,18 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export type Color = {
+    red: number;
+    green: number;
+    blue: number;
+    alpha?: number;
+    name?: string;
+};
+
+export type ColorRgb = {
     r: number;
     g: number;
     b: number;
     a?: number;
-    name?: string;
 };
 
 export type Palette = {

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -1,23 +1,35 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import tinycolor from 'tinycolor2';
-import { Color, ColorFormat } from '../types/colors';
+import { Color, ColorFormat, ColorRgb } from '../types/colors';
 
 export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlpha = true): string => {
-    const parsedColor = tinycolor(color);
+    const parsedColor = tinycolor(toShortRgb(color));
 
     switch (format) {
         case ColorFormat.Rgba:
             return parsedColor.toRgbString();
         case ColorFormat.Hex:
             const hex = parsedColor.toHexString();
-            return showAlpha && color.a && color.a < 1 ? `${hex} ${Math.trunc(parsedColor.getAlpha() * 100)}%` : hex;
+            return showAlpha && color.alpha && color.alpha < 1
+                ? `${hex} ${Math.trunc(parsedColor.getAlpha() * 100)}%`
+                : hex;
         default:
             return parsedColor.toHexString();
     }
 };
 
 export const isColorLight = (color: Color): boolean => {
-    const parsedColor = tinycolor(color);
+    const parsedColor = tinycolor(toShortRgb(color));
     return parsedColor.isLight() || parsedColor.getAlpha() < 0.25;
+};
+
+export const toShortRgb = (color: Color): ColorRgb => {
+    const { red, green, blue, alpha } = color;
+    return { r: red, g: green, b: blue, a: alpha };
+};
+
+export const toLongRgb = (color: ColorRgb): Color => {
+    const { r, g, b, a } = color;
+    return { red: r, green: g, blue: b, alpha: a };
 };


### PR DESCRIPTION
This PR changes the `ColorPicker` & `ColorInputFlyout` to work with the following color format to be consistent with the backend of Frontify.
```
{
   "red":234,
   "green":235,
   "blue":235,
   "alpha":1
}
```
Previously the short-notation rgb color format was used:
```
{
   "r":234,
   "g":235,
   "b":235,
   "a":1
}
```