### PR TITLE
chore(eslint): Prevent runtime fail on eslint error

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -40,6 +40,7 @@ export default {
                     include: 'src/components/**/*.+(js|ts|tsx)',
                     exclude: 'src/components/RichTextEditor/**/*.+(js|ts|tsx)',
                     emitWarning: true,
+                    failOnError: false
                 }),
                 enforce: 'pre',
             },


### PR DESCRIPTION
### To be discussed with the team

In my opinion, storybook shouldn't throw in case of an eslint error, it's very disruptive to the dev flow.

![image](https://user-images.githubusercontent.com/18708637/185416998-2d61e7bf-483f-4e91-a148-e17adfd91047.png)
