### PR TITLE
chore: move sorting logic from out of fondue and allow optional sorting columns

### DIFF
--- a/src/components/Table/Table.cy.tsx
+++ b/src/components/Table/Table.cy.tsx
@@ -1,12 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 import { Button } from '@components/Button/Button';
 import { TextInput } from '@components/TextInput/TextInput';
-import React, { useEffect, useState } from 'react';
-import { Column, Row, SelectionMode, Table } from './Table';
+import React, { Key, useEffect, useState } from 'react';
+import { Column, Row, SelectionMode, SortDirection, Table } from './Table';
 
 const TABLE_COLUMNS: Column[] = [
     { name: 'User', key: 'user' },
-    { name: 'Active Sessions', key: 'activeSessions' },
+    { name: 'Active Sessions', key: 'activeSessions', sortable: true },
     { name: 'Regions', key: 'regions' },
 ];
 
@@ -71,6 +71,30 @@ const TABLE_ACTIONS_ID = '[data-test-id=table-actions]';
 const CHECKBOX_ID = '[data-test-id=checkbox]';
 const CHECKBOX_INPUT_ID = '[data-test-id=checkbox-input]';
 
+const SortableTable = () => {
+    const [sortedRows, setfilteredRows] = useState<Row[]>(TABLE_ROWS);
+    const onSortChange = (key: string, direction?: SortDirection) => {
+        const sortRows = () => {
+            const clonedRows = [...sortedRows];
+
+            clonedRows.sort((a, b) => {
+                const keyA: Key = a.cells[key].sortId;
+                const keyB: Key = b.cells[key].sortId;
+
+                if (direction === SortDirection.Descending) {
+                    return keyA < keyB ? -1 : 1;
+                } else {
+                    return keyA < keyB ? 1 : -1;
+                }
+            });
+            setfilteredRows(clonedRows);
+        };
+        sortRows();
+    };
+
+    return <Table columns={TABLE_COLUMNS} rows={sortedRows} onSortChange={onSortChange} />;
+};
+
 describe('Table Component', () => {
     it('should render read only table', () => {
         cy.mount(<Table columns={TABLE_COLUMNS} rows={TABLE_ROWS} />);
@@ -129,16 +153,13 @@ describe('Table Component', () => {
     });
 
     it.only('should sort table', () => {
-        cy.mount(<Table columns={TABLE_COLUMNS} rows={TABLE_ROWS} />);
+        cy.mount(<SortableTable />);
 
-        cy.get(TABLE_ROW_ID).first().get('td').contains('Anna');
-        cy.get(TABLE_COLUMN_ID).first().click();
-        cy.get(TABLE_ROW_ID).first().get('td').contains('Chris');
+        cy.get(TABLE_ROW_ID).first().eq(0).contains('Anna');
         cy.get(TABLE_COLUMN_ID).eq(1).click();
-        cy.get(TABLE_ROW_ID).eq(1).get('td').contains(108);
+        cy.get(TABLE_ROW_ID).first().eq(0).contains('Bobby');
         cy.get(TABLE_COLUMN_ID).eq(1).click();
-        cy.get(TABLE_ROW_ID).eq(1).get('td').contains(125);
-        cy.get(TABLE_ROW_ID).first().get('td').contains('Bobby');
+        cy.get(TABLE_ROW_ID).first().eq(0).contains('Anna');
     });
 
     it('should rerender if rows change', () => {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -7,8 +7,8 @@ import { Button, ButtonSize, ButtonStyle } from '@components/Button/Button';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/react';
-import React, { FC, useEffect, useState } from 'react';
-import { Column, Row, SelectionMode, Table, TableProps } from './Table';
+import React, { FC, Key, useEffect, useState } from 'react';
+import { Column, Row, SelectionMode, SortDirection, Table, TableProps } from './Table';
 import { IconDotsVertical, IconFaceHappy } from '@foundation/Icon';
 
 export default {
@@ -47,7 +47,7 @@ const ActionButton: FC = () => (
 
 const columns: Column[] = [
     { name: 'User', key: 'user' },
-    { name: 'Active Sessions', key: 'activeSessions' },
+    { name: 'Active Sessions', key: 'activeSessions', sortable: true },
     { name: 'Last Active', key: 'lastActive' },
     { name: 'Regions', key: 'regions' },
     { name: 'Countries', key: 'countries' },
@@ -211,14 +211,35 @@ const rows: Row[] = [
 
 const Template: Story<TableProps> = (args) => {
     const [selectedRows, setSelectedRows] = useState<(string | number)[]>([]);
+    const [sortedRows, setSortedRows] = useState<Row[]>(rows);
+
+    const onSortChange = (key: Key, direction?: SortDirection) => {
+        const sortRows = () => {
+            const clonedRows = [...sortedRows];
+
+            clonedRows.sort((a, b) => {
+                const keyA = a.cells[key].sortId;
+                const keyB = b.cells[key].sortId;
+
+                if (direction !== SortDirection.Descending) {
+                    return keyA < keyB ? -1 : 1;
+                } else {
+                    return keyA < keyB ? 1 : -1;
+                }
+            });
+            setSortedRows(clonedRows);
+        };
+        sortRows();
+    };
 
     return (
         <Table
             {...args}
             columns={columns}
-            rows={rows}
+            rows={sortedRows}
             selectedRowIds={selectedRows}
             onSelectionChange={(ids) => setSelectedRows(ids || [])}
+            onSortChange={onSortChange}
         />
     );
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -7,7 +7,7 @@ import { Button, ButtonSize, ButtonStyle } from '@components/Button/Button';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/react';
-import React, { FC, Key, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { Column, Row, SelectionMode, SortDirection, Table, TableProps } from './Table';
 import { IconDotsVertical, IconFaceHappy } from '@foundation/Icon';
 
@@ -213,7 +213,7 @@ const Template: Story<TableProps> = (args) => {
     const [selectedRows, setSelectedRows] = useState<(string | number)[]>([]);
     const [sortedRows, setSortedRows] = useState<Row[]>(rows);
 
-    const onSortChange = (key: Key, direction?: SortDirection) => {
+    const onSortChange = (key: string, direction?: SortDirection) => {
         const sortRows = () => {
             const clonedRows = [...sortedRows];
 
@@ -221,7 +221,7 @@ const Template: Story<TableProps> = (args) => {
                 const keyA = a.cells[key].sortId;
                 const keyB = b.cells[key].sortId;
 
-                if (direction !== SortDirection.Descending) {
+                if (direction === SortDirection.Descending) {
                     return keyA < keyB ? -1 : 1;
                 } else {
                     return keyA < keyB ? 1 : -1;
@@ -261,6 +261,25 @@ const TemplateWithSearch: Story<TableProps> = (args) => {
         setfilteredRows(newFilteredRowsValue);
     }, [filter]);
 
+    const onSortChange = (key: string, direction?: SortDirection) => {
+        const sortRows = () => {
+            const clonedRows = [...filteredRows];
+
+            clonedRows.sort((a, b) => {
+                const keyA = a.cells[key].sortId;
+                const keyB = b.cells[key].sortId;
+
+                if (direction === SortDirection.Descending) {
+                    return keyA < keyB ? -1 : 1;
+                } else {
+                    return keyA < keyB ? 1 : -1;
+                }
+            });
+            setfilteredRows(clonedRows);
+        };
+        sortRows();
+    };
+
     return (
         <>
             <TextInput
@@ -274,6 +293,7 @@ const TemplateWithSearch: Story<TableProps> = (args) => {
                 rows={filteredRows}
                 selectedRowIds={selectedRows}
                 onSelectionChange={(ids) => setSelectedRows(ids || [])}
+                onSortChange={onSortChange}
             />
         </>
     );

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -65,24 +65,29 @@ type SortType = {
 
 /* react-aria hook props types are inexplicitly typed */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mapToTableAriaProps = (columns: Column[], rows: Row[]): TableStateProps<any> => ({
-    children: [
-        <TableHeader key="table-header" columns={columns}>
-            {(column) => <AriaColumn allowsSorting={column.sortable}>{column.name}</AriaColumn>}
-        </TableHeader>,
-        <TableBody key="table-body" items={rows}>
-            {(item) => (
-                <AriaRow>
-                    {(columnKey) => (
-                        <AriaCell key={`${item.key}-${columnKey}`} aria-label={item.cells[columnKey].ariaLabel}>
-                            {item.cells[columnKey].value}
-                        </AriaCell>
-                    )}
-                </AriaRow>
-            )}
-        </TableBody>,
-    ],
-});
+const mapToTableAriaProps = (columns: Column[], rows: Row[], hasSort = false): TableStateProps<any> => {
+    return {
+        children: [
+            <TableHeader key="table-header" columns={columns}>
+                {(column) => {
+                    const allowsSorting = !!(column.sortable && hasSort);
+                    return <AriaColumn allowsSorting={allowsSorting}>{column.name}</AriaColumn>;
+                }}
+            </TableHeader>,
+            <TableBody key="table-body" items={rows}>
+                {(item) => (
+                    <AriaRow>
+                        {(columnKey) => (
+                            <AriaCell key={`${item.key}-${columnKey}`} aria-label={item.cells[columnKey].ariaLabel}>
+                                {item.cells[columnKey].value}
+                            </AriaCell>
+                        )}
+                    </AriaRow>
+                )}
+            </TableBody>,
+        ],
+    };
+};
 
 const getRowFromId = (rows: Row[], id: Key) => rows.find(({ key }) => key === id) || null;
 
@@ -115,7 +120,7 @@ export const Table = ({
 
     const rowIds = getAllRowIds(rows);
     const ref = useRef<HTMLTableElement | null>(null);
-    const props = mapToTableAriaProps(columns, rows);
+    const props = mapToTableAriaProps(columns, rows, !!onSort);
     const state = useTableState({
         ...props,
         selectionMode,

--- a/src/components/Table/TableColumnHeader.tsx
+++ b/src/components/Table/TableColumnHeader.tsx
@@ -92,9 +92,10 @@ export const TableColumnHeader = ({
     return (
         <th
             ref={ref}
-            className={`tw-text-xs tw-font-medium tw-text-black-100 dark:tw-text-white tw-px-4 tw-py-3 tw-outline-none tw-group focus-visible:bg-violet-90 ${
-                allowsSorting ? 'tw-cursor-pointer' : ''
-            }`}
+            className={merge([
+                'tw-text-xs tw-font-medium tw-text-black-100 dark:tw-text-white tw-px-4 tw-py-3 tw-outline-none tw-group focus-visible:bg-violet-90',
+                allowsSorting ? 'tw-cursor-pointer' : '',
+            ])}
             data-test-id="table-column"
             scope="col"
             onClick={allowsSorting ? () => handleSortChange(column.key, sortDirection) : () => null}

--- a/src/components/Table/TableColumnHeader.tsx
+++ b/src/components/Table/TableColumnHeader.tsx
@@ -19,7 +19,7 @@ export type TableColumnHeaderProps = {
     sortDirection?: SortDirection;
     selectionMode: string;
     isColumnSorted?: boolean;
-    handleSortChange: (column: Key, direction: SortDirection) => void;
+    handleSortChange: (column: string, direction?: SortDirection) => void;
     setSelectedRows?: (ids?: Key[]) => void;
 };
 
@@ -41,8 +41,7 @@ export const TableColumnHeader = ({
     const [icon, setIcon] = useState(<IconArrowBidirectional />);
     const [isChecked, setIsChecked] = useState(false);
     const ref = useRef<HTMLTableCellElement | null>(null);
-    const inverseSortDirection =
-        sortDirection === SortDirection.Ascending ? SortDirection.Descending : SortDirection.Ascending;
+    const ButtonOrSpan = allowsSorting ? 'button' : 'span';
 
     useEffect(() => {
         if (isColumnSorted) {
@@ -93,12 +92,20 @@ export const TableColumnHeader = ({
     return (
         <th
             ref={ref}
-            className="tw-text-xs tw-font-medium tw-text-black-100 dark:tw-text-white tw-px-4 tw-py-3 tw-outline-none tw-cursor-pointer tw-group focus-visible:bg-violet-90"
+            className={`tw-text-xs tw-font-medium tw-text-black-100 dark:tw-text-white tw-px-4 tw-py-3 tw-outline-none tw-group focus-visible:bg-violet-90 ${
+                allowsSorting ? 'tw-cursor-pointer' : ''
+            }`}
             data-test-id="table-column"
             scope="col"
-            onClick={() => handleSortChange(column.key, inverseSortDirection)}
+            onClick={allowsSorting ? () => handleSortChange(column.key, sortDirection) : () => null}
         >
-            <button className={merge(['tw-flex tw-gap-x-1 tw-items-center', FOCUS_VISIBLE_STYLE])}>
+            <ButtonOrSpan
+                className={merge([
+                    'tw-flex tw-gap-x-1 tw-items-center',
+                    FOCUS_VISIBLE_STYLE,
+                    allowsSorting ? 'tw-cursor-pointer' : 'tw-cursor-default',
+                ])}
+            >
                 {rendered}
                 {allowsSorting && (
                     <span
@@ -112,7 +119,7 @@ export const TableColumnHeader = ({
                         {cloneElement(icon, { size: IconSize.Size12 })}
                     </span>
                 )}
-            </button>
+            </ButtonOrSpan>
         </th>
     );
 };


### PR DESCRIPTION
☝️ Now columns are optionally sortable with a prop and the sorting logic is exposed so that it can be customizable, which we need in analytics

![image](https://user-images.githubusercontent.com/18708637/189950157-e239efd6-b50f-4252-9226-a9f8a215b711.png)
