### PR TITLE
fix: normalize initial html value for rich text editor

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -8,7 +8,6 @@ import { useEditorState } from './hooks';
 import { RichTextEditorProvider } from './context/RichTextEditorContext';
 import { DesignTokens, PaddingSizes } from './types';
 import { defaultDesignTokens } from './utils/defaultDesignTokens';
-import { parseRawValue } from './utils/parseRawValue';
 import { Position } from './EditorPositioningWrapper';
 import { GeneratePlugins, PluginComposer, defaultPlugins } from './Plugins';
 import { forceTabOutOfActiveElement } from './helpers';
@@ -44,7 +43,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
     plugins = defaultPlugins,
 }) => {
     const editorId = useMemoizedId(id);
-    const { localValue, onChange } = useEditorState(onTextChange);
+    const { localValue, onChange, memoizedValue } = useEditorState({ editorId, initialValue, onTextChange });
 
     const editableProps: EditableProps = {
         placeholder,
@@ -75,8 +74,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
         <RichTextEditorProvider value={{ designTokens, position }}>
             <Plate
                 id={editorId}
-                initialValue={parseRawValue({ editorId, raw: initialValue })}
-                normalizeInitialValue
+                initialValue={memoizedValue}
                 onChange={onChange}
                 editableProps={editableProps}
                 plugins={config.create()}

--- a/src/components/RichTextEditor/hooks/useEditorState.ts
+++ b/src/components/RichTextEditor/hooks/useEditorState.ts
@@ -1,13 +1,17 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { TNode } from '@udecode/plate';
 import { debounce } from '@utilities/debounce';
-import { ON_SAVE_DELAY_IN_MS } from '../utils';
+import { ON_SAVE_DELAY_IN_MS, parseRawValue } from '../utils';
 
-type useEditorStateProps = ((value: string) => void) | undefined;
+type useEditorStateProps = {
+    editorId: string;
+    initialValue?: string;
+    onTextChange: ((value: string) => void) | undefined;
+};
 
-export const useEditorState = (onTextChange: useEditorStateProps) => {
+export const useEditorState = ({ editorId, onTextChange, initialValue }: useEditorStateProps) => {
     const localValue = useRef<TNode[] | null>(null);
 
     const debouncedOnChange = debounce((value: TNode[]) => {
@@ -22,5 +26,11 @@ export const useEditorState = (onTextChange: useEditorStateProps) => {
         [debouncedOnChange, localValue],
     );
 
-    return { localValue, onChange };
+    const memoizedValue = useMemo(
+        () => parseRawValue({ editorId, raw: initialValue }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [editorId],
+    );
+
+    return { localValue, onChange, memoizedValue };
 };

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -18,6 +18,7 @@ type ParseRawValueOptions = {
 };
 
 export const parseRawValue = ({ editorId = 'parseRawValue', raw }: ParseRawValueOptions): Value => {
+    const editor = InitPlateEditor.init(`${editorId}_parseRawValue`).getInstance();
     let parsedValue = EMPTY_RICH_TEXT_VALUE;
 
     if (!raw) {
@@ -27,7 +28,6 @@ export const parseRawValue = ({ editorId = 'parseRawValue', raw }: ParseRawValue
     try {
         parsedValue = JSON.parse(raw);
     } catch {
-        const editor = InitPlateEditor.init(`${editorId}_parseRawValue`).getInstance();
         const trimmed = raw.trim().replace(/>\s+</g, '><');
         const htmlDocumentString = wrapTextInHtml(trimmed);
         const parsedHtml = deserializeHtml(editor, {
@@ -35,11 +35,12 @@ export const parseRawValue = ({ editorId = 'parseRawValue', raw }: ParseRawValue
             stripWhitespace: true,
         }) as Value;
         if (parsedHtml) {
-            editor.children = parsedHtml;
-            normalizeEditor(editor, { force: true });
-            parsedValue = editor.children;
+            parsedValue = parsedHtml;
         }
     }
 
-    return parsedValue;
+    editor.children = parsedValue;
+    normalizeEditor(editor, { force: true });
+
+    return editor.children;
 };

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ELEMENT_PARAGRAPH, Value, deserializeHtml } from '@udecode/plate';
+import { ELEMENT_PARAGRAPH, Value, deserializeHtml, normalizeEditor } from '@udecode/plate';
 import { InitPlateEditor } from './InitPlateEditor';
 
 const isHtmlString = (string: string): boolean => {
@@ -35,7 +35,9 @@ export const parseRawValue = ({ editorId = 'parseRawValue', raw }: ParseRawValue
             stripWhitespace: true,
         }) as Value;
         if (parsedHtml) {
-            parsedValue = parsedHtml;
+            editor.children = parsedHtml;
+            normalizeEditor(editor, { force: true });
+            parsedValue = editor.children;
         }
     }
 


### PR DESCRIPTION
To test:
Replace this story with the following 
```
export const SerializedToHTML: StoryFn<RichTextEditorProps> = ({ onTextChange }) => {
    const serialized =
        '<ul class="tw-list-disc tw-pl-[10px] tw-mb-[10px] tw-ml-[25px]"><li style="font-size: 14px; font-style: normal; font-weight: normal; line-height: 16px; text-decoration: none;"><span style>padding</span></li></ul><ol class="tw-pl-[10px] tw-mb-[10px] tw-ml-[25px] tw-list-[decimal]"><li style="font-size: 14px; font-style: normal; font-weight: normal; line-height: 16px; text-decoration: none;"><span style>test</span></li></ol><p style="font-size: 14px; font-style: normal; font-weight: normal; line-height: 16px;"></p><p style="font-size: 14px; font-style: normal; font-weight: normal; line-height: 16px;"><a href="/" style="font-size: 14px; font-style: normal; color: rgb(113, 89, 215); text-decoration: underline; cursor: pointer;">tfhg</a></p>';
    const plate = JSON.stringify(parseRawValue({ raw: serialized }));

    return (
        <>
            {plate}
            {serialized ? (
                <>
                    Serialized:
                    <div className="tw-border-2 tw-border-black-10 tw-p-2 tw-m-6">
                        <code>{serialized}</code>
                    </div>
                    Rendered:
                    <div className="tw-border-2 tw-border-black-10 tw-p-2 tw-m-6">
                        <div dangerouslySetInnerHTML={{ __html: serialized }} />
                    </div>
                    <RichTextEditorComponent onTextChange={onTextChange} value={plate} />
                </>
            ) : null}
        </>
    );
};
```

`onChange` should not be called when it loads