### PR TITLE
fix: tree types

### DIFF
--- a/src/components/Tree/TreeItem.tsx
+++ b/src/components/Tree/TreeItem.tsx
@@ -163,3 +163,5 @@ function getAcceptTypes<
         return accepts as string | string[];
     }
 }
+
+TreeItem.type = TreeItem;

--- a/src/components/Tree/hooks/useDraggableEnhancedChildren.tsx
+++ b/src/components/Tree/hooks/useDraggableEnhancedChildren.tsx
@@ -1,16 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { ReactElement } from 'react';
+import React, { ReactNode } from 'react';
 
 import { DropZone, OnDropCallback } from '@components/DropZone';
 import { DraggableItem, DropZonePosition } from '@utilities/dnd';
 
-import { TreeItemProps } from '../types';
-
 type Configuration<T> = {
     onDrop?: OnDropCallback<T>;
     accept: string | string[];
-    children?: ReactElement<TreeItemProps> | ReactElement<TreeItemProps>[];
+    children?: ReactNode;
 };
 
 export const useDraggableEnhancedChildren = <T extends object>(config: Configuration<T>) => {
@@ -21,7 +19,7 @@ export const useDraggableEnhancedChildren = <T extends object>(config: Configura
 
         return React.cloneElement(
             <>
-                {index === 0 && (
+                {index === 0 && React.isValidElement(child) && (
                     <DropZone
                         data-position={DropZonePosition.Before}
                         data={{

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ReactElement, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { OnDropCallback } from '@components/DropZone';
 
@@ -9,7 +9,7 @@ export type TreeProps = {
     activeIds?: string[];
     draggable?: boolean;
     onDrop?: OnDropCallback<{ id: string; sort: Nullable<number> }>;
-    children: ReactElement<TreeItemProps> | ReactElement<TreeItemProps>[];
+    children: ReactNode;
 };
 
 export type ContentComponentArguments = {
@@ -41,5 +41,5 @@ export type TreeItemProps = {
      */
     accepts?: { within: string | string[]; after: string | string[]; before: string | string[] } | string | string[];
 
-    children?: ReactElement<TreeItemProps> | ReactElement<TreeItemProps>[];
+    children?: ReactNode;
 } & (TreeItemWithLabelProps | TreeItemWIthContentComponentProps);


### PR DESCRIPTION
Just some small type changes regarding TreeItem and Tree children. 
- Change from ReactElement | ReactElement[] to ReactNode, for better flexibility. 