### PR TITLE
fix(ColorPickerFlyout): flyout opening when disabled is true

### DIFF
--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -54,6 +54,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
             contentMinHeight={300}
             fixedHeader={<ColorPreview color={currentColor || { red: 255, green: 255, blue: 255 }} />}
             onOpenChange={handleOpenChange}
+            isTriggerDisabled={disabled}
             trigger={
                 <ColorInputTrigger
                     isOpen={open}

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -51,7 +51,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
             onConfirm={handleClick}
             isOpen={open}
             onCancel={() => handleOpenChange(false)}
-            contentMinHeight={300}
+            contentMinHeight={150}
             fixedHeader={<ColorPreview color={currentColor || { red: 255, green: 255, blue: 255 }} />}
             onOpenChange={handleOpenChange}
             isTriggerDisabled={disabled}

--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -48,6 +48,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                 {...focusProps}
                 type="button"
                 id={useMemoizedId(id)}
+                disabled={disabled}
                 className={merge([
                     'tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-2 tw-pl-3 tw-min-h-[34px] tw-pr-7',
                     !currentColor && 'tw-text-black-60',

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -66,10 +66,12 @@ export type FlyoutProps = PropsWithChildren<{
     placement?: FlyoutPlacement;
     offset?: number;
     updatePositionOnContentChange?: boolean;
+    isTriggerDisabled?: boolean;
 }>;
 
 export const Flyout: FC<FlyoutProps> = ({
     trigger,
+    isTriggerDisabled = false,
     decorator,
     onConfirm,
     onCancel,
@@ -111,7 +113,10 @@ export const Flyout: FC<FlyoutProps> = ({
         updatePositionOnContentChange,
     });
 
-    const { buttonProps, isPressed } = useButton({ onPress: () => toggle(), elementType: 'div' }, triggerRef);
+    const { buttonProps, isPressed } = useButton(
+        { onPress: () => toggle(), elementType: 'div', isDisabled: isTriggerDisabled },
+        triggerRef,
+    );
 
     useEffect(() => {
         const revert = watchModals();

--- a/src/components/Flyout/FlyoutFooter.tsx
+++ b/src/components/Flyout/FlyoutFooter.tsx
@@ -16,6 +16,10 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ buttons, border = true }) 
             className={merge([
                 'tw-flex tw-gap-x-3 tw-justify-end tw-py-5 tw-px-8 tw-bg-white dark:tw-bg-black-95',
                 border && 'tw-border-t tw-border-t-black-10',
+                // The footer min-height should be 76px, since we Tailwind doesn't have a tw-h-19 class
+                // we force TW to create it
+                // The 19 comes from, 10 from the tw-py-5 + 9 from button height tw-h-9
+                'tw-min-h-[4.75rem]',
             ])}
         >
             {buttons.map((button, index) => (

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -117,6 +117,7 @@ export const Trigger: FC<TriggerProps> = ({
                     {...buttonProps}
                     aria-hidden="true"
                     type="button"
+                    disabled={disabled}
                     className={merge([
                         'tw-rounded',
                         disabled


### PR DESCRIPTION
The `Flyout` component is using the `buttonProps` returned by the `react-aria` `useButton` hook on a div. So even with the `Trigger` being disabled, that div on the `Flyout` was triggering the `toggle` function to open it.
A new optional prop `isTriggerDisabled` was added to the component and the `ColorPickerFlyout` `disabled` prop is being passed down to all the child components.