### PR TITLE
fix: provide unique id to createPlateEditor

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -109,7 +109,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
         <RichTextEditorProvider value={{ designTokens, position }}>
             <Plate
                 id={editorId}
-                initialValue={parseRawValue(initialValue)}
+                initialValue={parseRawValue({ editorId, raw: initialValue })}
                 onChange={onChange}
                 editableProps={editableProps}
                 plugins={editorConfig}

--- a/src/components/RichTextEditor/serializer/serializeToHtml.ts
+++ b/src/components/RichTextEditor/serializer/serializeToHtml.ts
@@ -6,7 +6,7 @@ import { serializeNodeToHtmlRecursive } from './utils/serializeNodeToHtmlRecursi
 import { setDefaultDesignTokensIfNull } from './utils/setDefaultDesignTokensIfNull';
 
 export const serializeRawToHtml = (raw: string, designTokens: DesignTokens = defaultDesignTokens): string => {
-    const nodes = parseRawValue(raw);
+    const nodes = parseRawValue({ raw });
     return serializeNodesToHtml(nodes, designTokens);
 };
 

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -11,7 +11,12 @@ const wrapTextInHtml = (text: string) => {
 
 export const EMPTY_RICH_TEXT_VALUE: Value = [{ type: ELEMENT_PARAGRAPH, children: [{ text: '' }] }];
 
-export const parseRawValue = (raw?: string): Value => {
+type ParseRawValueOptions = {
+    editorId?: string;
+    raw?: string;
+};
+
+export const parseRawValue = ({ editorId = 'parseRawValue', raw }: ParseRawValueOptions): Value => {
     let parsedValue = EMPTY_RICH_TEXT_VALUE;
 
     if (!raw) {
@@ -21,7 +26,7 @@ export const parseRawValue = (raw?: string): Value => {
     try {
         parsedValue = JSON.parse(raw);
     } catch {
-        const editor = createPlateEditor({ plugins: getEditorConfig() });
+        const editor = createPlateEditor({ id: `${editorId}_parseRawValue`, plugins: getEditorConfig() });
         const trimmed = raw.trim().replace(/>\s+</g, '><');
         const htmlDocumentString = wrapTextInHtml(trimmed);
         const document = parseHtmlDocument(htmlDocumentString);


### PR DESCRIPTION
Redo changes from https://github.com/Frontify/fondue/pull/1008, which were reverted in https://github.com/Frontify/fondue/pull/1010. This time it's an unique id for the `parseRawValue`-method and switched to an object for the parameters.

How to test this with clarify (as linking fondue to clarify is somehow not working currently):
- fondue: `npm run build`
- copy folder `dist` from **fondue** to **clarify/node_modules/@frontify/fondue**
- run tests