### PR TITLE
fix(Rich Text Editor): Removed editor id prop from parsing method

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.cy.tsx
@@ -156,7 +156,7 @@ describe('RichTextEditor Component', () => {
         cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
     });
 
-    it('should be possible to pass and change value', () => {
+    it('wraps the Editor in the component ', () => {
         const TEXT = 'This is new text';
 
         cy.mount(<RichTextEditorWithValueSetOutside value={TEXT} />);

--- a/src/components/RichTextEditor/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.cy.tsx
@@ -121,6 +121,21 @@ const RichTextWithToolbarPositioning = ({ position }: { position?: Position }) =
     <RichTextEditor position={position} />
 );
 
+const RichTextEditorWithValueSetOutside = ({ value }: { value: string }) => {
+    const [initialValue, setInitialValue] = useState(value);
+
+    return <RichTextEditor onTextChange={(value) => setInitialValue(value)} value={initialValue} />;
+};
+
+describe('RichTextEditor Component', () => {
+    it('should be possible to pass and change value', () => {
+        const TEXT = 'This is text';
+
+        cy.mount(<RichTextEditorWithValueSetOutside value={TEXT} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
+    });
+});
+
 describe('RichTextEditor Component', () => {
     it('should render an empty rich text editor', () => {
         cy.mount(<RichTextEditor />);

--- a/src/components/RichTextEditor/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.cy.tsx
@@ -128,15 +128,6 @@ const RichTextEditorWithValueSetOutside = ({ value }: { value: string }) => {
 };
 
 describe('RichTextEditor Component', () => {
-    it('should be possible to pass and change value', () => {
-        const TEXT = 'This is text';
-
-        cy.mount(<RichTextEditorWithValueSetOutside value={TEXT} />);
-        cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
-    });
-});
-
-describe('RichTextEditor Component', () => {
     it('should render an empty rich text editor', () => {
         cy.mount(<RichTextEditor />);
 
@@ -162,6 +153,13 @@ describe('RichTextEditor Component', () => {
         const TEXT = 'This is text';
         cy.mount(<RichTextEditor value={TEXT} />);
 
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
+    });
+
+    it('should be possible to pass and change value', () => {
+        const TEXT = 'This is new text';
+
+        cy.mount(<RichTextEditorWithValueSetOutside value={TEXT} />);
         cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
     });
 

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -109,7 +109,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
         <RichTextEditorProvider value={{ designTokens, position }}>
             <Plate
                 id={editorId}
-                initialValue={parseRawValue(editorId, initialValue)}
+                initialValue={parseRawValue(initialValue)}
                 onChange={onChange}
                 editableProps={editableProps}
                 plugins={editorConfig}

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -11,7 +11,7 @@ const wrapTextInHtml = (text: string) => {
 
 export const EMPTY_RICH_TEXT_VALUE: Value = [{ type: ELEMENT_PARAGRAPH, children: [{ text: '' }] }];
 
-export const parseRawValue = (editorId: string, raw?: string): Value => {
+export const parseRawValue = (raw?: string): Value => {
     let parsedValue = EMPTY_RICH_TEXT_VALUE;
 
     if (!raw) {
@@ -21,7 +21,7 @@ export const parseRawValue = (editorId: string, raw?: string): Value => {
     try {
         parsedValue = JSON.parse(raw);
     } catch {
-        const editor = createPlateEditor({ id: editorId, plugins: getEditorConfig() });
+        const editor = createPlateEditor({ plugins: getEditorConfig() });
         const trimmed = raw.trim().replace(/>\s+</g, '><');
         const htmlDocumentString = wrapTextInHtml(trimmed);
         const document = parseHtmlDocument(htmlDocumentString);


### PR DESCRIPTION
It is breaking the Clarify test with infinite rendering.
The Fondue beta 10 is working normally the 11 is breaking.