### PR TITLE
chore(table): refactor components

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -33,7 +33,7 @@ export type Column = {
 };
 
 export type Row = {
-    key: string | number;
+    key: Key;
     // cell keys have to correspond to column key values
     // e.g. Column { name: 'User', key: 'user' } ==> Row Cell { user: { id: 'anna', value: 'Anna' } }
     cells: Record<string, Cell>;
@@ -45,16 +45,19 @@ export type TableProps = PropsWithChildren<{
     rows: Row[];
     onSelectionChange?: (ids?: Key[]) => void;
     selectionMode?: SelectionMode;
-    selectedRowIds?: (string | number)[];
+    selectedRowIds?: Key[];
     ariaLabel?: string;
 }>;
 
-const DEFAULT_SORT_ORDER = 'descending';
+export enum SortDirection {
+    Ascending = 'ascending',
+    Descending = 'descending',
+}
 
-export type SortDirection = 'ascending' | 'descending';
+const DEFAULT_SORT_ORDER = SortDirection.Descending;
 
 type SortType = {
-    sortedColumnKey?: string | number;
+    sortedColumnKey?: Key;
     sortOrder?: SortDirection;
 };
 
@@ -79,11 +82,11 @@ const mapToTableAriaProps = (columns: Column[], rows: Row[]): TableStateProps<an
     ],
 });
 
-const getRowFromId = (rows: Row[], id: string | number) => rows.find(({ key }) => key === id) || null;
+const getRowFromId = (rows: Row[], id: Key) => rows.find(({ key }) => key === id) || null;
 
-const getAllRowIds = (rows: Row[]): (string | number)[] => rows.map(({ key: id }) => id);
+const getAllRowIds = (rows: Row[]): Key[] => rows.map(({ key: id }) => id);
 
-const sortRows = (rows: Row[], columnKey: string | number, isDescending: boolean) => {
+const sortRows = (rows: Row[], columnKey: Key, isDescending: boolean) => {
     const sort = (a: Row, b: Row) => {
         const keyA = a.cells[columnKey].sortId;
         const keyB = b.cells[columnKey].sortId;

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,14 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Checkbox, CheckboxState } from '@components/Checkbox/Checkbox';
-import { useCheckbox } from '@react-aria/checkbox';
-import { useFocusRing } from '@react-aria/focus';
-import { useTableCell, useTableSelectionCheckbox } from '@react-aria/table';
-import { mergeProps } from '@react-aria/utils';
-import { TableState } from '@react-stately/table';
-import { useToggleState } from '@react-stately/toggle';
-import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
+import { Checkbox as CheckboxCmp, CheckboxState } from '@components/Checkbox/Checkbox';
 import { merge } from '@utilities/merge';
-import React, { FC, useRef } from 'react';
+import React, { FC, Key, useRef } from 'react';
+import { SelectionMode } from '..';
 
 export enum TableCellType {
     Default = 'Default',
@@ -17,37 +11,57 @@ export enum TableCellType {
 
 export type TableCellProps = {
     cell: any;
-    state: TableState<any>;
+    selectionMode: string;
     type?: TableCellType;
+    isChecked?: boolean;
+    selectedRows: Key[];
+    setSelectedRows?: (ids?: Key[]) => void;
 };
 
-export const TableCell: FC<TableCellProps> = ({ cell, state, type = TableCellType.Default }) => {
+export const TableCell: FC<TableCellProps> = ({
+    cell,
+    selectionMode,
+    type = TableCellType.Default,
+    isChecked = false,
+    selectedRows,
+    setSelectedRows,
+}) => {
     const ref = useRef<HTMLTableCellElement | null>(null);
-    const { gridCellProps } = useTableCell({ node: cell }, state, ref);
-    const { checkboxProps } = useTableSelectionCheckbox({ key: cell.parentKey }, state);
-    const inputRef = useRef(null);
-    const {
-        inputProps: { checked },
-    } = useCheckbox(checkboxProps, useToggleState(checkboxProps), inputRef);
-    const { isFocusVisible, focusProps } = useFocusRing();
 
     if (type === TableCellType.Checkbox) {
         const { key } = cell;
+        const handleChange = () => {
+            if (!setSelectedRows) {
+                return;
+            }
+
+            if (isChecked) {
+                const filteredRows = selectedRows.filter((row) => row !== cell.parentKey);
+                setSelectedRows(filteredRows);
+                return;
+            }
+            if (selectionMode === SelectionMode.SingleSelect) {
+                setSelectedRows([cell.parentKey]);
+            } else {
+                setSelectedRows([...selectedRows, cell.parentKey]);
+            }
+        };
 
         return (
             <td
-                {...gridCellProps}
+                role="cell"
                 ref={ref}
                 className={merge([
                     'tw-pl-8 tw-py-4 tw-pr-4 tw-border-l-4',
-                    checked ? 'tw-border-violet-60' : 'tw-border-transparent',
+                    isChecked ? 'tw-border-violet-60' : 'tw-border-transparent',
                 ])}
                 data-test-id="table-select-cell"
             >
-                <Checkbox
+                <CheckboxCmp
                     value={key}
                     ariaLabel={cell['aria-label'] || key}
-                    state={checked ? CheckboxState.Checked : CheckboxState.Unchecked}
+                    state={isChecked ? CheckboxState.Checked : CheckboxState.Unchecked}
+                    onChange={handleChange}
                 />
             </td>
         );
@@ -55,12 +69,11 @@ export const TableCell: FC<TableCellProps> = ({ cell, state, type = TableCellTyp
 
     return (
         <td
-            {...mergeProps(gridCellProps, focusProps)}
+            role="cell"
             ref={ref}
             className={merge([
                 'tw-p-4 tw-font-normal tw-text-xs focus:tw-outline-none',
-                checked ? 'tw-text-black-100 dark:tw-text-white' : 'tw-text-black-80 dark:tw-text-black-20',
-                isFocusVisible && FOCUS_STYLE_INSET,
+                isChecked ? 'tw-text-black-100 dark:tw-text-white' : 'tw-text-black-80 dark:tw-text-black-20',
             ])}
         >
             {cell.rendered}

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Checkbox as CheckboxCmp, CheckboxState } from '@components/Checkbox/Checkbox';
+import { Checkbox as CheckboxComponent, CheckboxState } from '@components/Checkbox/Checkbox';
 import { merge } from '@utilities/merge';
-import React, { FC, Key, useRef } from 'react';
+import React, { Key, useRef } from 'react';
 import { SelectionMode } from '..';
 
 export enum TableCellType {
@@ -18,14 +18,14 @@ export type TableCellProps = {
     setSelectedRows?: (ids?: Key[]) => void;
 };
 
-export const TableCell: FC<TableCellProps> = ({
+export const TableCell = ({
     cell,
     selectionMode,
     type = TableCellType.Default,
     isChecked = false,
     selectedRows,
     setSelectedRows,
-}) => {
+}: TableCellProps) => {
     const ref = useRef<HTMLTableCellElement | null>(null);
 
     if (type === TableCellType.Checkbox) {
@@ -40,11 +40,10 @@ export const TableCell: FC<TableCellProps> = ({
                 setSelectedRows(filteredRows);
                 return;
             }
-            if (selectionMode === SelectionMode.SingleSelect) {
-                setSelectedRows([cell.parentKey]);
-            } else {
-                setSelectedRows([...selectedRows, cell.parentKey]);
-            }
+
+            const rowsToSelect =
+                selectionMode === SelectionMode.SingleSelect ? [cell.parentKey] : [...selectedRows, cell.parentKey];
+            setSelectedRows(rowsToSelect);
         };
 
         return (
@@ -57,7 +56,7 @@ export const TableCell: FC<TableCellProps> = ({
                 ])}
                 data-test-id="table-select-cell"
             >
-                <CheckboxCmp
+                <CheckboxComponent
                     value={key}
                     ariaLabel={cell['aria-label'] || key}
                     state={isChecked ? CheckboxState.Checked : CheckboxState.Unchecked}

--- a/src/components/Table/TableColumnHeader.tsx
+++ b/src/components/Table/TableColumnHeader.tsx
@@ -3,7 +3,7 @@ import { Checkbox, CheckboxState } from '@components/Checkbox/Checkbox';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, Key, cloneElement, useEffect, useRef, useState } from 'react';
+import React, { Key, cloneElement, useEffect, useRef, useState } from 'react';
 import { IconArrowBidirectional, IconArrowDown, IconArrowUp } from '@foundation/Icon';
 import { SelectionMode, SortDirection } from '..';
 
@@ -23,7 +23,7 @@ export type TableColumnHeaderProps = {
     setSelectedRows?: (ids?: Key[]) => void;
 };
 
-export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
+export const TableColumnHeader = ({
     column,
     type = TableColumnHeaderType.Default,
     rowIds,
@@ -32,7 +32,7 @@ export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
     isColumnSorted = false,
     handleSortChange,
     setSelectedRows,
-}) => {
+}: TableColumnHeaderProps) => {
     const {
         key,
         rendered,
@@ -41,11 +41,12 @@ export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
     const [icon, setIcon] = useState(<IconArrowBidirectional />);
     const [isChecked, setIsChecked] = useState(false);
     const ref = useRef<HTMLTableCellElement | null>(null);
-    const inverseSortDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
+    const inverseSortDirection =
+        sortDirection === SortDirection.Ascending ? SortDirection.Descending : SortDirection.Ascending;
 
     useEffect(() => {
         if (isColumnSorted) {
-            setIcon(sortDirection === 'descending' ? <IconArrowDown /> : <IconArrowUp />);
+            setIcon(sortDirection === SortDirection.Descending ? <IconArrowDown /> : <IconArrowUp />);
         } else {
             setIcon(<IconArrowBidirectional />);
         }

--- a/src/components/Table/TableColumnHeader.tsx
+++ b/src/components/Table/TableColumnHeader.tsx
@@ -1,17 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Checkbox, CheckboxState } from '@components/Checkbox/Checkbox';
 import { IconSize } from '@foundation/Icon/IconSize';
-import { useCheckbox } from '@react-aria/checkbox';
-import { useFocusRing } from '@react-aria/focus';
-import { useTableColumnHeader, useTableSelectAllCheckbox } from '@react-aria/table';
-import { mergeProps } from '@react-aria/utils';
-import { VisuallyHidden } from '@react-aria/visually-hidden';
-import { TableState } from '@react-stately/table';
-import { useToggleState } from '@react-stately/toggle';
-import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
+import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, cloneElement, useCallback, useEffect, useRef, useState } from 'react';
+import React, { FC, Key, cloneElement, useEffect, useRef, useState } from 'react';
 import { IconArrowBidirectional, IconArrowDown, IconArrowUp } from '@foundation/Icon';
+import { SelectionMode, SortDirection } from '..';
 
 export enum TableColumnHeaderType {
     Default = 'Default',
@@ -20,14 +14,24 @@ export enum TableColumnHeaderType {
 
 export type TableColumnHeaderProps = {
     column: any;
-    state: TableState<any>;
     type?: TableColumnHeaderType;
+    rowIds: Key[];
+    sortDirection?: SortDirection;
+    selectionMode: string;
+    isColumnSorted?: boolean;
+    handleSortChange: (column: Key, direction: SortDirection) => void;
+    setSelectedRows?: (ids?: Key[]) => void;
 };
 
 export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
     column,
-    state,
     type = TableColumnHeaderType.Default,
+    rowIds,
+    sortDirection,
+    selectionMode,
+    isColumnSorted = false,
+    handleSortChange,
+    setSelectedRows,
 }) => {
     const {
         key,
@@ -35,55 +39,52 @@ export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
         props: { allowsSorting },
     } = column;
     const [icon, setIcon] = useState(<IconArrowBidirectional />);
+    const [isChecked, setIsChecked] = useState(false);
     const ref = useRef<HTMLTableCellElement | null>(null);
-    const { columnHeaderProps } = useTableColumnHeader({ node: column }, state, ref);
-    const isSortedColumn = state.sortDescriptor?.column === key;
-    const sortDirection = state.sortDescriptor?.direction;
-    const { isFocusVisible, focusProps } = useFocusRing();
+    const inverseSortDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
 
     useEffect(() => {
-        if (isSortedColumn) {
+        if (isColumnSorted) {
             setIcon(sortDirection === 'descending' ? <IconArrowDown /> : <IconArrowUp />);
         } else {
             setIcon(<IconArrowBidirectional />);
         }
-    }, [isSortedColumn, sortDirection]);
+    }, [isColumnSorted, sortDirection]);
 
     if (type === TableColumnHeaderType.SelectAll) {
-        const { checkboxProps } = useTableSelectAllCheckbox(state);
-        const {
-            selectionManager: { selectedKeys, selectionMode },
-        } = state;
-        const inputRef = useRef(null);
-        const toggleState = useToggleState(checkboxProps);
-        const { inputProps } = useCheckbox(checkboxProps, toggleState, inputRef);
-        const headerProps = { ...columnHeaderProps, onClick: () => state.selectionManager.toggleSelectAll() };
-        const selectedKeyCount = selectedKeys.size;
+        const ariaProps = {
+            'aria-checked': isChecked,
+            'aria-label': 'Select all',
+            scope: 'col',
+        };
 
-        const getCheckboxState = useCallback(() => {
-            if (selectedKeyCount === state.collection.size) {
-                return CheckboxState.Checked;
+        const checkboxState = isChecked ? CheckboxState.Checked : CheckboxState.Unchecked;
+
+        const handleChange = () => {
+            if (!setSelectedRows) {
+                return;
             }
-            if (selectedKeyCount > 0) {
-                return CheckboxState.Mixed;
+
+            if (isChecked) {
+                setSelectedRows([]);
+            } else {
+                setSelectedRows(rowIds);
             }
-            return CheckboxState.Unchecked;
-        }, [selectedKeyCount]);
+
+            setIsChecked((checked) => !checked);
+        };
 
         return (
             <th
-                {...headerProps}
+                {...ariaProps}
                 ref={ref}
-                className={merge([
-                    'tw-pl-8 tw-py-3 tw-pr-4 tw-w-16 tw-border-l-4 tw-border-transparent tw-group tw-outline-none',
-                    selectionMode === 'multiple' && 'tw-cursor-pointer',
-                ])}
+                className="tw-pl-8 tw-py-3 tw-pr-4 tw-w-16 tw-border-l-4 tw-border-transparent tw-group tw-outline-none"
                 data-test-id="table-select-cell"
             >
-                {selectionMode === 'single' ? (
-                    <VisuallyHidden>{inputProps['aria-label']}</VisuallyHidden>
+                {selectionMode === SelectionMode.SingleSelect ? (
+                    <span className="tw-sr-only">{ariaProps['aria-label']}</span>
                 ) : (
-                    <Checkbox value={key} ariaLabel={key} state={getCheckboxState()} />
+                    <Checkbox value={key} ariaLabel={key} state={checkboxState} onChange={handleChange} />
                 )}
             </th>
         );
@@ -91,21 +92,19 @@ export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
 
     return (
         <th
-            {...mergeProps(columnHeaderProps, focusProps)}
             ref={ref}
-            className={merge([
-                'tw-text-xs tw-font-medium tw-text-black-100 dark:tw-text-white tw-px-4 tw-py-3 tw-outline-none tw-cursor-pointer tw-group',
-                isFocusVisible && FOCUS_STYLE_INSET,
-            ])}
+            className="tw-text-xs tw-font-medium tw-text-black-100 dark:tw-text-white tw-px-4 tw-py-3 tw-outline-none tw-cursor-pointer tw-group focus-visible:bg-violet-90"
             data-test-id="table-column"
+            scope="col"
+            onClick={() => handleSortChange(column.key, inverseSortDirection)}
         >
-            <div className="tw-flex tw-gap-x-1 tw-items-center">
+            <button className={merge(['tw-flex tw-gap-x-1 tw-items-center', FOCUS_VISIBLE_STYLE])}>
                 {rendered}
                 {allowsSorting && (
                     <span
                         aria-hidden="true"
                         className={
-                            isSortedColumn
+                            isColumnSorted
                                 ? 'tw-text-violet-50'
                                 : 'tw-text-black-40 dark:tw-text-black-60 group-hover:tw-text-black-100 dark:group-hover:tw-text-white'
                         }
@@ -113,7 +112,7 @@ export const TableColumnHeader: FC<TableColumnHeaderProps> = ({
                         {cloneElement(icon, { size: IconSize.Size12 })}
                     </span>
                 )}
-            </div>
+            </button>
         </th>
     );
 };

--- a/src/components/Table/TableHeaderRow.tsx
+++ b/src/components/Table/TableHeaderRow.tsx
@@ -1,19 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { useTableHeaderRow } from '@react-aria/table';
-import { TableState } from '@react-stately/table';
 import React, { FC, useRef } from 'react';
 
-export type TableHeaderRowProps = {
-    item: any;
-    state: TableState<any>;
-};
-
-export const TableHeaderRow: FC<TableHeaderRowProps> = ({ item, state, children }) => {
+export const TableHeaderRow: FC = ({ children }) => {
     const ref = useRef<HTMLTableRowElement | null>(null);
-    const { rowProps } = useTableHeaderRow({ node: item }, state, ref);
 
     return (
-        <tr {...rowProps} ref={ref} className="tw-py-4 tw-px-8 tw-sticky tw-top-0 tw-bg-base tw-z-10">
+        <tr role="row" ref={ref} className="tw-py-4 tw-px-8 tw-sticky tw-top-0 tw-bg-base tw-z-10">
             {children}
         </tr>
     );

--- a/src/components/Table/TableHeaderRow.tsx
+++ b/src/components/Table/TableHeaderRow.tsx
@@ -1,6 +1,10 @@
-import React, { FC, useRef } from 'react';
+import React, { ReactNode, useRef } from 'react';
 
-export const TableHeaderRow: FC = ({ children }) => {
+type TableHeaderRowProps = {
+    children: ReactNode;
+};
+
+export const TableHeaderRow = ({ children }: TableHeaderRowProps) => {
     const ref = useRef<HTMLTableRowElement | null>(null);
 
     return (

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,10 +1,11 @@
-import React, { FC, useRef } from 'react';
+import React, { ReactNode, useRef } from 'react';
 
 export type TableRowProps = {
     isSelected?: boolean;
+    children: ReactNode;
 };
 
-export const TableRow: FC<TableRowProps> = ({ isSelected = false, children }) => {
+export const TableRow = ({ isSelected = false, children }: TableRowProps) => {
     const ref = useRef<HTMLTableRowElement | null>(null);
 
     const ariaProps = {

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,30 +1,22 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { useFocusRing } from '@react-aria/focus';
-import { useTableRow } from '@react-aria/table';
-import { mergeProps } from '@react-aria/utils';
-import { TableState } from '@react-stately/table';
-import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
-import { merge } from '@utilities/merge';
 import React, { FC, useRef } from 'react';
 
 export type TableRowProps = {
-    item: any;
-    state: TableState<any>;
+    isSelected?: boolean;
 };
 
-export const TableRow: FC<TableRowProps> = ({ item, state, children }) => {
+export const TableRow: FC<TableRowProps> = ({ isSelected = false, children }) => {
     const ref = useRef<HTMLTableRowElement | null>(null);
-    const { rowProps } = useTableRow({ node: item }, state, ref);
-    const { isFocusVisible, focusProps } = useFocusRing();
+
+    const ariaProps = {
+        'aria-selected': isSelected,
+        role: 'row',
+    };
 
     return (
         <tr
-            {...mergeProps(rowProps, focusProps)}
+            {...ariaProps}
             ref={ref}
-            className={merge([
-                'tw-relative tw-border-t tw-border-black-10 hover:tw-bg-black-0 dark:tw-border-black-95 dark:hover:tw-bg-black-95',
-                isFocusVisible && FOCUS_STYLE_INSET,
-            ])}
+            className="tw-relative tw-border-t tw-border-black-10 hover:tw-bg-black-0 dark:tw-border-black-95 dark:hover:tw-bg-black-95"
             data-test-id="table-row"
         >
             {children}


### PR DESCRIPTION
- Remove react-aria from table components
- Improve keyboard navigation, both checkboxes and action buttons can now be navigated to and interacted with using tabs and space(validated with Jamie)
- Improve code by removing the child components dependency on the huge state object created in the <Table> component.