### PR TITLE
fix(rte): immediately set editor width when node is rendered

### DIFF
--- a/src/components/RichTextEditor/hooks/useEditorResize.ts
+++ b/src/components/RichTextEditor/hooks/useEditorResize.ts
@@ -12,6 +12,7 @@ export const useEditorResize = () => {
         if (!node) {
             return;
         }
+        setEditorWidth(node.clientWidth);
 
         const observer = new ResizeObserver((entries) => {
             if (entries.length > 0) {


### PR DESCRIPTION
Prevents visual glitch that can be seen here for 10ms immediately after rendering, caused by debounce. https://fondue-components.frontify.com/?path=/story/components-rich-text-editor--with-toolbar-top-and-small-padding