### PR TITLE
feat(RichTextEditor): add plaintext support

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.cy.tsx
@@ -141,6 +141,13 @@ describe('RichTextEditor Component', () => {
         cy.get('[contenteditable=true]').should('include.html', 'tw-italic');
     });
 
+    it('should render a plain text string content state', () => {
+        const TEXT = 'This is text';
+        cy.mount(<RichTextEditor value={TEXT} />);
+
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
+    });
+
     it('should be editable by default ', () => {
         cy.mount(<RichTextEditor />);
 

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -3,6 +3,12 @@
 import { ELEMENT_PARAGRAPH, TDescendant, createPlateEditor, deserializeHtml, parseHtmlDocument } from '@udecode/plate';
 import { getEditorConfig } from './editorConfig';
 
+const wrapTextInHtml = (text: string) => {
+    const htmlDocRegex = /^<\w+>.*<\/\w+>$/;
+
+    return htmlDocRegex.test(text) ? text : `<p>${text}</p>`;
+};
+
 export const EMPTY_RICH_TEXT_VALUE: TDescendant[] = [{ type: ELEMENT_PARAGRAPH, children: [{ text: '' }] }];
 
 export const parseRawValue = (raw?: string): TDescendant[] => {
@@ -17,7 +23,8 @@ export const parseRawValue = (raw?: string): TDescendant[] => {
     } catch {
         const editor = createPlateEditor({ plugins: getEditorConfig() });
         const trimmed = raw.trim().replace(/>\s+</g, '><');
-        const document = parseHtmlDocument(trimmed);
+        const htmlDocumentString = wrapTextInHtml(trimmed);
+        const document = parseHtmlDocument(htmlDocumentString);
         const parsedHtml = deserializeHtml(editor, {
             element: document.body,
             stripWhitespace: true,


### PR DESCRIPTION
When converting a textarea to a RTE as is a common case the saved value from the previous textarea which is plaintext will be added as the value of the RTE, causing the RTE to crash unexpectedly. 