### PR TITLE
fix(table): a11y violations and hover/selected style

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -37,6 +37,7 @@ const User: FC<{ name: string }> = ({ name }) => (
 
 const ActionButton: FC = () => (
     <Button
+        aria-label="action menu"
         onClick={action('click')}
         size={ButtonSize.Small}
         style={ButtonStyle.Secondary}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -138,15 +138,11 @@ export const Table = ({
         showSelectionCheckboxes: isSelectTable,
     });
     const { collection } = state;
-    const ariaProps = {
-        'aria-label': ariaLabel,
-        'aria-multiselectable': selectionMode === SelectionMode.MultiSelect,
-    };
 
     return (
         <div className="tw-w-full tw-max-h-96 sm:tw-max-h-full">
             <table
-                {...ariaProps}
+                aria-label={ariaLabel}
                 ref={ref}
                 className="tw-border-collapse tw-table-auto tw-w-full tw-min-w-max tw-text-left dark:tw-bg-black-100 dark:tw-text-black-20"
             >
@@ -172,7 +168,7 @@ export const Table = ({
                                     />
                                 );
                             })}
-                            <th />
+                            <td />
                         </TableHeaderRow>
                     ))}
                 </thead>

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -52,7 +52,7 @@ export const TableCell = ({
                 ref={ref}
                 className={merge([
                     'tw-pl-8 tw-py-4 tw-pr-4 tw-relative after:tw-absolute after:tw-left-0 after:tw-top-[-1px] after:tw-bottom-[-1px] after:tw-w-1',
-                    isChecked ? 'after:tw-bg-violet-60' : 'after:tw-bg-transparent',
+                    isChecked ? 'after:tw-bg-box-selected-strong' : 'after:tw-bg-transparent',
                 ])}
                 data-test-id="table-select-cell"
             >

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -51,8 +51,8 @@ export const TableCell = ({
                 role="cell"
                 ref={ref}
                 className={merge([
-                    'tw-pl-8 tw-py-4 tw-pr-4 tw-border-l-4',
-                    isChecked ? 'tw-border-violet-60' : 'tw-border-transparent',
+                    'tw-pl-8 tw-py-4 tw-pr-4 tw-relative after:tw-absolute after:tw-left-0 after:tw-top-[-1px] after:tw-bottom-[-1px] after:tw-w-1',
+                    isChecked ? 'after:tw-bg-violet-60' : 'after:tw-bg-transparent',
                 ])}
                 data-test-id="table-select-cell"
             >

--- a/src/components/Table/TableColumnHeader.tsx
+++ b/src/components/Table/TableColumnHeader.tsx
@@ -54,7 +54,6 @@ export const TableColumnHeader = ({
 
     if (type === TableColumnHeaderType.SelectAll) {
         const ariaProps = {
-            'aria-checked': isChecked,
             'aria-label': 'Select all',
             scope: 'col',
         };


### PR DESCRIPTION
https://app.clickup.com/t/2t9epjp

- Fix selected border
- Fix hover on safari/firefox
- Fix a11y axe violations. Only one remaining which is unrelated to the table, but to the badge component. It should be fixed in a different PR with input from design, since it's a contrast issue

<img width="975" alt="image" src="https://user-images.githubusercontent.com/18708637/186918099-beab47b8-cf14-42e1-aeb5-23c104e078f6.png">
