### PR TITLE
fix(Rich Text Editor): hook not called inside plate editor

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.cy.tsx
@@ -3,7 +3,7 @@
 import { ELEMENT_LINK, ELEMENT_PARAGRAPH } from '@udecode/plate';
 import React, { FC, useState } from 'react';
 import { Position } from './EditorPositioningWrapper';
-import { RichTextEditor, RichTextEditorProps } from './RichTextEditor';
+import { RichTextEditor } from './RichTextEditor';
 import { DesignTokens } from './types';
 import { ON_SAVE_DELAY_IN_MS } from './utils';
 import { EditorActions } from './utils/actions';
@@ -28,18 +28,6 @@ const BUTTON = '[data-test-id=button]';
 const LINK_CHOOSER_CHECKBOX = '.tw-group > .tw-inline-flex > .tw-flex-1 > .tw-select-none';
 
 const insertTextAndOpenToolbar = () => cy.get('[contenteditable=true]').click().type('hello{selectall}');
-
-const RichTextWithClearButton: FC<Pick<RichTextEditorProps, 'value'>> = ({ value }) => {
-    const [clear, setClear] = useState(false);
-    return (
-        <div>
-            <button data-test-id="clear-button" onClick={() => setClear(true)}>
-                clear
-            </button>
-            <RichTextEditor value={value} clear={clear} />
-        </div>
-    );
-};
 
 const RichTextWithLink: FC<{ text: string; link: string }> = ({ text, link }) => {
     return (
@@ -431,17 +419,6 @@ describe('RichTextEditor Component', () => {
                     JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text: content }] }]),
                 );
             });
-    });
-
-    it('should clear editor content', () => {
-        const text = 'This is some text';
-        cy.mount(
-            <RichTextWithClearButton value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text }] }])} />,
-        );
-
-        cy.get(RICH_TEXT_EDITOR).should('contain.text', text);
-        cy.get('[data-test-id=clear-button]').click();
-        cy.get(RICH_TEXT_EDITOR).should('not.contain.text', text);
     });
 
     describe('link plugin', () => {


### PR DESCRIPTION
Refactored useEditorState while usePlateEditorState should be called inside Plate editor.
Because we don't use the clear prop I removed it, to clear it is also possible to pass empty value.
Removed also corresponding tests

<img width="673" alt="Screenshot 2022-10-26 at 15 52 02" src="https://user-images.githubusercontent.com/517677/198045802-6e601fac-e12e-4acc-b80d-66b0b155c048.png">
