### PR TITLE
fix(RTE): disable LinkChooser in readonly mode

### DIFF
--- a/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/CustomFloatingLink.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/CustomFloatingLink.tsx
@@ -1,13 +1,17 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { TEditableProps, useFloatingLinkSelectors } from '@udecode/plate';
 import React from 'react';
-import { useFloatingLinkSelectors } from '@udecode/plate';
-import { FloatingLink } from './FloatingLink';
 import { EditModal } from './EditLinkModal';
+import { FloatingLink } from './FloatingLink';
 import { InsertLinkModal } from './InsertLinkModal/InsertLinkModal';
 
-export const CustomFloatingLink = () => {
+export const CustomFloatingLink = ({ readOnly }: TEditableProps) => {
     const isEditing = useFloatingLinkSelectors().isEditing();
+
+    if (readOnly) {
+        return null;
+    }
 
     const input = <InsertLinkModal />;
     const editContent = isEditing ? input : <EditModal />;


### PR DESCRIPTION
Previously the LinkChooser could be opened even in `readonly` mode, see [loom](https://www.loom.com/share/50abc1c4b96541a3b5b0c0cd44977b12).