### PR TITLE
feat(Tooltip): add open boolean prop to the component

### DIFF
--- a/src/components/Tooltip/Tooltip.cy.tsx
+++ b/src/components/Tooltip/Tooltip.cy.tsx
@@ -30,10 +30,12 @@ export const TooltipComponent = (args: TooltipProps) => {
     );
 };
 
-const initTooltip = (args: TooltipProps) => {
+const initTooltip = (args: TooltipProps, triggerOpen = true) => {
     cy.mount(<TooltipComponent {...args} />);
     cy.get('[data-test-id=tooltip-trigger]').as('Trigger');
-    cy.get('@Trigger').trigger('mouseover');
+    if (triggerOpen) {
+        cy.get('@Trigger').trigger('mouseover');
+    }
 };
 
 describe('Tooltip Component', () => {
@@ -41,6 +43,11 @@ describe('Tooltip Component', () => {
         initTooltip({ content: TOOLTIP_TEXT });
         cy.get(TOOLTIP_ID).should('contain', TOOLTIP_TEXT);
         cy.get(BRIGHT_HEADER_ID).should('not.exist');
+    });
+
+    it('should render a tooltip open by default via component prop', () => {
+        initTooltip({ content: TOOLTIP_TEXT, open: true }, false);
+        cy.get(TOOLTIP_ID).should('contain', TOOLTIP_TEXT);
     });
 
     it('should render an icon next to the tooltip', () => {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -55,6 +55,10 @@ export default {
             control: { type: 'boolean' },
             defaultValue: false,
         },
+        open: {
+            control: { type: 'boolean' },
+            defaultValue: false,
+        },
         flip: {
             control: { type: 'boolean' },
             defaultValue: true,
@@ -183,5 +187,11 @@ WithEverythingDisplayed.args = {
 
 export const WithArrow = TooltipComponent.bind({});
 WithArrow.args = {
+    withArrow: true,
+};
+
+export const OpenByDefault = TooltipComponent.bind({});
+OpenByDefault.args = {
+    open: true,
     withArrow: true,
 };

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ import React, {
     ReactNode,
     cloneElement,
     useCallback,
+    useEffect,
     useMemo,
     useRef,
     useState,
@@ -43,6 +44,7 @@ export type TooltipProps = PropsWithChildren<{
     flip?: boolean;
     withArrow?: boolean;
     hoverDelay?: number;
+    open?: boolean;
 }>;
 
 /**
@@ -132,6 +134,7 @@ export const Tooltip = ({
     flip = true,
     triggerElement,
     hoverDelay = 200,
+    open = false,
 }: TooltipProps) => {
     const triggerRefElement = useRef<HTMLElement | HTMLDivElement | HTMLButtonElement | null>(null);
     const linkRef = useRef<HTMLAnchorElement | null>(null);
@@ -205,6 +208,10 @@ export const Tooltip = ({
         onFocus: () => setIsOpen(true),
         onBlur: () => (!hasInteractiveElements ? setIsOpen(false) : null),
     };
+
+    useEffect(() => {
+        setIsOpen(open);
+    }, [open]);
 
     return (
         <>


### PR DESCRIPTION
- Add the `open` boolean attribute to the Tooltip component. So it is possible to control the `isOpen` state from the outside like setting the tooltip box to be visible by default.

> The new attribute will not impact the normal behavior of the Tooltip component i.e. if it is open by default and the user interacts with the trigger element, the tooltip box will be visible when the mouse is over and hidden when the mouse is out.