### PR TITLE
feat(Tree): Create tree node badge tooltip

### DIFF
--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -7,6 +7,7 @@ import { DropZone, OnDropCallback } from '@components/DropZone';
 import { TreeFlatListItem } from '@components/Tree';
 import { DraggableItem, DropZonePosition } from '@utilities/dnd';
 import { EditableText } from '../EditableText';
+import { Tooltip, TooltipPosition } from '../Tooltip';
 
 export type RenderNodeArrayData = Omit<NodeProps, 'isFirst' | 'strong' | 'node'> & {
     nodes: DraggableItem<TreeNodeItem>[];
@@ -82,7 +83,7 @@ export const Node = ({
     onEditableSave,
     treeId,
 }: NodeProps): ReactElement<NodeProps> => {
-    const { id, value, name, label, icon, nodes, actions, editable, badge } = node;
+    const { id, value, name, label, icon, nodes, actions, editable, badge, tooltipContent } = node;
     const [{ opacity }, drag] = useDrag({
         item: { id, value, name, label, icon, nodes, actions, editable, badge },
         collect: (monitor) => ({
@@ -114,15 +115,23 @@ export const Node = ({
 
     const insertBadge = () => {
         return (
-            <div
-                data-test-id="node-badge"
-                className={merge([
-                    'tw-flex tw-justify-center tw-items-center tw-ml-2 tw-text-text-weak',
-                    badge?.props.size && 'tw-w-8 tw-h-5 tw-bg-box-neutral tw-rounded-full',
-                ])}
-            >
-                {badge}
-            </div>
+            <Tooltip
+                disabled={!tooltipContent}
+                content={tooltipContent}
+                position={TooltipPosition.Right}
+                withArrow
+                triggerElement={
+                    <div
+                        data-test-id="node-badge"
+                        className={merge([
+                            'tw-flex tw-justify-center tw-items-center tw-ml-2 tw-text-text-weak',
+                            badge?.props.size && 'tw-w-8 tw-h-5 tw-bg-box-neutral tw-rounded-full',
+                        ])}
+                    >
+                        {badge}
+                    </div>
+                }
+            />
         );
     };
 

--- a/src/components/Tree/Tree.cy.tsx
+++ b/src/components/Tree/Tree.cy.tsx
@@ -40,6 +40,7 @@ const DROP_ZONE_ID = '[data-test-id=drop-zone]';
 const BADGE_ID = '[data-test-id=node-badge]';
 const NODE_EDITABLE_ID = '[data-test-id=editable-input]';
 const NODE_LABEL_ID = '[data-test-id=node-label]';
+const TOOLTIP_ID = '[data-test-id=tooltip]';
 
 describe('Tree Component', () => {
     // TODO check if DropZones are not present when no onDrop props is provided. Refactoring needed first
@@ -153,6 +154,22 @@ describe('Badge Tree Component', () => {
     it('renders badge', () => {
         cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(2) ${TOGGLE_ID}`).click();
         cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(2) ${BADGE_ID}`).should('exist');
+    });
+
+    it('does not render badge tooltip', () => {
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(2) ${TOGGLE_ID}`).click();
+        cy.get(
+            `${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(2) > ${SUB_TREE_ID} > ${NODE_ID}:first-of-type ${BADGE_ID}`,
+        ).trigger('mouseover');
+        cy.get(TOOLTIP_ID).should('not.exist');
+    });
+
+    it('renders badge tooltip', () => {
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(2) ${TOGGLE_ID}`).click();
+        cy.get(
+            `${SUB_TREE_ID} > ${NODE_ID}:nth-last-of-type(2) > ${SUB_TREE_ID} > ${NODE_ID}:last-of-type ${BADGE_ID}`,
+        ).trigger('mouseover');
+        cy.get(TOOLTIP_ID).should('exist');
     });
 });
 

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, ReactElement, useEffect, useState } from 'react';
+import React, { FC, ReactElement, ReactNode, useEffect, useState } from 'react';
 import { renderNodeArray } from './Node';
 import { useId } from '@react-aria/utils';
 import { DndWrapper, DraggableItem, DropZonePosition, draggableItemCompareFn } from '@utilities/dnd';
@@ -15,6 +15,7 @@ export interface TreeFlatListItem {
     value?: string;
     actions?: React.ReactNode[];
     badge?: ReactElement<IconProps> | ReactElement<BadgeProps>;
+    tooltipContent?: ReactNode;
     parentId: NullableString;
     editable?: boolean;
 }

--- a/src/components/Tree/utils/mocks.tsx
+++ b/src/components/Tree/utils/mocks.tsx
@@ -118,6 +118,7 @@ const testCategoryNodes = [
         icon: <IconDocument size={IconSize.Size16} />,
         sort: null,
         badge: <Badge>Hello, I am a badge</Badge>,
+        tooltipContent: 'Hello, I am tooltip content',
     },
 ];
 


### PR DESCRIPTION
Tooltip for the tree node badge. When the `tooltipContent` is not set, the `Tooltip` is disabled, if it is set, then it displays the `tooltipContent` when hovering over the badge. 