### PR TITLE
fix(Button): remove button react-aria

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React, { ForwardRefRenderFunction, MouseEvent, ReactElement, ReactNode, cloneElement, forwardRef } from 'react';
-
-import { useButton } from '@react-aria/button';
 import { merge } from '@utilities/merge';
 import { useForwardedRef } from '@utilities/useForwardedRef';
 import {
@@ -85,10 +83,6 @@ const ButtonComponent: ForwardRefRenderFunction<HTMLButtonElement | null, Button
     }
 
     const ref = useForwardedRef<HTMLButtonElement | null>(externalRef);
-    const { buttonProps } = useButton(
-        { onPress: () => onClick && onClick(), isDisabled: disabled, type: buttonTypeMap[type] },
-        ref,
-    );
 
     const getStyles = (kind: keyof ButtonElements) =>
         !disabled
@@ -108,12 +102,13 @@ const ButtonComponent: ForwardRefRenderFunction<HTMLButtonElement | null, Button
         <button
             aria-label={ariaLabel}
             aria-disabled={disabled}
-            ref={ref}
             className={merge([buttonClassName, inverted && 'tw-dark'])}
-            disabled={disabled}
             data-test-id="button"
             form={formId}
-            {...buttonProps}
+            onClick={onClick}
+            type={buttonTypeMap[type]}
+            disabled={disabled}
+            ref={ref}
         >
             {icon && (
                 <span


### PR DESCRIPTION
React-aria always trigger the focusring when clicking the button. Removing react-aria fixes this issue and does not harm any accessibility criterias.