### PR TITLE
fix(TextInput): remove hover style on disabled input

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -121,12 +121,12 @@ export const TextInput: FC<TextInputProps> = ({
         <div
             {...focusProps}
             className={merge([
-                'tw-flex tw-items-center tw-h-9 tw-gap-2 tw-px-3 tw-border hover:tw-border-black-90 tw-transition tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent',
+                'tw-flex tw-items-center tw-h-9 tw-gap-2 tw-px-3 tw-border tw-transition tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent',
                 dotted ? 'tw-border-dashed' : 'tw-border-solid',
                 disabled || readonly
                     ? 'tw-border-black-5 tw-bg-black-5 dark:tw-bg-black-90 dark:tw-border-black-90'
                     : merge([
-                          'focus-within:tw-border-black-90',
+                          'focus-within:tw-border-black-90 hover:tw-border-black-90',
                           validationClassMap[validation],
                           isFocusVisible && FOCUS_STYLE,
                       ]),


### PR DESCRIPTION
Fixing my own issue introducing a hover style that should only be visible when the input is interactive 😅 
Before:
<img width="464" alt="Screenshot 2022-09-29 at 12 51 11" src="https://user-images.githubusercontent.com/93908356/193012730-062a5067-48fd-4691-ac08-7c7ccd164132.png">
After:
<img width="464" alt="Screenshot 2022-09-29 at 12 51 46" src="https://user-images.githubusercontent.com/93908356/193012831-b49d5a3b-020b-4a45-b917-750f6066910d.png">
