### PR TITLE
fix(OrderableList): add fragment with key 

### DIFF
--- a/src/components/OrderableList/OrderableList.tsx
+++ b/src/components/OrderableList/OrderableList.tsx
@@ -53,7 +53,7 @@ export const OrderableList = <T extends object>({
         <DndProvider backend={HTML5Backend}>
             <div className="tw-outline-none" data-test-id="orderable-list">
                 {itemsState.map((item, index) => (
-                    <>
+                    <React.Fragment key={`dropzone-orderable-list-key-${index}`}>
                         <DropZone
                             key={`orderable-list-item-${index}-before`}
                             data={{
@@ -81,7 +81,7 @@ export const OrderableList = <T extends object>({
                                 treeId={listId}
                             />
                         )}
-                    </>
+                    </React.Fragment>
                 ))}
             </div>
         </DndProvider>


### PR DESCRIPTION
- There was a bug with the orderable list because the fragment around had no key associated with it. 