### PR TITLE
fix(RichTextEditor): infinite loop inside parseRawValue

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -109,7 +109,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
         <RichTextEditorProvider value={{ designTokens, position }}>
             <Plate
                 id={editorId}
-                initialValue={parseRawValue(initialValue)}
+                initialValue={parseRawValue(editorId, initialValue)}
                 onChange={onChange}
                 editableProps={editableProps}
                 plugins={editorConfig}

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -11,7 +11,7 @@ const wrapTextInHtml = (text: string) => {
 
 export const EMPTY_RICH_TEXT_VALUE: Value = [{ type: ELEMENT_PARAGRAPH, children: [{ text: '' }] }];
 
-export const parseRawValue = (raw?: string): Value => {
+export const parseRawValue = (editorId: string, raw?: string): Value => {
     let parsedValue = EMPTY_RICH_TEXT_VALUE;
 
     if (!raw) {
@@ -21,7 +21,7 @@ export const parseRawValue = (raw?: string): Value => {
     try {
         parsedValue = JSON.parse(raw);
     } catch {
-        const editor = createPlateEditor({ plugins: getEditorConfig() });
+        const editor = createPlateEditor({ id: editorId, plugins: getEditorConfig() });
         const trimmed = raw.trim().replace(/>\s+</g, '><');
         const htmlDocumentString = wrapTextInHtml(trimmed);
         const document = parseHtmlDocument(htmlDocumentString);


### PR DESCRIPTION
This PR provides the editor id to `createPlateEditor` inside `parseRawValue` to prevent an infinite loop when multiple editors are used on the same page in clarify.

Loom of the issue: https://www.loom.com/share/e3cbdc35a88140649107933ee9373d92