### PR TITLE
fix(MultiSelect): Disable animation to enable flip

### DIFF
--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -210,6 +210,12 @@ export const MultiSelect: FC<MultiSelectProps> = ({
         ],
     });
 
+    useEffect(() => {
+        if (popperInstance.update) {
+            popperInstance.update();
+        }
+    }, [activeItemKeys]);
+
     return (
         <div className="tw-relative" ref={multiSelectRef}>
             <Trigger

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -280,36 +280,31 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 heightIsReady &&
                 emphasis === MultiSelectEmphasis.Default &&
                 createPortal(
-                    <AnimatePresence>
-                        <motion.div
-                            ref={setMultiSelectMenuRef}
-                            className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-30 tw-bg-base tw-min-w-[18rem]"
-                            key="content"
-                            style={{
-                                ...popperInstance.styles.popper,
-                                width: triggerRef?.getBoundingClientRect().width,
-                            }}
-                            {...popperInstance.attributes.popper}
-                            initial={false} //disabling animation for now
-                            animate={{ height: 'auto' }}
-                            transition={{ ease: [0.04, 0.62, 0.23, 0.98], duration: 0.5 }}
-                        >
-                            <FocusScope restoreFocus>
-                                <div
-                                    className="tw-p-4 tw-overflow-y-auto tw-overflow-x-hidden tw-w-full tw-relative"
-                                    style={{ maxHeight }}
-                                >
-                                    <Checklist
-                                        activeValues={activeItemKeys.map((key) => key.toString())}
-                                        setActiveValues={onSelectionChange}
-                                        checkboxes={checkboxes.filter((item) => !item.isDivider && !item.isCategory)}
-                                        direction={ChecklistDirection.Vertical}
-                                        ariaLabel={ariaLabel}
-                                    />
-                                </div>
-                            </FocusScope>
-                        </motion.div>
-                    </AnimatePresence>,
+                    <div
+                        ref={setMultiSelectMenuRef}
+                        className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-30 tw-bg-base tw-min-w-[18rem]"
+                        key="content"
+                        style={{
+                            ...popperInstance.styles.popper,
+                            width: triggerRef?.getBoundingClientRect().width,
+                        }}
+                        {...popperInstance.attributes.popper}
+                    >
+                        <FocusScope restoreFocus>
+                            <div
+                                className="tw-p-4 tw-overflow-y-auto tw-overflow-x-hidden tw-w-full tw-relative"
+                                style={{ maxHeight }}
+                            >
+                                <Checklist
+                                    activeValues={activeItemKeys.map((key) => key.toString())}
+                                    setActiveValues={onSelectionChange}
+                                    checkboxes={checkboxes.filter((item) => !item.isDivider && !item.isCategory)}
+                                    direction={ChecklistDirection.Vertical}
+                                    ariaLabel={ariaLabel}
+                                />
+                            </div>
+                        </FocusScope>
+                    </div>,
                     document.body,
                 )}
             {open &&

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -210,12 +210,6 @@ export const MultiSelect: FC<MultiSelectProps> = ({
         ],
     });
 
-    useEffect(() => {
-        if (popperInstance.update) {
-            popperInstance.update();
-        }
-    }, [activeItemKeys]);
-
     return (
         <div className="tw-relative" ref={multiSelectRef}>
             <Trigger
@@ -296,7 +290,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                                 width: triggerRef?.getBoundingClientRect().width,
                             }}
                             {...popperInstance.attributes.popper}
-                            initial={{ height: DEFAULT_DROPDOWN_MIN_ANIMATION_HEIGHT }}
+                            initial={false} //disabling animation for now
                             animate={{ height: 'auto' }}
                             transition={{ ease: [0.04, 0.62, 0.23, 0.98], duration: 0.5 }}
                         >


### PR DESCRIPTION
Flip is flaky on overlays with dynamic height calculation and use of popper.js for positioning.

Rule of Animation:
If the animation is causing more trouble than it delivers value, Don't animate.