### PR TITLE
fix(Tabs): Tab and focus on tab panel only when no interactive content.

### DIFF
--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, ReactElement, ReactNode } from 'react';
+import React, { FC, ReactElement, ReactNode, useRef } from 'react';
 import { BadgeProps } from '@components/Badge';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
@@ -18,14 +18,19 @@ export type TabItemProps = {
 
 export const TabItem: FC<TabItemProps & { active?: boolean }> = ({ active, disabled, children, id }) => {
     const { isFocusVisible, focusProps } = useFocusRing();
+    const ref = useRef<HTMLDivElement | null>(null);
+    const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const focusableChildren = ref.current?.querySelectorAll(focusableElements) ?? [];
+    const hasInteractiveElements = focusableChildren.length > 0;
 
     return (
         <div
             role="tabpanel"
+            ref={ref}
             id={`${id}-content`}
             aria-labelledby={id}
             className={merge([!active || disabled ? 'tw-hidden' : '', isFocusVisible && FOCUS_STYLE])}
-            tabIndex={0}
+            tabIndex={hasInteractiveElements ? -1 : 0}
             {...focusProps}
         >
             {children}

--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -5,6 +5,7 @@ import { BadgeProps } from '@components/Badge';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
+import { checkIfContainInteractiveElements } from '@utilities/elements';
 
 export type TabItemProps = {
     id: string;
@@ -19,9 +20,7 @@ export type TabItemProps = {
 export const TabItem: FC<TabItemProps & { active?: boolean }> = ({ active, disabled, children, id }) => {
     const { isFocusVisible, focusProps } = useFocusRing();
     const ref = useRef<HTMLDivElement | null>(null);
-    const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-    const focusableChildren = ref.current?.querySelectorAll(focusableElements) ?? [];
-    const hasInteractiveElements = focusableChildren.length > 0;
+    const hasInteractiveElements = checkIfContainInteractiveElements(ref.current);
 
     return (
         <div

--- a/src/components/Tabs/Tabs.cy.tsx
+++ b/src/components/Tabs/Tabs.cy.tsx
@@ -176,6 +176,18 @@ describe('Tabs Component', () => {
         cy.get('button#tab-3-btn').should('be.focused');
     });
 
+    it('should not focus on tab content if it contains interactive elements', () => {
+        cy.get('[data-test-id=tab-item]').first().click();
+        cy.get('body').realPress('Tab');
+        cy.get('body').realPress('Tab');
+        cy.get('#tab-1-content').should('be.focused');
+        cy.get('[data-test-id=tab-item]').eq(5).click();
+        cy.get('body').realPress('Tab');
+        cy.get('body').realPress('Tab');
+        cy.get('#tab-6-content').children().first().should('be.focused');
+        cy.get('#tab-6-content').should('not.be.focused');
+    });
+
     it('should not pass on disabled tab with keyboard', () => {
         cy.get('[data-test-id=tab-item]').first().trigger('keydown', { key: 'ArrowRight' });
         cy.get('[data-test-id=tab-item]').eq(1).should('not.have.class', 'tw-font-medium');

--- a/src/utilities/elements.ts
+++ b/src/utilities/elements.ts
@@ -11,3 +11,12 @@ export const getItemElementType = (link?: string, onClick?: (event: MouseEvent<H
 
     return 'span';
 };
+
+export const checkIfContainInteractiveElements = (node: HTMLElement | null) => {
+    if (node) {
+        const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+        const focusableChildren = node.querySelectorAll(focusableElements) ?? [];
+        return focusableChildren.length > 0;
+    }
+    return false;
+};


### PR DESCRIPTION
Issue:
When tabbing, the tab content panel always focus.

Fix:
The focus should be on the whole panel when no interactive elements are present. Else, you should tab directly to whatever you can interact with inside of it.