### PR TITLE
fix(RichTextEditor): serialize checked checklist and link correct to html

### DIFF
--- a/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
+++ b/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
@@ -199,11 +199,13 @@ export const defaultValue = [
     {
         type: ELEMENT_PARAGRAPH,
         children: [
+            { text: '' },
             {
                 type: ELEMENT_LINK,
-                children: [{ text: 'This is a Link.' }],
+                children: [{ text: 'This is a Link. Without any breaks before or after' }],
                 url: 'https://frontify.com',
             },
+            { text: '' },
         ],
     },
     {
@@ -319,6 +321,15 @@ export const alignedValues = [
         children: [{ text: 'This text is justified.' }],
         align: 'justify',
     },
+
+    {
+        type: 'p',
+        children: [
+            { text: '' },
+            { type: 'a', url: 'https://frontify.com/', target: '_blank', children: [{ text: 'This is a Link.' }] },
+            { text: '' },
+        ],
+    },
 ];
 
 export const htmlValue = `
@@ -412,8 +423,9 @@ export const checkboxValue = [
         type: ELEMENT_CHECK_ITEM,
         checked: true,
         indent: 2,
-        children: [{ text: "And I'm checked!" }],
+        children: [{ text: "And I'm checked! Followed by an empty one!" }],
     },
+    { type: ELEMENT_CHECK_ITEM, children: [{ text: '' }] },
 ];
 
 export const buttonValues = [

--- a/src/components/RichTextEditor/serializer/nodes/checkItem.ts
+++ b/src/components/RichTextEditor/serializer/nodes/checkItem.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { TElement } from '@udecode/plate-core';
-import { merge } from 'lodash-es';
+import { merge } from '@utilities/merge';
 
 export const checkItemNode = (
     node: TElement,
@@ -19,6 +19,6 @@ export const checkItemNode = (
     </div>
     <span class="${merge([
         'tw-flex-1 tw-focus:outline-none',
-        (node.checked as boolean) && 'tw-line-through',
+        node.checked ? 'tw-line-through' : '',
     ])}">${children}</span>
 </div>`;

--- a/src/components/RichTextEditor/serializer/serializeToHtml.spec.ts
+++ b/src/components/RichTextEditor/serializer/serializeToHtml.spec.ts
@@ -33,4 +33,16 @@ describe('serializeNodesToHtml()', () => {
         const serialized = serializeNodesToHtml(nodesToSerialize, { columns: 2 });
         expect(serialized).to.contain('column-gap:normal');
     });
+
+    it('serializes an empty line to a linebreak', () => {
+        const node = [
+            {
+                type: 'p',
+                children: [{ text: '' }],
+            },
+        ];
+
+        const result = serializeNodesToHtml(node);
+        expect(result).to.equal('<br />');
+    });
 });

--- a/src/components/RichTextEditor/serializer/serializeToHtml.ts
+++ b/src/components/RichTextEditor/serializer/serializeToHtml.ts
@@ -40,7 +40,7 @@ export const serializeNodesToHtml = (
 
     const html = nodes
         .map((node) => {
-            if (isBreakNode(node)) {
+            if (isEmptyNode(node)) {
                 return '<br />';
             }
             return serializeNodeToHtmlRecursive(node, {
@@ -57,10 +57,9 @@ export const serializeNodesToHtml = (
     return html;
 };
 
-const isBreakNode = (node: TDescendant): boolean => {
+const isEmptyNode = (node: TDescendant): boolean => {
     if (!Array.isArray(node?.children)) {
         return false;
     }
-    const isChecklistElement = node?.type === 'checkbox-item';
-    return node.children?.length === 1 && node.children[0].text === '' && !isChecklistElement;
+    return node?.children?.every((child) => child.text === '');
 };

--- a/src/components/RichTextEditor/serializer/serializeToHtml.ts
+++ b/src/components/RichTextEditor/serializer/serializeToHtml.ts
@@ -39,12 +39,15 @@ export const serializeNodesToHtml = (
     const mappedMentionable = mentionable ? mapMentionable(mentionable) : new Map();
 
     const html = nodes
-        .map((node) =>
-            serializeNodeToHtmlRecursive(node, {
+        .map((node) => {
+            if (isBreakNode(node)) {
+                return '<br />';
+            }
+            return serializeNodeToHtmlRecursive(node, {
                 designTokens: mergedDesignTokens,
                 mappedMentionable,
-            }),
-        )
+            });
+        })
         .join('');
 
     if (columns > 1) {
@@ -52,4 +55,12 @@ export const serializeNodesToHtml = (
     }
 
     return html;
+};
+
+const isBreakNode = (node: TDescendant): boolean => {
+    if (!Array.isArray(node?.children)) {
+        return false;
+    }
+    const isChecklistElement = node?.type === 'checkbox-item';
+    return node.children?.length === 1 && node.children[0].text === '' && !isChecklistElement;
 };

--- a/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.spec.ts
@@ -62,13 +62,4 @@ describe('serializeLeafToHtml()', () => {
         const result = serializeLeafToHtml(node);
         expect(result).to.equal('text');
     });
-
-    it('serializes an empty leaf to a linebreak', () => {
-        const node = {
-            text: '',
-        };
-
-        const result = serializeLeafToHtml(node);
-        expect(result).to.equal('<br />');
-    });
 });

--- a/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeLeafToHtml.ts
@@ -28,5 +28,5 @@ export const serializeLeafToHtml = (node: TText): string => {
     if (node.code) {
         string = `<span class="${CODE_CLASSES}">${string}</span>`;
     }
-    return string.trim().length === 0 ? '<br />' : string;
+    return string;
 };


### PR DESCRIPTION
[Ticket: checklist points](https://app.clickup.com/t/8677a1v57)

When saving a text to link it is saved as following:

```
    {
        type: ELEMENT_PARAGRAPH,
        children: [
            { text: '' },
            {
                type: ELEMENT_LINK,
                children: [{ text: 'This is a Link. Without any breaks before or after' }],
                url: 'https://frontify.com',
            },
            { text: '' },
        ],
    },
```

this caused the element to have a line break before and after the link in view mode.