### PR TITLE
fix(Modal): re-order buttons in documentation

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -185,16 +185,18 @@ const ModalTemplate: Story<ModalProps & ModalVisualProps & ModalHeaderProps & Mo
                 <Modal.Footer
                     buttons={[
                         {
-                            children: 'Okay',
+                            children: 'Cancel',
                             onClick: () => {
-                                action('click');
                                 state.close();
                             },
                             style: ButtonStyle.Secondary,
                         },
                         {
-                            children: 'Cancel',
-                            onClick: () => state.close(),
+                            children: 'Confirm',
+                            onClick: () => {
+                                action('click');
+                                state.close();
+                            },
                             style: ButtonStyle.Primary,
                         },
                     ]}


### PR DESCRIPTION
The primary action button should be the furthest-right, to make our documentation clearer

Before:
<img width="823" alt="Screenshot 2022-09-07 at 15 28 57" src="https://user-images.githubusercontent.com/93908356/188890509-2dca30ac-aaf2-4d13-b54e-e910edba4f3e.png">

After:
<img width="823" alt="Screenshot 2022-09-07 at 15 29 31" src="https://user-images.githubusercontent.com/93908356/188890627-49ff95bb-96f5-45eb-b684-e88eb662d514.png">
