### PR TITLE
feat(Tooltip): add enterDelay prop

### DIFF
--- a/src/components/Tooltip/Tooltip.cy.tsx
+++ b/src/components/Tooltip/Tooltip.cy.tsx
@@ -13,6 +13,9 @@ const TOOLTIP_HEADING_TEXT = "I'm a heading";
 const GENERIC_ICON = <IconIcon />;
 const GENERIC_ICON_CODE = 'svg[name=IconIcon16]';
 const BRIGHT_HEADER_ID = '[data-test-id=bright-header]';
+const ENTER_DELAY = 1000;
+const DEFAULT_HOVER_DELAY = 200;
+const CUSTOM_HOVER_DELAY = 1000;
 
 export const TooltipComponent = (args: TooltipProps) => {
     return (
@@ -48,6 +51,40 @@ describe('Tooltip Component', () => {
     it('should render a tooltip open by default via component prop', () => {
         initTooltip({ content: TOOLTIP_TEXT, open: true }, false);
         cy.get(TOOLTIP_ID).should('contain', TOOLTIP_TEXT);
+    });
+
+    it('should render a tooltip after a timeout if enterDelay is set to a number greater than 0', () => {
+        initTooltip({ content: TOOLTIP_TEXT, enterDelay: ENTER_DELAY });
+
+        cy.get(TOOLTIP_ID).should('not.exist');
+
+        cy.wait(ENTER_DELAY);
+
+        cy.get(TOOLTIP_ID).should('exist');
+    });
+
+    it(`should close the tooltip after ${DEFAULT_HOVER_DELAY} milliseconds by default`, () => {
+        initTooltip({ content: TOOLTIP_TEXT });
+
+        cy.get('@Trigger').trigger('mouseout');
+
+        cy.get(TOOLTIP_ID).should('exist');
+
+        cy.wait(DEFAULT_HOVER_DELAY);
+
+        cy.get(TOOLTIP_ID).should('not.exist');
+    });
+
+    it('should close the tooltip after a specified time if hoverDelay is defined', () => {
+        initTooltip({ content: TOOLTIP_TEXT, hoverDelay: CUSTOM_HOVER_DELAY });
+
+        cy.get('@Trigger').trigger('mouseout');
+
+        cy.get(TOOLTIP_ID).should('exist');
+
+        cy.wait(CUSTOM_HOVER_DELAY);
+
+        cy.get(TOOLTIP_ID).should('not.exist');
     });
 
     it('should render an icon next to the tooltip', () => {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -75,6 +75,10 @@ export default {
             control: { type: 'number' },
             defaultValue: 200,
         },
+        enterDelay: {
+            control: { type: 'number' },
+            defaultValue: null,
+        },
     },
 } as Meta<TooltipProps>;
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -44,6 +44,7 @@ export type TooltipProps = PropsWithChildren<{
     flip?: boolean;
     withArrow?: boolean;
     hoverDelay?: number;
+    enterDelay?: number;
     open?: boolean;
     disabled?: boolean;
     hidden?: boolean;
@@ -136,6 +137,7 @@ export const Tooltip = ({
     flip = true,
     triggerElement,
     hoverDelay = 200,
+    enterDelay = 0,
     open = false,
     disabled = false,
     hidden = false,
@@ -182,16 +184,25 @@ export const Tooltip = ({
     const [isOpen, setIsOpen] = useState(false);
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    const handleHideTooltipOnHover = useCallback(() => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => setIsOpen(false), hoverDelay);
+    }, [hoverDelay]);
+
     const handleShowTooltipOnHover = useCallback(() => {
         if (timeoutRef.current) {
             clearTimeout(timeoutRef.current);
         }
-        setIsOpen(true);
-    }, []);
 
-    const handleHideTooltipOnHover = useCallback(() => {
-        timeoutRef.current = setTimeout(() => setIsOpen(false), hoverDelay);
-    }, [hoverDelay]);
+        if (enterDelay) {
+            timeoutRef.current = setTimeout(() => setIsOpen(true), enterDelay);
+            return;
+        }
+
+        setIsOpen(true);
+    }, [enterDelay]);
 
     const checkIfHovered = useCallback(
         (event) => {


### PR DESCRIPTION
The optional enterDelay prop defines the amount of time that should pass before the tooltip becomes visible. If not defined, the tooltip will render immediately.

https://app.clickup.com/t/32yf5y9