### PR TITLE
fix: reduce padding on x axis of small multiselect

### DIFF
--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -104,7 +104,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                     {...mergeProps(buttonProps, focusProps)}
                     ref={triggerRef}
                     className={merge([
-                        'tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-min-h-[34px] tw-outline-none ',
+                        'tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-min-h-[34px] tw-outline-none',
                         getPaddingClasses(size, activeItemKeys.length > 0),
                     ])}
                 >

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -10,7 +10,7 @@ import { mergeProps } from '@react-aria/utils';
 import { merge } from '@utilities/merge';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { FC, useRef, useState } from 'react';
-import { getSizeClasses } from './helpers';
+import { getPaddingClasses } from './helpers';
 
 export enum MultiSelectType {
     Default = 'Default',
@@ -104,8 +104,8 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                     {...mergeProps(buttonProps, focusProps)}
                     ref={triggerRef}
                     className={merge([
-                        'tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-pl-[19px] tw-min-h-[34px] tw-outline-none tw-pr-7',
-                        getSizeClasses(size, activeItemKeys.length > 0),
+                        'tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-min-h-[34px] tw-outline-none ',
+                        getPaddingClasses(size, activeItemKeys.length > 0),
                     ])}
                 >
                     {type === MultiSelectType.Default &&

--- a/src/components/MultiSelect/helpers.ts
+++ b/src/components/MultiSelect/helpers.ts
@@ -1,10 +1,18 @@
 import { merge } from '@utilities/merge';
 import { MultiSelectSize } from './MultiSelect';
 
-export const getPaddingClasses = (size: MultiSelectSize, hasActiveKeys: boolean) =>
-    merge([
-        'tw-pr-9',
-        size === MultiSelectSize.Small
-            ? `tw-pl-3 ${hasActiveKeys ? 'tw-py-1' : 'tw-py-2'}`
-            : 'tw-pl-[19px] tw-py-[11px]',
-    ]);
+export const getPaddingClasses = (size: MultiSelectSize, hasActiveKeys: boolean) => {
+    const classes = ['tw-pr-9'];
+    switch (size) {
+        case MultiSelectSize.Small:
+            classes.push(`tw-pl-3 ${hasActiveKeys ? 'tw-py-1' : 'tw-py-2'}`);
+            break;
+        case MultiSelectSize.Medium:
+            classes.push('tw-pl-[19px] tw-py-[11px]');
+            break;
+        default:
+            return;
+    }
+
+    return merge(classes);
+};

--- a/src/components/MultiSelect/helpers.ts
+++ b/src/components/MultiSelect/helpers.ts
@@ -1,12 +1,10 @@
+import { merge } from '@utilities/merge';
 import { MultiSelectSize } from './MultiSelect';
 
-export const getSizeClasses = (size: MultiSelectSize, hasActiveKeys: boolean) => {
-    if (size === MultiSelectSize.Small) {
-        if (hasActiveKeys) {
-            return 'tw-py-1';
-        } else {
-            return 'tw-py-2';
-        }
-    }
-    return 'tw-py-[11px]';
-};
+export const getPaddingClasses = (size: MultiSelectSize, hasActiveKeys: boolean) =>
+    merge([
+        'tw-pr-9',
+        size === MultiSelectSize.Small
+            ? `tw-pl-3 ${hasActiveKeys ? 'tw-py-1' : 'tw-py-2'}`
+            : 'tw-pl-[19px] tw-py-[11px]',
+    ]);


### PR DESCRIPTION
This pr adds 8px of padding the right side of all multi select sizes due to the caret being to close to the badges inside the select, and also reduces left padding on the small multiselect from 20px to 12px.