### PR TITLE
chore(deps): upgrade react-dnd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "immer": "9.0.12",
                 "react-colorful": "5.6.1",
                 "react-datepicker": "4.8.0",
-                "react-dnd": "15.1.1",
+                "react-dnd": "16.0.1",
                 "react-dnd-html5-backend": "15.1.2",
                 "react-is": "18.2.0",
                 "react-popper": "2.3.0",
@@ -4008,9 +4008,9 @@
             "integrity": "sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA=="
         },
         "node_modules/@react-dnd/shallowequal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-3.0.0.tgz",
-            "integrity": "sha512-1ELWQdJB2UrCXTKK5cCD9uGLLIwECLIEdttKA255owdpchtXohIjZBTlFJszwYi2ZKe2Do+QvUzsGyGCMNwbdw=="
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+            "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
         },
         "node_modules/@react-hook/merged-ref": {
             "version": "1.3.2",
@@ -22293,13 +22293,13 @@
             }
         },
         "node_modules/react-dnd": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.1.1.tgz",
-            "integrity": "sha512-QLrHtPU08U4c5zop0ANeqrHXaQw2EWLMn8DQoN6/e4eSN/UbB84P49/80Qg0MEF29VLB5vikSoiFh9N8ASNmpQ==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+            "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
             "dependencies": {
-                "@react-dnd/invariant": "3.0.0",
-                "@react-dnd/shallowequal": "3.0.0",
-                "dnd-core": "15.1.1",
+                "@react-dnd/invariant": "^4.0.1",
+                "@react-dnd/shallowequal": "^4.0.1",
+                "dnd-core": "^16.0.1",
                 "fast-deep-equal": "^3.1.3",
                 "hoist-non-react-statics": "^3.3.2"
             },
@@ -22327,6 +22327,26 @@
             "integrity": "sha512-mem9QbutUF+aA2YC1y47G3ECjnYV/sCYKSnu5Jd7cbg3fLMPAwbnTf/JayYdnCH5l3eg9akD9dQt+cD0UdF8QQ==",
             "dependencies": {
                 "dnd-core": "15.1.1"
+            }
+        },
+        "node_modules/react-dnd/node_modules/@react-dnd/asap": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+            "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="
+        },
+        "node_modules/react-dnd/node_modules/@react-dnd/invariant": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+            "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw=="
+        },
+        "node_modules/react-dnd/node_modules/dnd-core": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+            "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+            "dependencies": {
+                "@react-dnd/asap": "^5.0.1",
+                "@react-dnd/invariant": "^4.0.1",
+                "redux": "^4.2.0"
             }
         },
         "node_modules/react-docgen": {
@@ -31909,9 +31929,9 @@
             "integrity": "sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA=="
         },
         "@react-dnd/shallowequal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-3.0.0.tgz",
-            "integrity": "sha512-1ELWQdJB2UrCXTKK5cCD9uGLLIwECLIEdttKA255owdpchtXohIjZBTlFJszwYi2ZKe2Do+QvUzsGyGCMNwbdw=="
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+            "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
         },
         "@react-hook/merged-ref": {
             "version": "1.3.2",
@@ -45309,15 +45329,37 @@
             }
         },
         "react-dnd": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.1.1.tgz",
-            "integrity": "sha512-QLrHtPU08U4c5zop0ANeqrHXaQw2EWLMn8DQoN6/e4eSN/UbB84P49/80Qg0MEF29VLB5vikSoiFh9N8ASNmpQ==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+            "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
             "requires": {
-                "@react-dnd/invariant": "3.0.0",
-                "@react-dnd/shallowequal": "3.0.0",
-                "dnd-core": "15.1.1",
+                "@react-dnd/invariant": "^4.0.1",
+                "@react-dnd/shallowequal": "^4.0.1",
+                "dnd-core": "^16.0.1",
                 "fast-deep-equal": "^3.1.3",
                 "hoist-non-react-statics": "^3.3.2"
+            },
+            "dependencies": {
+                "@react-dnd/asap": {
+                    "version": "5.0.2",
+                    "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+                    "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="
+                },
+                "@react-dnd/invariant": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+                    "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw=="
+                },
+                "dnd-core": {
+                    "version": "16.0.1",
+                    "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+                    "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+                    "requires": {
+                        "@react-dnd/asap": "^5.0.1",
+                        "@react-dnd/invariant": "^4.0.1",
+                        "redux": "^4.2.0"
+                    }
+                }
             }
         },
         "react-dnd-html5-backend": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         "immer": "9.0.12",
         "react-colorful": "5.6.1",
         "react-datepicker": "4.8.0",
-        "react-dnd": "15.1.1",
+        "react-dnd": "16.0.1",
         "react-dnd-html5-backend": "15.1.2",
         "react-is": "18.2.0",
         "react-popper": "2.3.0",


### PR DESCRIPTION
Updating dependencies in small parts to prepare the migration to React 18.
Using current version of Fondue in a react 18 app gives `./jsx-runtime.js is not exported from package (react-dnd)` error.
Fix: update react-dnd to version 16.0.1

To be tested without using `npm link`



