### PR TITLE
fix: allow custom ids on tab to be ordered

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -18,7 +18,7 @@ import { IconDotsHorizontal } from '@foundation/Icon';
 import { Badge } from '@components/Badge';
 import { motion } from 'framer-motion';
 import { useFocusRing } from '@react-aria/focus';
-import { FOCUS_STYLE, FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
+import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 
 export enum TabsPaddingX {
@@ -88,15 +88,17 @@ export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, on
     };
 
     const filterTabList = (array: TabItemProps[], direction: string) => {
-        return array.filter((tab) => {
+        const activeItemIndex = array.findIndex((tab) => tab.id === activeItemId);
+
+        return array.filter((tab, index) => {
             if (direction === 'next') {
-                if (tab.id > activeItemId && !tab.disabled) {
+                if (index > activeItemIndex && !tab.disabled) {
                     return tab;
                 }
             }
 
             if (direction === 'previous') {
-                if (tab.id < activeItemId && !tab.disabled) {
+                if (index < activeItemIndex && !tab.disabled) {
                     return tab;
                 }
             }
@@ -210,8 +212,6 @@ export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, on
                                 id={`${tab.id}-btn`}
                                 className={merge([
                                     'tw-group tw-relative tw-mx-0 tw-py-4 tw-px-2 tw-w-max tw-cursor-pointer tw-flex tw-items-center tw-justify-center tw-whitespace-nowrap',
-                                    FOCUS_VISIBLE_STYLE,
-                                    'tw-ring-inset',
                                     tab.disabled && 'tw-text-text-disabled',
                                     tab.id === activeItemId ? 'tw-font-medium tw-text-text' : 'tw-text-text-weak',
                                     size === TabSize.Small ? 'tw-text-sm' : 'tw-text-md',


### PR DESCRIPTION
The id was being used in an alphabetized comparison, but if the id's of the tabs were not in order then it broke keyboard accessibility. Using the index ensures that custom tab id's can be used