### PR TITLE
Display subtitle for the selected dropdown option if it exists.

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -191,6 +191,7 @@ export const Dropdown: FC<DropdownProps> = ({
                         ariaProps={valueProps}
                         title={activeItem?.title || placeholder}
                         decorator={decorator ?? activeItem?.decorator}
+                        subtitle={activeItem?.subtitle}
                         size={size === DropdownSize.Small ? MenuItemContentSize.Small : MenuItemContentSize.Large}
                     />
                 </button>


### PR DESCRIPTION
This PR introduces the display of the subtitle for a selected element if that exists.
The subtitle is displayed only in the case the size of the dropdown is NOT `DropdownSize.Small` 