### PR TITLE
chore: updated vite with lib name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
     plugins: [dts({ insertTypesEntry: true })],
     build: {
         lib: {
+            name: 'Fondue',
             entry: resolve(__dirname, 'src/index.ts'),
             fileName: (format: string) => `[name].${format}.js`,
         },


### PR DESCRIPTION
Vite needs lib name to build the library