### PR TITLE
feat(Tooltip): add disabled and hidden props to component

### DIFF
--- a/src/components/Tooltip/Tooltip.cy.tsx
+++ b/src/components/Tooltip/Tooltip.cy.tsx
@@ -129,4 +129,29 @@ describe('Tooltip Component', () => {
         cy.get('button').realPress('Tab');
         cy.get('button').should('be.focused').and('contain', 'Secondary');
     });
+
+    it('should not render the tooltip content when disabled', () => {
+        initTooltip(
+            {
+                content: TOOLTIP_TEXT,
+                disabled: true,
+            },
+            true,
+        );
+
+        cy.get(TOOLTIP_ID).should('not.exist');
+    });
+
+    it('should render but not display the tooltip content when hidden', () => {
+        initTooltip(
+            {
+                content: TOOLTIP_TEXT,
+                hidden: true,
+            },
+            true,
+        );
+
+        cy.get(TOOLTIP_ID).should('exist');
+        cy.get(TOOLTIP_ID).should('have.class', 'tw-hidden');
+    });
 });

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -59,6 +59,14 @@ export default {
             control: { type: 'boolean' },
             defaultValue: false,
         },
+        disabled: {
+            control: { type: 'boolean' },
+            defaultValue: false,
+        },
+        hidden: {
+            control: { type: 'boolean' },
+            defaultValue: false,
+        },
         flip: {
             control: { type: 'boolean' },
             defaultValue: true,
@@ -195,3 +203,34 @@ OpenByDefault.args = {
     open: true,
     withArrow: true,
 };
+
+export const DisabledTooltip = TooltipComponent.bind({});
+DisabledTooltip.args = {
+    disabled: true,
+};
+DisabledTooltip.decorators = [
+    (StoryElement) => (
+        <div className="tw-flex tw-flex-col tw-justify-start">
+            <p>
+                The tooltip content will NOT be rendered when <strong>disabled</strong> is true. It disables the tooltip
+                open/close feature.
+            </p>
+            <StoryElement />
+        </div>
+    ),
+];
+
+export const HiddenTooltip = TooltipComponent.bind({});
+HiddenTooltip.args = {
+    hidden: true,
+};
+HiddenTooltip.decorators = [
+    (StoryElement) => (
+        <div className="tw-flex tw-flex-col tw-justify-start">
+            <p>
+                The tooltip content will not be displayed, but still be rendered, when <strong>hidden</strong> is true.
+            </p>
+            <StoryElement />
+        </div>
+    ),
+];

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -45,6 +45,8 @@ export type TooltipProps = PropsWithChildren<{
     withArrow?: boolean;
     hoverDelay?: number;
     open?: boolean;
+    disabled?: boolean;
+    hidden?: boolean;
 }>;
 
 /**
@@ -135,6 +137,8 @@ export const Tooltip = ({
     triggerElement,
     hoverDelay = 200,
     open = false,
+    disabled = false,
+    hidden = false,
 }: TooltipProps) => {
     const triggerRefElement = useRef<HTMLElement | HTMLDivElement | HTMLButtonElement | null>(null);
     const linkRef = useRef<HTMLAnchorElement | null>(null);
@@ -222,10 +226,14 @@ export const Tooltip = ({
                     })}
             </div>
             {isOpen &&
+                !disabled &&
                 createPortal(
                     <div
                         ref={tooltipContainerRef}
-                        className="tw-popper-container tw-inline-block tw-max-w-[200px] tw-bg-black-100 dark:tw-bg-white tw-rounded-md tw-shadow-mid tw-text-white dark:tw-text-black-100 tw-z-[120000]"
+                        className={merge([
+                            'tw-popper-container tw-inline-block tw-max-w-[200px] tw-bg-black-100 dark:tw-bg-white tw-rounded-md tw-shadow-mid tw-text-white dark:tw-text-black-100 tw-z-[120000]',
+                            hidden && 'tw-hidden',
+                        ])}
                         data-test-id="tooltip"
                         role="tooltip"
                         style={popperInstance.styles.popper}


### PR DESCRIPTION
This PR adds two new properties to the `Tooltip` component

- `disabled` -> disables tooltip functionality. The tooltip content will not be rendered at all;
- `hidden` -> hides the tooltip content. The content is rendered but hidden with a `display: none;` through Tailwind `tw-hidden` class

New stories and test cases were also added for the new properties.