### PR TITLE
fix(dropdown): add alias tokens and remove brand tokens

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -122,7 +122,7 @@ export const Dropdown: FC<DropdownProps> = ({
 
     const textColorClass = activeItem
         ? menuItemTextColorRecord[activeItem.style || MenuItemStyle.Primary][textState]
-        : 'tw-text-black-60';
+        : 'tw-text-text-x-weak';
 
     const onClear = clearable
         ? () => {
@@ -207,7 +207,7 @@ export const Dropdown: FC<DropdownProps> = ({
                                 minWidth: 'fit-content',
                             }}
                             {...popperInstance.attributes.popper}
-                            className="tw-absolute tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-z-[120000] tw-min-w-full tw-overflow-hidden"
+                            className="tw-absolute tw-p-0 tw-shadow tw-list-none tw-m-0 tw-z-[120000] tw-min-w-full tw-overflow-hidden"
                             key="content"
                             initial={{ height: 0 }}
                             animate={{ height: 'auto' }}
@@ -238,7 +238,7 @@ export const Dropdown: FC<DropdownProps> = ({
                 document.body,
             )}
             {validation === Validation.Loading && (
-                <span className="tw-absolute tw-top-[-0.55rem] tw-right-[-0.55rem] tw-bg-white tw-rounded-full tw-p-[2px] tw-border tw-border-black-10">
+                <span className="tw-absolute tw-top-[-0.55rem] tw-right-[-0.55rem] tw-bg-base tw-rounded-full tw-p-[2px] tw-border tw-border-line-weak">
                     <LoadingCircle size={LoadingCircleSize.ExtraSmall} />
                 </span>
             )}

--- a/src/components/Dropdown/SelectMenu/SelectMenu.tsx
+++ b/src/components/Dropdown/SelectMenu/SelectMenu.tsx
@@ -51,7 +51,7 @@ export const SelectMenu = ({
             {...listBoxProps}
             ref={listRef}
             className={merge([
-                'tw-list-none tw-p-0 tw-m-0 tw-bg-white tw-z-20 focus-visible:tw-outline-none',
+                'tw-list-none tw-p-0 tw-m-0 tw-bg-base tw-z-20 focus-visible:tw-outline-none',
                 scrollable && 'tw-overflow-y-auto',
             ])}
         >

--- a/src/components/Dropdown/SelectMenu/SelectMenuItem.tsx
+++ b/src/components/Dropdown/SelectMenu/SelectMenuItem.tsx
@@ -34,7 +34,7 @@ export const SelectMenuItem: FC<SelectMenuItemProps> = ({ state, menuItem, node 
             {...mergeProps(optionProps, focusProps)}
             data-test-id="menu-item"
             className={merge([
-                'tw-relative hover:tw-bg-black-0 tw-list-none tw-outline-none',
+                'tw-relative hover:tw-bg-box-neutral-hover tw-list-none tw-outline-none',
                 disabled && 'tw-pointer-events-none tw-top-px',
                 isFocusVisible && FOCUS_STYLE_INSET,
             ])}

--- a/src/components/Dropdown/SelectMenu/SelectMenuSection.tsx
+++ b/src/components/Dropdown/SelectMenu/SelectMenuSection.tsx
@@ -9,11 +9,7 @@ export const SelectMenuSection: FC<SelectMenuSectionProps> = ({ ariaLabel, child
     const { itemProps, groupProps } = useListBoxSection({ 'aria-label': ariaLabel });
 
     return (
-        <li
-            {...itemProps}
-            className="tw-border-b tw-border-b-black-10 last:tw-border-0"
-            data-test-id="menu-block-divider"
-        >
+        <li {...itemProps} className="tw-border-b tw-border-b-line last:tw-border-0" data-test-id="menu-block-divider">
             <ul {...groupProps} className="tw-py-2 tw-px-0 tw-m-0 tw-list-none" data-test-id="menu-item-list">
                 {children}
             </ul>

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -39,9 +39,9 @@ export enum MenuItemTextColorState {
 
 export const menuItemTextColorRecord: Record<MenuItemStyle, Record<MenuItemTextColorState, string>> = {
     [MenuItemStyle.Primary]: {
-        [MenuItemTextColorState.Default]: 'tw-text-black-80',
-        [MenuItemTextColorState.Active]: 'tw-text-black',
-        [MenuItemTextColorState.Disabled]: 'tw-text-black-40',
+        [MenuItemTextColorState.Default]: 'tw-text-text-x-weak',
+        [MenuItemTextColorState.Active]: 'tw-text-text',
+        [MenuItemTextColorState.Disabled]: 'tw-text-text-disabled',
     },
     [MenuItemStyle.Danger]: {
         [MenuItemTextColorState.Default]: 'tw-text-red-60',
@@ -85,10 +85,10 @@ export const MenuItem: FC<MenuItemProps> = ({
     return (
         <div
             className={merge([
-                'tw-rounded tw-cursor-pointer tw-flex tw-items-center tw-justify-between tw-transition-colors tw-gap-2',
-                isDangerStyle ? 'hover:tw-text-red-70' : 'hover:tw-text-black',
+                'tw-cursor-pointer tw-flex tw-items-center tw-justify-between tw-transition-colors tw-gap-2',
+                isDangerStyle ? 'hover:tw-text-negative' : 'hover:tw-text-text',
                 menuItemSizeClassMap[size],
-                disabled && 'tw-bg-black-0 tw-pointer-events-none',
+                disabled && 'tw-bg-box-disabled tw-pointer-events-none',
                 active && 'tw-font-medium',
                 textClass,
             ])}

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -50,8 +50,8 @@ export const Trigger: FC<TriggerProps> = ({
                 disabled
                     ? 'tw-border-black-5 tw-bg-black-5 tw-pointer-events-none'
                     : merge([
-                          'tw-bg-white hover:tw-border-black-90',
-                          isOpen ? 'tw-border-black-100' : 'tw-border-black-20',
+                          'tw-bg-base hover:tw-border-line-xx-strong',
+                          isOpen ? 'tw-border-line-xx-strong' : 'tw-border-line',
                           validationClassMap[validation],
                       ]),
             ])}


### PR DESCRIPTION
Hey,

I changed the dropdown component to now use only alias tokens. Hope everything looks like before but with other tokens.

- To test its best to add the tw-dark class to the body of the iframe in the storybook, because the portal moves the html end of the document and is not covered by a tw-dark.