### PR TITLE
fix(EditableText): Hide isOverflowing control

### DIFF
--- a/src/components/EditableText/EditableText.stories.tsx
+++ b/src/components/EditableText/EditableText.stories.tsx
@@ -13,6 +13,11 @@ export default {
                 disable: true,
             },
         },
+        isOverflowing: {
+            table: {
+                disable: true,
+            },
+        },
         options: {
             table: {
                 category: 'Custom',


### PR DESCRIPTION
![Screenshot 2022-10-17 at 11 24 04](https://user-images.githubusercontent.com/35405438/196141239-d4469c62-1bab-467e-9f26-dbe2612b58d6.png)

isOverflowing shouldn't be visible in Storybook as it is a property added only to fix the overflow in the Tree component.