### PR TITLE
refactor(Rich Text Editor): Fix type errors

### DIFF
--- a/src/components/RichTextEditor/Plugins/LinkPlugin/LinkMarkupElement/LinkMarkupElementNode.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/LinkMarkupElement/LinkMarkupElementNode.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import { HTMLPropsAs, LinkRootProps, useElementProps } from '@udecode/plate';
 import { getUrlFromLinkOrLegacyLink } from '../utils';
 import { TLinkElement } from '../types';

--- a/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.ts
@@ -11,7 +11,7 @@ import {
 import escapeHtml from 'escape-html';
 
 export const serializeLeafToHtml = (node: TDescendant): string => {
-    let string = escapeHtml(node.text);
+    let string = escapeHtml(node.text as string);
     if (node.bold) {
         string = `<span class="${BOLD_CLASSES}">${string}</span>`;
     }

--- a/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.ts
@@ -1,6 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { TDescendant } from '@udecode/plate';
 import {
     BOLD_CLASSES,
     CODE_CLASSES,
@@ -10,8 +9,8 @@ import {
 } from '@components/RichTextEditor/Plugins';
 import escapeHtml from 'escape-html';
 
-export const serializeLeafToHtml = (node: TDescendant): string => {
-    let string = escapeHtml(node.text as string);
+export const serializeLeafToHtml = (node: any): string => {
+    let string = escapeHtml(node.text);
     if (node.bold) {
         string = `<span class="${BOLD_CLASSES}">${string}</span>`;
     }

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
@@ -13,7 +13,8 @@ export const serializeNodeToHtmlRecursive = (node: TDescendant, designTokens: De
         return serializeLeafToHtml(node);
     }
 
-    const children = node.children.map((n: TDescendant) => serializeNodeToHtmlRecursive(n, designTokens)).join('');
+    const nodeChildren: any = node.children;
+    const children = nodeChildren.map((n: TDescendant) => serializeNodeToHtmlRecursive(n, designTokens)).join('');
 
     switch (node.type) {
         case TextStyles.ELEMENT_HEADING1:
@@ -42,11 +43,14 @@ export const serializeNodeToHtmlRecursive = (node: TDescendant, designTokens: De
             return `<li>${children}</li>`;
         case ELEMENT_LINK:
             if (node.chosenLink) {
+                const { chosenLink }: any = node;
                 return `<a style="${reactCssPropsToCss(designTokens.link)}" target=${
-                    node.chosenLink.openInNewTab ? '_blank' : '_self'
-                } href="${escapeHtml(node.chosenLink.searchResult.link)}">${children}</a>`;
+                    chosenLink.openInNewTab ? '_blank' : '_self'
+                } href="${escapeHtml(chosenLink.searchResult.link)}">${children}</a>`;
             }
-            return `<a style="${reactCssPropsToCss(designTokens.link)}" href="${escapeHtml(node.url)}">${children}</a>`;
+            return `<a style="${reactCssPropsToCss(designTokens.link)}" href="${escapeHtml(
+                node.url as any,
+            )}">${children}</a>`;
         case ELEMENT_CHECK_ITEM:
             return `<input type="checkbox"/><label>${children}</label>`;
 

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
@@ -8,13 +8,11 @@ import escapeHtml from 'escape-html';
 import { reactCssPropsToCss } from './reactCssPropsToCss';
 import { serializeLeafToHtml } from './serializeLeafToHtml';
 
-export const serializeNodeToHtmlRecursive = (node: TDescendant, designTokens: DesignTokens): string => {
+export const serializeNodeToHtmlRecursive = (node: any, designTokens: DesignTokens): string => {
     if (!node.children) {
         return serializeLeafToHtml(node);
     }
-
-    const nodeChildren: any = node.children;
-    const children = nodeChildren.map((n: TDescendant) => serializeNodeToHtmlRecursive(n, designTokens)).join('');
+    const children = node.children.map((n: TDescendant) => serializeNodeToHtmlRecursive(n, designTokens)).join('');
 
     switch (node.type) {
         case TextStyles.ELEMENT_HEADING1:
@@ -43,14 +41,12 @@ export const serializeNodeToHtmlRecursive = (node: TDescendant, designTokens: De
             return `<li>${children}</li>`;
         case ELEMENT_LINK:
             if (node.chosenLink) {
-                const { chosenLink }: any = node;
+                const { chosenLink } = node;
                 return `<a style="${reactCssPropsToCss(designTokens.link)}" target=${
                     chosenLink.openInNewTab ? '_blank' : '_self'
                 } href="${escapeHtml(chosenLink.searchResult.link)}">${children}</a>`;
             }
-            return `<a style="${reactCssPropsToCss(designTokens.link)}" href="${escapeHtml(
-                node.url as any,
-            )}">${children}</a>`;
+            return `<a style="${reactCssPropsToCss(designTokens.link)}" href="${escapeHtml(node.url)}">${children}</a>`;
         case ELEMENT_CHECK_ITEM:
             return `<input type="checkbox"/><label>${children}</label>`;
 


### PR DESCRIPTION
Fixing Type errors listed when running `npm run typecheck`
Because of the complexity and not being able to easily define a type and using `unknown` is not an option, type `any` will be used.

The decision being that is preferable to have a lint warning for `no-explicit-any` than a type error. 