### PR TITLE
fix(RTE): make hover optional in DesignTokens type

### DIFF
--- a/src/components/RichTextEditor/types.ts
+++ b/src/components/RichTextEditor/types.ts
@@ -4,7 +4,7 @@ import { CSSProperties } from 'react';
 import { ButtonStyles, TextStyles } from './Plugins/TextStylePlugin/TextStyles';
 
 export type DesignTokens = Partial<Record<TextStyles, CSSProperties>> &
-    Partial<Record<ButtonStyles, CSSProperties & { hover: CSSProperties }>>;
+    Partial<Record<ButtonStyles, CSSProperties & { hover?: CSSProperties }>>;
 
 export enum PaddingSizes {
     None = 'tw-p-0',


### PR DESCRIPTION
Property `hover` should be optional in `DesignTokens` type, see: [useGuidelineDesignTokens.ts#L73](https://github.com/Frontify/guideline-blocks/blob/main/packages/shared/src/hooks/useGuidelineDesignTokens.ts#L73)