### PR TITLE
chore(cypress): activate experimental single tab run mode

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
             framework: 'react',
             bundler: 'vite',
         },
+        experimentalSingleTabRunMode: true,
     },
 });


### PR DESCRIPTION
### Change
Activate experimentalSingleTabRunMode to increase test performance

### Effect
Component test time before: 12m 44s
Component test time in this PR: 6m 08s
--> -52% total running time!

### How to tests
Component tests should not fail
