### PR TITLE
fix(TextInput): add zero timeout for focusing the text input after mounting

### DIFF
--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -45,76 +45,91 @@ export default {
     },
 } as Meta<FlyoutProps>;
 
-const FlyoutTemplate: Story<FlyoutProps> = (args) => {
-    const [activeItemId, setActiveItemId] = useState('a');
-    const [input, setInput] = useState('');
-    const [open, setOpen] = useState(false);
+const FlyoutTemplate: (addScrollingContent: boolean, inputFocus: boolean) => Story<FlyoutProps> = (
+    addScrollingContent = false,
+    inputFocus = false,
+) => {
+    const Component = (args) => {
+        const [activeItemId, setActiveItemId] = useState('a');
+        const [input, setInput] = useState('');
+        const [open, setOpen] = useState(false);
 
-    return (
-        <div className="dark:tw-text-white">
-            <div className="tw-flex tw-items-center">
-                Some text
-                <Flyout
-                    {...args}
-                    isOpen={open}
-                    onOpenChange={chain(args.onOpenChange, setOpen)}
-                    onCancel={chain(args.onCancel, () => setOpen(false))}
-                    onConfirm={args.onConfirm && chain(args.onConfirm, setOpen)}
-                >
-                    <div className="tw-flex tw-flex-col tw-gap-y-8 tw-p-8">
-                        <FormControl
-                            label={{
-                                children: 'Input Label',
-                                htmlFor: 'input-id',
-                                tooltip: { content: 'Input tooltip' },
-                            }}
-                            extra="Extra Text"
-                        >
-                            <TextInput value={input} onChange={setInput} />
-                        </FormControl>
-                        <Divider color={FLYOUT_DIVIDER_COLOR} height={FLYOUT_DIVIDER_HEIGHT} />
-                        <FormControl
-                            label={{
-                                children: 'Slider Label',
-                                htmlFor: 'slider-id',
-                            }}
-                        >
-                            <Slider
-                                activeItemId={activeItemId}
-                                onChange={setActiveItemId}
-                                items={[
-                                    { id: 'a', value: 'abc' },
-                                    { id: 'b', value: 'def' },
-                                    { id: 'c', value: 'ghi' },
-                                ]}
-                            />
-                        </FormControl>
-                    </div>
+        return (
+            <div className="dark:tw-text-white">
+                <div className="tw-flex tw-items-center">
+                    Some text
+                    <Flyout
+                        {...args}
+                        isOpen={open}
+                        onOpenChange={chain(args.onOpenChange, setOpen)}
+                        onCancel={chain(args.onCancel, () => setOpen(false))}
+                        onConfirm={args.onConfirm && chain(args.onConfirm, setOpen)}
+                    >
+                        <div className="tw-flex tw-flex-col tw-gap-y-8 tw-p-8">
+                            <FormControl
+                                label={{
+                                    children: 'Input Label',
+                                    htmlFor: 'input-id',
+                                    tooltip: { content: 'Input tooltip' },
+                                }}
+                                extra="Extra Text"
+                            >
+                                <TextInput value={input} onChange={setInput} focusOnMount={inputFocus} />
+                            </FormControl>
+                            <Divider color={FLYOUT_DIVIDER_COLOR} height={FLYOUT_DIVIDER_HEIGHT} />
+                            <FormControl
+                                label={{
+                                    children: 'Slider Label',
+                                    htmlFor: 'slider-id',
+                                }}
+                            >
+                                <Slider
+                                    activeItemId={activeItemId}
+                                    onChange={setActiveItemId}
+                                    items={[
+                                        { id: 'a', value: 'abc' },
+                                        { id: 'b', value: 'def' },
+                                        { id: 'c', value: 'ghi' },
+                                    ]}
+                                />
+                            </FormControl>
+                        </div>
 
-                    <div className="tw-p-8">
-                        <FormControl
-                            label={{
-                                children: 'Textarea Label',
-                                htmlFor: 'textarea-id',
-                            }}
-                        >
-                            <Textarea placeholder="This is a placeholder" />
-                        </FormControl>
-                    </div>
-                </Flyout>
+                        <div className="tw-p-8">
+                            <FormControl
+                                label={{
+                                    children: 'Textarea Label',
+                                    htmlFor: 'textarea-id',
+                                }}
+                            >
+                                <Textarea placeholder="This is a placeholder" />
+                            </FormControl>
+                        </div>
+                    </Flyout>
+                </div>
+                <div>
+                    Deserunt voluptate deserunt laborum dolor excepteur. Reprehenderit amet cillum ad ut. Magna labore
+                    consequat enim tempor amet in qui. In esse proident officia aliquip ea in in nulla aliqua in laborum
+                    anim ipsum est.
+                </div>
+                {addScrollingContent &&
+                    Array.from(Array(15).keys()).map((i) => (
+                        <div key={`content${i}`}>
+                            Deserunt voluptate deserunt laborum dolor excepteur. Reprehenderit amet cillum ad ut. Magna
+                            labore consequat enim tempor amet in qui. In esse proident officia aliquip ea in in nulla
+                            aliqua in laborum anim ipsum est.
+                        </div>
+                    ))}
             </div>
-            <div>
-                Deserunt voluptate deserunt laborum dolor excepteur. Reprehenderit amet cillum ad ut. Magna labore
-                consequat enim tempor amet in qui. In esse proident officia aliquip ea in in nulla aliqua in laborum
-                anim ipsum est.
-            </div>
-        </div>
-    );
+        );
+    };
+
+    return Component;
 };
 
-export const WithoutHeader = FlyoutTemplate.bind({});
+export const WithoutHeader = FlyoutTemplate().bind({});
 
-export const WithOnclick = FlyoutTemplate.bind({});
+export const WithOnclick = FlyoutTemplate().bind({});
 
 WithOnclick.argTypes = {
     onConfirm: { action: 'onConfirm' },
@@ -126,7 +141,7 @@ WithOnclick.args = {
     onConfirm: action('onConfirm'),
 };
 
-export const WithBadges = FlyoutTemplate.bind({});
+export const WithBadges = FlyoutTemplate().bind({});
 
 WithBadges.args = {
     title: 'Header title',
@@ -358,7 +373,7 @@ WithRenderFunctionTrigger.argTypes = {
     decorator: { table: { disable: true } },
 };
 
-export const WithContentMinHeight = FlyoutTemplate.bind({});
+export const WithContentMinHeight = FlyoutTemplate().bind({});
 
 WithContentMinHeight.args = {
     contentMinHeight: 200,
@@ -397,3 +412,5 @@ WithPlacementAndOffset.args = {
     placement: FlyoutPlacement.Top,
     offset: 20,
 };
+
+export const WithTextInputAutofocusAndPageScrolling = FlyoutTemplate(true, true).bind({});

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -91,8 +91,10 @@ export const TextInput: FC<TextInputProps> = ({
     );
 
     useEffect(() => {
-        focusOnMount && inputElement.current?.focus();
-    }, []);
+        setTimeout(() => {
+            focusOnMount && inputElement.current?.focus();
+        }, 0);
+    }, [focusOnMount]);
 
     useEffect(() => {
         if (typeof obfuscated === 'boolean') {


### PR DESCRIPTION
This PR fixes the issue with the `TextInput` component `focusOnMount` prop on the first render when inside a `Flyout` component.
 - If the page had scrolling, it would try to focus the element on the first DOM position it is placed, forcing the page to scroll down and the `Flyout` to close.

> The solution was to put the input field focus side-effect inside a `setTimeout(() => {}, 0);` so it could happen on the next event loop, making sure the `Flyout` and the `TextInput` are properly mounted and positioned, avoiding the scrolling and the `Flyout` to close.