### PR TITLE
fix(trigger): fix padding on small variant

### DIFF
--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -185,7 +185,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                         tabIndex={0}
                         onKeyDown={handleSpacebarToggle}
                     >
-                        <div className="tw-flex tw-flex-wrap tw-gap-2 tw-outline-none tw-items-center tw-min-h-[34px]">
+                        <div className="tw-flex tw-flex-wrap tw-gap-2 tw-outline-none tw-items-center tw-min-h-[28px]">
                             {decorator && <div className={getDecoratorClasses()}>{decorator}</div>}
                             {label && hasSelectedItems && <Text weight="strong">{label}</Text>}
                             {type === MultiSelectType.Default &&


### PR DESCRIPTION
The height wasn't matching the new design, here, should be 36px instead of 42px: https://www.figma.com/file/WfEbqZI0nnPWHN43MCtvnm/Fondue---Inputs?node-id=43%3A32279&t=1JXIVp1n0yuj7EAa-4

CC @SamCreasey 

![image](https://user-images.githubusercontent.com/18708637/210239796-c761ded7-bb88-44ca-9d02-381fb04ebc9b.png)
