### PR TITLE
fix(Slider): add a flex wrapper for buttons to have the full height

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -129,29 +129,31 @@ export const Slider: FC<SliderProps> = ({
     const selectedIndex = items.findIndex((item) => item.id === radioGroupState.selectedValue);
 
     return (
-        <fieldset
-            {...radioGroupProps}
-            data-test-id="slider"
-            className="tw-relative tw-h-9 tw-w-full tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly tw-p-0 tw-border tw-border-black-20 tw-m-0 tw-bg-black-0 tw-rounded tw-font-sans tw-text-s tw-select-none"
-        >
-            <motion.div
-                aria-hidden="true"
-                // div border is not included in width so it must be subtracted from translation.
-                animate={{ x: `calc(${100 * selectedIndex}% - ${2 * selectedIndex}px)` }}
-                initial={false}
-                transition={{ type: 'tween', duration: 0.3 }}
-                style={{
-                    width: `${100 / items.length}%`,
-                }}
-                hidden={!activeItemId}
-                className={merge([
-                    'tw-absolute tw--inset-px tw-h-full tw-box-content tw-border tw-rounded tw-pointer-events-none',
-                    disabled
-                        ? 'tw-border-line-x-strong tw-border-opacity-30 tw-bg-black-0'
-                        : 'tw-border-black tw-bg-white',
-                ])}
-            />
-            {itemElements}
-        </fieldset>
+        <div className="tw-flex">
+            <fieldset
+                {...radioGroupProps}
+                data-test-id="slider"
+                className="tw-relative tw-h-9 tw-w-full tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly tw-p-0 tw-border tw-border-black-20 tw-m-0 tw-bg-black-0 tw-rounded tw-font-sans tw-text-s tw-select-none"
+            >
+                <motion.div
+                    aria-hidden="true"
+                    // div border is not included in width so it must be subtracted from translation.
+                    animate={{ x: `calc(${100 * selectedIndex}% - ${2 * selectedIndex}px)` }}
+                    initial={false}
+                    transition={{ type: 'tween', duration: 0.3 }}
+                    style={{
+                        width: `${100 / items.length}%`,
+                    }}
+                    hidden={!activeItemId}
+                    className={merge([
+                        'tw-absolute tw--inset-px tw-h-full tw-box-content tw-border tw-rounded tw-pointer-events-none',
+                        disabled
+                            ? 'tw-border-line-x-strong tw-border-opacity-30 tw-bg-black-0'
+                            : 'tw-border-black tw-bg-white',
+                    ])}
+                />
+                {itemElements}
+            </fieldset>
+        </div>
     );
 };


### PR DESCRIPTION
Tested on Chrome, Safari, Firefox and Edge