### PR TITLE
fix(RichTextEditor): fix code markup element in html rendering

### DIFF
--- a/src/components/RichTextEditor/Plugins/CodePlugin/CodeMarkupElement.tsx
+++ b/src/components/RichTextEditor/Plugins/CodePlugin/CodeMarkupElement.tsx
@@ -5,7 +5,7 @@ import { MARK_CODE, PlateRenderLeafProps } from '@udecode/plate';
 import { MarkupElement } from '../MarkupElement';
 
 export const CODE_CLASSES =
-    'tw-table-cell tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]';
+    'tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]';
 
 export const CodeMarkupElementNode = ({ attributes, children }: PlateRenderLeafProps) => (
     <span {...attributes} className={CODE_CLASSES}>

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -316,7 +316,7 @@ describe('RichTextEditor Component', () => {
             cy.get(TOOLBAR_GROUP_1).children().eq(6).click();
             cy.get('[contenteditable=true]').should(
                 'include.html',
-                'tw-table-cell tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
+                'tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
             );
         });
 
@@ -788,13 +788,13 @@ describe('RichTextEditor Component', () => {
             cy.get(TOOLBAR_GROUP_1).children().eq(6).click();
             cy.get('[contenteditable=true]').should(
                 'include.html',
-                'tw-table-cell tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
+                'tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
             );
 
             cy.get(TOOLBAR_GROUP_2).children().last().click();
             cy.get('[contenteditable=true]').should(
                 'not.include.html',
-                'tw-table-cell tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
+                'tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
             );
         });
 
@@ -810,7 +810,7 @@ describe('RichTextEditor Component', () => {
             cy.get(TOOLBAR_GROUP_1).children().eq(6).click();
             cy.get('[contenteditable=true]').should(
                 'include.html',
-                'tw-table-cell tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
+                'tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
             );
             cy.get('[contenteditable=true]').should('include.html', 'tw-font-bold');
             cy.get('[contenteditable=true]').should('include.html', 'tw-italic');
@@ -820,7 +820,7 @@ describe('RichTextEditor Component', () => {
             cy.get(TOOLBAR_GROUP_2).children().last().click();
             cy.get('[contenteditable=true]').should(
                 'not.include.html',
-                'tw-table-cell tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
+                'tw-rounded tw-bg-box-neutral tw-text-box-neutral-inverse tw-m-0 tw-px-[0.2em] tw-font-mono tw-text-[85%]',
             );
             cy.get('[contenteditable=true]').should('not.include.html', 'tw-font-bold');
             cy.get('[contenteditable=true]').should('not.include.html', 'tw-italic');

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
@@ -76,55 +76,66 @@ export const serializeNodeToHtmlRecursive = (
 
     const hasColumnBreak = node.breakAfterColumn === 'active';
     const columnBreakClasses = hasColumnBreak ? 'tw-break-after-column tw-break-inside-avoid-column' : '';
+    const breakWordsClass = 'tw-break-words';
 
     switch (node.type) {
         case TextStyles.ELEMENT_HEADING1:
-            return `<h1 class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<h1 class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.heading1,
             )}">${children}</h1>`;
         case TextStyles.ELEMENT_HEADING2:
-            return `<h2 class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<h2 class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.heading2,
             )}">${children}</h2>`;
         case TextStyles.ELEMENT_HEADING3:
-            return `<h3 class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<h3 class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.heading3,
             )}">${children}</h3>`;
         case TextStyles.ELEMENT_HEADING4:
-            return `<h4 class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<h4 class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.heading4,
             )}">${children}</h4>`;
         case TextStyles.ELEMENT_CUSTOM1:
-            return `<p class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<p class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.custom1,
             )}">${children}</p>`;
         case TextStyles.ELEMENT_CUSTOM2:
-            return `<p class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<p class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.custom2,
             )}">${children}</p>`;
         case TextStyles.ELEMENT_CUSTOM3:
-            return `<p class="${columnBreakClasses}" style="${reactCssPropsToCss(
+            return `<p class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
                 designTokens.custom3,
             )}">${children}</p>`;
         case TextStyles.ELEMENT_QUOTE:
-            return `<p class="${columnBreakClasses}" style="${reactCssPropsToCss(designTokens.quote)}">${children}</p>`;
+            return `<p class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
+                designTokens.quote,
+            )}">${children}</p>`;
         case ELEMENT_PARAGRAPH:
-            return `<p class="${columnBreakClasses}" style="${reactCssPropsToCss(designTokens.p)}">${children}</p>`;
+            return `<p class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
+                designTokens.p,
+            )}">${children}</p>`;
         case ELEMENT_UL:
-            return `<ul class="${UL_CLASSES} ${columnBreakClasses}">${children}</ul>`;
+            return `<ul class="${UL_CLASSES} ${columnBreakClasses} ${breakWordsClass}">${children}</ul>`;
         case ELEMENT_OL:
             const nestingLevel = Math.max(rootNestingCount - countNodesOfType([node], ELEMENT_OL), 0);
-            return `<ol class="${getOrderedListClasses(nestingLevel)} ${columnBreakClasses}">${children}</ol>`;
+            return `<ol class="${getOrderedListClasses(
+                nestingLevel,
+            )} ${columnBreakClasses} ${breakWordsClass}">${children}</ol>`;
         case ELEMENT_LI:
             const liElement = node as TElement;
             const styledLicElement = (liElement.children[0]?.children as TDescendant[])?.[0];
             const liStyles = { ...designTokens[getTextStyle(styledLicElement)], textDecoration: 'none' };
 
-            return `<li class="${columnBreakClasses}" style="${reactCssPropsToCss(liStyles)}">${children}</li>`;
+            return `<li class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
+                liStyles,
+            )}">${children}</li>`;
         case ELEMENT_LIC:
             const licElement = node as TElement;
             const licStyles = { textDecoration: designTokens[getTextStyle(licElement.children[0])]?.textDecoration };
-            return `<p class="${columnBreakClasses}" style="${reactCssPropsToCss(licStyles)}">${children}</p>`;
+            return `<p class="${columnBreakClasses} ${breakWordsClass}" style="${reactCssPropsToCss(
+                licStyles,
+            )}">${children}</p>`;
         case ELEMENT_LINK:
             return linkNode(node, children, designTokens, columnBreakClasses);
         case ELEMENT_BUTTON:


### PR DESCRIPTION
When rendering a text like 
```{
        type: ELEMENT_PARAGRAPH,
        children: [{ text: 'This text is a code', code: true }, { text: ' line' }, { text: '.', code: true }],
    },
```

the serialized html was rendered on three lines instead of just one.

![image](https://user-images.githubusercontent.com/42832501/221506007-80890b57-c4c7-4cbf-ad5e-71d44fd9d284.png)
