### PR TITLE
fix(Checklist): enforce correct vertical spacing

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -91,7 +91,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                 <span
                     aria-hidden="true"
                     className={merge([
-                        'tw-relative tw-flex tw-w-4 tw-h-4 tw-items-center tw-justify-center tw-rounded tw-border tw-shrink-0',
+                        'tw-relative tw-flex tw-w-4 tw-h-4 tw-items-center tw-justify-center tw-rounded tw-border tw-shrink-0 tw-flex-none',
                         isFocusVisible && FOCUS_STYLE,
                         disabled
                             ? merge([

--- a/src/components/Checklist/Checklist.stories.tsx
+++ b/src/components/Checklist/Checklist.stories.tsx
@@ -76,3 +76,26 @@ MultipleColumns.args = {
     direction: ChecklistDirection.Vertical,
     columns: 2,
 };
+
+export const MultipleColumnsInContainedSpace: Story<ChecklistProps> = (args) => {
+    const [activeBoxes, setActiveBoxes] = useState<string[]>([]);
+
+    return (
+        <div className="tw-w-[300px] tw-p-2 tw-border- tw-border tw-rounded tw-border-line">
+            <ChecklistComponent
+                {...args}
+                checkboxes={COLUMN_CHECKBOXES}
+                activeValues={activeBoxes}
+                setActiveValues={setActiveBoxes}
+            />
+        </div>
+    );
+};
+MultipleColumnsInContainedSpace.args = {
+    direction: ChecklistDirection.Vertical,
+    columns: 2,
+};
+
+MultipleColumnsInContainedSpace.argTypes = {
+    direction: { table: { disable: true } },
+};

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -33,7 +33,7 @@ export const InputLabel: FC<InputLabelProps> = ({
     return (
         <div
             className={merge([
-                'tw-inline-flex tw-items-center tw-gap-1 tw-font-sans tw-text-s tw-max-w-full',
+                'tw-inline-flex tw-items-center tw-gap-1 tw-font-sans tw-text-s tw-max-w-full tw-min-w-0 tw-flex-initial',
                 disabled
                     ? 'tw-text-black-40 hover:tw-text-black-40 dark:tw-text-black-60 dark:hover:tw-text-black-60'
                     : 'tw-text-black-90 dark:tw-text-white',


### PR DESCRIPTION
Since the children of this component were not flex children they were overflowing incorrectly, as below

<img width="309" alt="Screen Shot 2022-09-15 at 12 31 28" src="https://user-images.githubusercontent.com/93908356/190635150-051a288e-2977-4854-80d3-9ddafcc0098c.png">
