### PR TITLE
fix(DatePicker): adjust datepicker popper class to have a higher z-index value

### DIFF
--- a/src/components/DatePicker/DatePicker.css
+++ b/src/components/DatePicker/DatePicker.css
@@ -1,6 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 @import url('react-datepicker/dist/react-datepicker.min.css');
 
+.react-datepicker-popper {
+    /** 
+     *  The Modal default z-index is 50 (vide Modal.tsx file)
+     *  so it's better to place the DatePicker in a smaller z-index 
+     */
+    z-index: 49;
+}
+
 .react-datepicker-wrap {
     font-family: var(--body-family);
     border-radius: var(--radius);

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import { Meta, Story } from '@storybook/react';
 import { DatePicker, DatePickerProps } from './DatePicker';
+import { FormControl } from '@components/FormControl';
+import { Slider } from '@components/Slider';
 
 export default {
     title: 'Components/DatePicker',
@@ -15,6 +17,33 @@ const Template: Story<DatePickerProps> = (args) => {
     return <DatePicker {...args} value={selectedDate as Date} onChange={setSelectedDate} />;
 };
 
+const TemplateWithFormControl: Story<DatePickerProps> = (args) => {
+    const [selectedDate, setSelectedDate] = useState<Date | null>();
+
+    return (
+        <div className="tw-flex tw-flex-col">
+            <div className="tw-px-5 tw-py-3 tw-flex tw-flex-col tw-gap-3">
+                <FormControl>
+                    <DatePicker {...args} value={selectedDate as Date} onChange={setSelectedDate} />
+                </FormControl>
+            </div>
+            <div className="tw-px-5 tw-py-3 tw-flex tw-flex-col tw-gap-3">
+                <FormControl>
+                    <Slider
+                        activeItemId="a"
+                        items={[
+                            { id: 'a', value: 'abc' },
+                            { id: 'b', value: 'def' },
+                            { id: 'c', value: 'ghi' },
+                        ]}
+                        onChange={() => void 0}
+                    />
+                </FormControl>
+            </div>
+        </div>
+    );
+};
+
 export const Default = Template.bind({});
 Default.args = {
     placeHolder: 'Select a date',
@@ -24,3 +53,11 @@ Default.args = {
 };
 
 Default.storyName = 'Date Picker';
+
+export const InsideFormControlAndOverSlider = TemplateWithFormControl.bind({});
+InsideFormControlAndOverSlider.args = {
+    placeHolder: 'Select a date',
+    isClearable: true,
+    shouldCloseOnSelect: true,
+    dateFormat: 'MM/dd/yyyy',
+};


### PR DESCRIPTION
This PR changes the datepicker calendar `z-index`.

The problem: when using the `Datepicker` right before a `Slider`, the date picker was placed underneath the slider which has a `z-index: 10`.

The solution: Changed the `Datepicker.css` to override the class `.react-datepicker-popper` which was setting the `z-index: 1` to `z-index: 40`. This value is because the default `Modal` `z-index` value is 50, so we can assure a datepicker will not be placed above a modal, if for some reason the two of them are on the screen at the same time.