### PR TITLE
fix: use correct react aria typing

### DIFF
--- a/src/components/Modal/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter.tsx
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, useContext } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { ModalFooterProps } from './types';
 import { Button, ButtonSize } from '@components/Button';
 import { ModalLayout } from './context/ModalLayout';
 
-export const ModalFooter: FC<ModalFooterProps> = ({ buttons }) => {
+export const ModalFooter = ({ buttons }: ModalFooterProps): ReactElement => {
     const { padding } = useContext(ModalLayout);
 
     return (

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { OverlayProps } from '@react-aria/overlays';
+import { AriaOverlayProps } from '@react-aria/overlays';
 import { AriaDialogProps } from '@react-types/dialog';
 import { PatternDesign, PatternTheme } from '@foundation/Pattern';
 import { ScrollWrapperDirection } from '@components/ScrollWrapper/types';
@@ -67,5 +67,5 @@ export type ModalProps = {
     isDismissable?: boolean;
     zIndex?: number;
     compact?: boolean;
-} & Omit<OverlayProps, 'isOpen'> &
+} & Omit<AriaOverlayProps, 'isOpen'> &
     AriaDialogProps;


### PR DESCRIPTION
Fixes issue introduced when upgrading react-aria as some types changed and `shouldCloseOnBlur` have moved to another type