### PR TITLE
fix(Tooltip): Fix styling for overflow texts.

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -10,7 +10,7 @@ export default {
     title: 'Components/Tooltip',
     component: Tooltip,
     args: {
-        content: 'Cupcake ipsum dolor sit amet ice cream.',
+        content: 'Cupcake ipsum dolor sit amet ice cream. (https://Cupcakeipsumdolorsitameticecream.com)',
         heading: '',
     },
     argTypes: {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -252,7 +252,7 @@ export const Tooltip = ({
                                             {cloneElement(tooltipIcon, { size: IconSize.Size16 })}
                                         </span>
                                     )}
-                                    <p className="tw-text-s">{content}</p>
+                                    <p className="tw-text-s tw-min-w-0 tw-break-words">{content}</p>
                                 </div>
                                 {linkUrl && (
                                     <a


### PR DESCRIPTION
Issue:
<img width="354" alt="Screenshot 2022-08-11 at 11 03 14" src="https://user-images.githubusercontent.com/35405438/184367730-7bf923ca-7908-436d-a73e-b33e5084982f.png">

Fix:
![Screenshot 2022-08-12 at 15 53 13](https://user-images.githubusercontent.com/35405438/184367891-48c108bd-991d-499c-8c51-847f64b3cb57.png)

