### PR TITLE
refactor: use optimized path

### DIFF
--- a/scripts/generateIconEnum.ts
+++ b/scripts/generateIconEnum.ts
@@ -7,7 +7,7 @@ const ICON_ENUM_OUTPUT_PATH = './src/foundation/Icon/IconEnum.ts';
 
 (async () => {
     const iconFilePath = await fastGlob('./src/foundation/Icon/Generated/*.tsx', { objectMode: true });
-    const iconNames = iconFilePath.map((path) => path.name.replace(/^Icon|\.tsx$/g, ''));
+    const iconNames = iconFilePath.map((path) => path.name.replace(/(^Icon)|(\.tsx$)/g, ''));
 
     const iconsEnumString = `
         export enum IconEnum {

--- a/scripts/generateIconEnum.ts
+++ b/scripts/generateIconEnum.ts
@@ -7,7 +7,7 @@ const ICON_ENUM_OUTPUT_PATH = './src/foundation/Icon/IconEnum.ts';
 
 (async () => {
     const iconFilePath = await fastGlob('./src/foundation/Icon/Generated/*.tsx', { objectMode: true });
-    const iconNames = iconFilePath.map((path) => path.name.replace('Icon', '').replace('.tsx', ''));
+    const iconNames = iconFilePath.map((path) => path.name.replace(/^Icon|\.tsx$/g, ''));
 
     const iconsEnumString = `
         export enum IconEnum {

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -12,7 +12,12 @@ import { LinkChooser } from '@components/LinkChooser/LinkChooser.stories';
 import { Slider } from '@components/Slider/Slider';
 import { Switch, SwitchSize } from '@components/Switch/Switch';
 import { TextInput, TextInputType } from '@components/TextInput/TextInput';
-import { IconIcon, IconTextAlignmentLeft, IconTextAlignmentRight } from '@foundation/Icon/Generated';
+import {
+    IconIcon,
+    IconTextAlignmentCentre,
+    IconTextAlignmentLeft,
+    IconTextAlignmentRight,
+} from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
@@ -23,7 +28,6 @@ import { EXAMPLE_IMAGES } from '../AssetInput/example-assets';
 import { Accordion as AccordionComponent, AccordionItem } from './Accordion';
 import { AccordionHeaderIcon } from './AccordionHeaderIcon';
 import { AccordionHeaderIconSize, AccordionHeaderProps, AccordionProps } from './types';
-import { IconTextAlignmentCentre } from '@foundation/Icon/Generated';
 import { Stack } from '@layout/Stack';
 
 export default {

--- a/src/components/Accordion/AccordionHeader.cy.tsx
+++ b/src/components/Accordion/AccordionHeader.cy.tsx
@@ -9,7 +9,7 @@ import {
     FieldsetHeaderType,
 } from '@components/FieldsetHeader';
 import { SWITCH_ID } from '../Switch/Switch';
-import { IconIcon12 } from '@foundation/Icon';
+import { IconIcon12 } from '@foundation/Icon/Generated';
 
 const FIELDSET_HEADER_ID = '[data-test-id="fieldset-header"]';
 const ACCORDION_HEADER_TEXT_ID = '[data-test-id="accordion-header-text"]';

--- a/src/components/Accordion/AccordionHeader.stories.tsx
+++ b/src/components/Accordion/AccordionHeader.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import { AccordionHeader as AccordionHeaderComponent } from './AccordionHeader';
 import { AccordionHeaderProps } from './types';
-import { IconExclamationMarkTriangle, IconHome, IconIcon } from '@foundation/Icon';
+import { IconExclamationMarkTriangle, IconHome, IconIcon } from '@foundation/Icon/Generated';
 
 const decorators = {
     IconNone: null,

--- a/src/components/Accordion/AccordionHeader.tsx
+++ b/src/components/Accordion/AccordionHeader.tsx
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React, { FC, ReactElement, cloneElement, isValidElement } from 'react';
-import { IconProps, IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
+import { IconProps } from '@foundation/Icon/IconProps';
 import { merge } from '@utilities/merge';
 import { AccordionHeaderIconSize, AccordionHeaderProps } from './types';
 import { AccordionHeaderIcon } from './AccordionHeaderIcon';

--- a/src/components/AssetInput/AssetThumbnail.tsx
+++ b/src/components/AssetInput/AssetThumbnail.tsx
@@ -5,7 +5,7 @@ import { merge } from '@utilities/merge';
 import React, { FC, cloneElement } from 'react';
 import { AssetInputProps, AssetInputSize } from './AssetInput';
 import { SelectedAssetProps } from './SingleAsset/SelectedAsset';
-import { IconMusicNote } from '@foundation/Icon';
+import { IconMusicNote } from '@foundation/Icon/Generated';
 
 type AssetThumbnailProps = {
     asset: SelectedAssetProps['asset'];

--- a/src/components/AssetInput/MultiAssetPreview/MultiAssetPreview.tsx
+++ b/src/components/AssetInput/MultiAssetPreview/MultiAssetPreview.tsx
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconCaretRight, IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
+import { IconCaretRight } from '@foundation/Icon/Generated';
 import { useButton } from '@react-aria/button';
 import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';

--- a/src/components/AssetInput/SingleAsset/AssetSubline.tsx
+++ b/src/components/AssetInput/SingleAsset/AssetSubline.tsx
@@ -3,7 +3,7 @@
 import React, { FC } from 'react';
 import { AssetInputProps } from '../AssetInput';
 import { SelectedAssetProps } from './SelectedAsset';
-import { IconArrowCircleUp, IconImageStack } from '@foundation/Icon';
+import { IconArrowCircleUp, IconImageStack } from '@foundation/Icon/Generated';
 
 type AssetSublineProps = Pick<AssetInputProps, 'isLoading' | 'hideSize' | 'hideExtension'> &
     Pick<SelectedAssetProps, 'asset'>;

--- a/src/components/AssetInput/asset-input-actions.tsx
+++ b/src/components/AssetInput/asset-input-actions.tsx
@@ -2,7 +2,13 @@
 
 import React from 'react';
 import { ActionMenuBlock, MenuItemStyle } from '..';
-import { IconArrowCircleUp, IconArrowOutExternal, IconCrop, IconCross, IconImageStack } from '@foundation/Icon';
+import {
+    IconArrowCircleUp,
+    IconArrowOutExternal,
+    IconCrop,
+    IconCross,
+    IconImageStack,
+} from '@foundation/Icon/Generated';
 
 export const assetInputActions = [
     {

--- a/src/components/AssetInput/example-assets.tsx
+++ b/src/components/AssetInput/example-assets.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 import React from 'react';
 import { AssetType } from './AssetInput';
 

--- a/src/components/Badge/Badge.cy.tsx
+++ b/src/components/Badge/Badge.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconDocumentText } from '@foundation/Icon';
+import { IconDocumentText } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import React from 'react';
 import { BadgeStyle } from '.';

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,8 +3,9 @@
 import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import { Button, ButtonProps } from './Button';
-import { IconAnchor16, IconColorFan16, IconDotsVertical16, IconEnum, IconIcon16 } from '@foundation/Icon';
+import { IconAnchor16, IconColorFan16, IconDotsVertical16, IconIcon16 } from '@foundation/Icon/Generated';
 import { ButtonEmphasis, ButtonRounding, ButtonSize, ButtonStyle, ButtonType } from './ButtonTypes';
+import { IconEnum } from '@foundation/Icon/IconEnum';
 
 const defaultArgs = {
     type: ButtonType.Button,

--- a/src/components/Button/mappings.ts
+++ b/src/components/Button/mappings.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
 import { ButtonSize, ButtonType } from '@components/Button/ButtonTypes';
 
 export const buttonIconSizeMap: Record<ButtonSize, IconSize> = {

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -7,7 +7,7 @@ import { FormControl } from '@components/FormControl';
 import { Slider } from '@components/Slider';
 import { Validation } from '@utilities/validation';
 import { intlFormat, subDays } from 'date-fns';
-import { IconCalendar16 } from '@foundation/Icon';
+import { IconCalendar16 } from '@foundation/Icon/Generated';
 import { Badge, BadgeEmphasis, BadgeStyle } from '..';
 
 export default {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -7,7 +7,7 @@ import React, { FC, useState } from 'react';
 import DatepickerComponent from 'react-datepicker';
 import './DatePicker.css';
 import { DatePickerTrigger } from './DatePickerTrigger';
-import { IconCaretLeft, IconCaretLeftDouble, IconCaretRight, IconCaretRightDouble } from '@foundation/Icon';
+import { IconCaretLeft, IconCaretLeftDouble, IconCaretRight, IconCaretRightDouble } from '@foundation/Icon/Generated';
 import { Validation } from '@utilities/validation';
 
 type SingleDatePickerProps = {

--- a/src/components/Dropdown/Dropdown.cy.tsx
+++ b/src/components/Dropdown/Dropdown.cy.tsx
@@ -2,7 +2,7 @@
 
 import { MenuBlock } from '@components/Dropdown/SelectMenu/SelectMenu';
 import { MenuItemContentSize } from '@components/MenuItem';
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { Validation } from '@utilities/validation';
 import React, { FC, ReactElement, useState } from 'react';

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@
 
 import { MenuItemContentSize, MenuItemStyle } from '@components/MenuItem';
 import { TriggerEmphasis } from '@components/Trigger';
-import { IconMusicNote } from '@foundation/Icon';
+import { IconMusicNote } from '@foundation/Icon/Generated';
 import { Meta, StoryFn } from '@storybook/react';
 import { Validation } from '@utilities/validation';
 import React, { useEffect, useState } from 'react';

--- a/src/components/EditableText/EditableText.stories.tsx
+++ b/src/components/EditableText/EditableText.stories.tsx
@@ -3,7 +3,8 @@
 import React, { useState } from 'react';
 import { EditableMode, EditableText, EditableTextProps } from '@components/EditableText/EditableText';
 import { StoryFn } from '@storybook/react';
-import { IconPen, IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
+import { IconPen } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Editable Text',

--- a/src/components/EditableText/lib/helper.cy.tsx
+++ b/src/components/EditableText/lib/helper.cy.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { EditableTextHelper } from '@components/EditableText/lib/helper';
-import { IconPen } from '@foundation/Icon';
+import { IconPen } from '@foundation/Icon/Generated';
 
 describe('Test Children Nesting', () => {
     it('Output correct Text insdie div', () => {

--- a/src/components/FieldsetHeader/FieldsetHeader.stories.tsx
+++ b/src/components/FieldsetHeader/FieldsetHeader.stories.tsx
@@ -8,7 +8,7 @@ import {
     FieldsetHeaderSize,
     FieldsetHeaderType,
 } from './FieldsetHeader';
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Fieldset Header',

--- a/src/components/FieldsetHeader/FieldsetHeader.tsx
+++ b/src/components/FieldsetHeader/FieldsetHeader.tsx
@@ -4,8 +4,9 @@ import { Switch, SwitchSize } from '@components/Switch/Switch';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { merge } from '@utilities/merge';
 import React, { FC, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
-import { IconCaretDown, IconMinus, IconPlus, IconProps, IconSize } from '@foundation/Icon/Generated';
+import { IconCaretDown, IconMinus, IconPlus } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
+import { IconProps } from '@foundation/Icon';
 
 export const ACCORDION_ICON_CONTAINER_ID = 'accordion-icon-container';
 

--- a/src/components/FieldsetHeader/FieldsetHeader.tsx
+++ b/src/components/FieldsetHeader/FieldsetHeader.tsx
@@ -4,7 +4,8 @@ import { Switch, SwitchSize } from '@components/Switch/Switch';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { merge } from '@utilities/merge';
 import React, { FC, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
-import { IconCaretDown, IconMinus, IconPlus, IconProps, IconSize } from '@foundation/Icon';
+import { IconCaretDown, IconMinus, IconPlus, IconProps, IconSize } from '@foundation/Icon/Generated';
+import { IconSize } from '@foundation/Icon/IconSize';
 
 export const ACCORDION_ICON_CONTAINER_ID = 'accordion-icon-container';
 

--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -18,7 +18,7 @@ import { FlyoutFooter } from './FlyoutFooter';
 import { Dropdown } from '@components/Dropdown';
 import { DatePicker } from '@components/DatePicker';
 import { TooltipIcon } from '@components/TooltipIcon';
-import { IconDotsVertical, IconExclamationMarkCircle, IconIcon } from '@foundation/Icon';
+import { IconDotsVertical, IconExclamationMarkCircle, IconIcon } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Flyout',

--- a/src/components/Flyout/FlyoutFooter.tsx
+++ b/src/components/Flyout/FlyoutFooter.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Button, ButtonEmphasis, ButtonProps, ButtonSize, ButtonStyle } from '@components/Button';
-import { IconCheckMark } from '@foundation/Icon';
+import { IconCheckMark } from '@foundation/Icon/Generated';
 import { merge } from '@utilities/merge';
 import React, { FC, PropsWithChildren } from 'react';
 

--- a/src/components/LinkChooser/NavigationMenu.tsx
+++ b/src/components/LinkChooser/NavigationMenu.tsx
@@ -2,7 +2,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { MenuItem, MenuItemContentSize, SelectionIndicatorIcon } from '@components/MenuItem';
-import { IconArrowLeft } from '@foundation/Icon';
+import { IconArrowLeft } from '@foundation/Icon/Generated';
 import { getInteractionModality } from '@react-aria/interactions';
 import { useOption } from '@react-aria/listbox';
 import { merge } from '@utilities/merge';

--- a/src/components/LinkChooser/SearchInput.tsx
+++ b/src/components/LinkChooser/SearchInput.tsx
@@ -12,7 +12,7 @@ import { merge } from '@utilities/merge';
 import { useActor } from '@xstate/react';
 import React, { FC, MouseEvent, forwardRef } from 'react';
 import { IconButtonProps, SearchInputProps } from './types';
-import { IconArrowOutExternal, IconClipboard, IconCross } from '@foundation/Icon';
+import { IconArrowOutExternal, IconClipboard, IconCross } from '@foundation/Icon/Generated';
 
 export const SearchInput = forwardRef<HTMLInputElement | null, SearchInputProps>(
     (

--- a/src/components/MenuItem/MenuItem.cy.tsx
+++ b/src/components/MenuItem/MenuItem.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconMusicNote } from '@foundation/Icon';
+import { IconMusicNote } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import React from 'react';
 import { MenuItem, MenuItemContentSize, MenuItemProps, SelectionIndicatorIcon } from '@components/MenuItem';

--- a/src/components/MenuItem/MenuItem.stories.tsx
+++ b/src/components/MenuItem/MenuItem.stories.tsx
@@ -10,7 +10,7 @@ import {
     SelectionIndicatorIcon,
 } from '@components/MenuItem';
 import { Switch, SwitchSize } from '@components/Switch';
-import { IconMusicNote } from '@foundation/Icon';
+import { IconMusicNote } from '@foundation/Icon/Generated';
 
 const SwitchComponent = () => {
     const [switchValue, setSwitchValue] = useState<boolean>(false);

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -3,7 +3,7 @@
 import React, { MouseEvent, PropsWithChildren, useEffect, useState } from 'react';
 import { merge } from '@utilities/merge';
 import { IconCaretRight, IconCheckMark } from '@foundation/Icon/Generated';
-import {  IconSize } from '@foundation/Icon/IconSize';
+import { IconSize } from '@foundation/Icon/IconSize';
 import { MenuItemContent, MenuItemContentProps } from '@components/MenuItem/MenuItemContent';
 import { MenuItemContentSize, MenuItemStyle, SelectionIndicatorIcon } from './types';
 import { getItemElementType } from '@utilities/elements';

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -2,7 +2,8 @@
 
 import React, { MouseEvent, PropsWithChildren, useEffect, useState } from 'react';
 import { merge } from '@utilities/merge';
-import { IconCaretRight, IconCheckMark, IconSize } from '@foundation/Icon';
+import { IconCaretRight, IconCheckMark } from '@foundation/Icon/Generated';
+import {  IconSize } from '@foundation/Icon/IconSize';
 import { MenuItemContent, MenuItemContentProps } from '@components/MenuItem/MenuItemContent';
 import { MenuItemContentSize, MenuItemStyle, SelectionIndicatorIcon } from './types';
 import { getItemElementType } from '@utilities/elements';

--- a/src/components/Modal/Modal.cy.tsx
+++ b/src/components/Modal/Modal.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 import { PatternDesign, PatternTheme } from '@foundation/Pattern';
 import { OverlayProvider } from '@react-aria/overlays';
 import React from 'react';

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 import { generateRandomId } from '@utilities/generateRandomId';
 import { useOverlayTriggerState } from '@react-stately/overlays';
 import { PatternDesign, PatternTheme } from '@foundation/Pattern';
-import { IconCap, IconIcon, IconMusicNote } from '@foundation/Icon';
+import { IconCap, IconIcon, IconMusicNote } from '@foundation/Icon/Generated';
 import { ScrollWrapperDirection } from '@components/ScrollWrapper/types';
 import { OverlayContainer, OverlayProvider } from '@react-aria/overlays';
 import {

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -3,7 +3,7 @@
 import React, { FC, cloneElement, useContext } from 'react';
 import { merge } from '@utilities/merge';
 import { ModalHeaderProps, ModalHeaderVariant, modalHeaderVariants } from './types';
-import { IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
 import { ModalTitle } from './context/ModalTitle';
 import { ModalLayout } from './context/ModalLayout';
 

--- a/src/components/MultiInput/MultiInput.stories.tsx
+++ b/src/components/MultiInput/MultiInput.stories.tsx
@@ -7,7 +7,7 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 import { MultiInput as MultiInputComponent, MultiInputLayout, MultiInputProps } from './MultiInput';
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Multi Input',

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -11,7 +11,7 @@ import {
     MultiSelectSize,
     MultiSelectType,
 } from './MultiSelect';
-import { IconNook16, IconPerson16 } from '@foundation/Icon';
+import { IconNook16, IconPerson16 } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Multi Select',

--- a/src/components/MultiSelect/SelectMenuItems/SelectMenuItems.tsx
+++ b/src/components/MultiSelect/SelectMenuItems/SelectMenuItems.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Text } from '@typography/Text';
-import { IconCheckMark16 } from '@foundation/Icon';
+import { IconCheckMark16 } from '@foundation/Icon/Generated';
 import { Item } from '../MultiSelect';
 
 export const DividerItem = () => {

--- a/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/src/components/OverflowMenu/OverflowMenu.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React, { MouseEvent, useRef, useState } from 'react';
-import { IconDotsHorizontal } from '@foundation/Icon';
+import { IconDotsHorizontal } from '@foundation/Icon/Generated';
 import { merge } from '@utilities/merge';
 import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { Menu } from '@components/Menu';

--- a/src/components/RadioPill/RadioPill.cy.tsx
+++ b/src/components/RadioPill/RadioPill.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 import React from 'react';
 import { RadioPill } from './RadioPill';
 

--- a/src/components/RadioPill/RadioPill.stories.tsx
+++ b/src/components/RadioPill/RadioPill.stories.tsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { RadioPill as RadioPillComponent, RadioPillProps } from './RadioPill';
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Radio Pill',

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignCenterPlugin/AlignCenterButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignCenterPlugin/AlignCenterButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextAlignmentCentre } from '@foundation/Icon';
+import { IconTextAlignmentCentre16 } from '@foundation/Icon/Generated';
 import { AlignToolbarButton } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
@@ -12,7 +12,7 @@ export const AlignCenterButton = ({ id }: PluginButtonProps) => (
         <AlignToolbarButton
             tooltip={getTooltip('Align center')}
             value="center"
-            icon={<IconStylingWrapper icon={<IconTextAlignmentCentre size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextAlignmentCentre16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignJustifyPlugin/AlignJustifyButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignJustifyPlugin/AlignJustifyButton.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { AlignToolbarButton } from '@udecode/plate';
-import { IconSize, IconTextAlignmentJustify } from '@foundation/Icon';
+import { IconTextAlignmentJustify16 } from '@foundation/Icon/Generated';
 import { PluginButtonProps } from '../../types';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
@@ -12,7 +12,7 @@ export const AlignJustifyButton = ({ id }: PluginButtonProps) => (
         <AlignToolbarButton
             tooltip={getTooltip('Justify')}
             value="justify"
-            icon={<IconStylingWrapper icon={<IconTextAlignmentJustify size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextAlignmentJustify16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignLeftPlugin/AlignLeftButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignLeftPlugin/AlignLeftButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextAlignmentLeft } from '@foundation/Icon';
+import { IconTextAlignmentLeft16 } from '@foundation/Icon/Generated';
 import { AlignToolbarButton } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
@@ -12,7 +12,7 @@ export const AlignLeftButton = ({ id }: PluginButtonProps) => (
         <AlignToolbarButton
             tooltip={getTooltip('Align left')}
             value="left"
-            icon={<IconStylingWrapper icon={<IconTextAlignmentLeft size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextAlignmentLeft16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignRightPlugin/AlignRightButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignRightPlugin/AlignRightButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextAlignmentRight } from '@foundation/Icon';
+import { IconTextAlignmentRight16 } from '@foundation/Icon/Generated';
 import { AlignToolbarButton } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
@@ -12,7 +12,7 @@ export const AlignRightButton = ({ id }: PluginButtonProps) => (
         <AlignToolbarButton
             tooltip={getTooltip('Align right')}
             value="right"
-            icon={<IconStylingWrapper icon={<IconTextAlignmentRight size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextAlignmentRight16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/BoldPlugin/BoldButton.tsx
+++ b/src/components/RichTextEditor/Plugins/BoldPlugin/BoldButton.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
-import { IconSize, IconTextFormatBold } from '@foundation/Icon';
+import { IconTextFormatBold16 } from '@foundation/Icon/Generated';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
 import { PluginButtonProps } from '../types';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
@@ -14,7 +14,7 @@ export const BoldButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip(`Bold\n${getHotkeyByPlatform('Ctrl+B')}`)}
             key={id}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconTextFormatBold size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextFormatBold16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonButton.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { getPluginType } from '@udecode/plate';
-import { IconButton, IconSize } from '@foundation/Icon';
+import { IconButton16 } from '@foundation/Icon/Generated';
 import { PluginButtonProps } from '../../types';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
 import { ButtonToolbarButton } from './ButtonToolbarButton';
@@ -12,7 +12,7 @@ export const ButtonButton = ({ editor, id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <ButtonToolbarButton
             type={getPluginType(editor, ELEMENT_BUTTON)}
-            icon={<IconStylingWrapper icon={<IconButton size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconButton16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
         />

--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/components/FloatingButton/EditButtonModal/EditModal.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/components/FloatingButton/EditButtonModal/EditModal.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React from 'react';
-import { IconPen, IconTrashBin } from '@foundation/Icon';
+import { IconPen16, IconTrashBin16 } from '@foundation/Icon/Generated';
 import { FloatingButton } from '../FloatingButton';
 import { useFloatingButtonUrlInput } from '../FloatingButtonUrlInput';
 import { useRichTextEditorContext } from '@components/RichTextEditor/context/RichTextEditorContext';
@@ -24,7 +24,7 @@ export const EditModal = () => {
                         className="tw-transition tw-cursor-pointer tw-rounded hover:tw-bg-black-10 tw-p-1"
                     >
                         <FloatingButton.EditButton>
-                            <IconPen />
+                            <IconPen16 />
                         </FloatingButton.EditButton>
                     </span>
 
@@ -35,7 +35,7 @@ export const EditModal = () => {
                         className="tw-transition tw-cursor-pointer tw-rounded hover:tw-bg-black-10 tw-p-1"
                     >
                         <FloatingButton.UnlinkButton>
-                            <IconTrashBin />
+                            <IconTrashBin16 />
                         </FloatingButton.UnlinkButton>
                     </span>
                 </span>

--- a/src/components/RichTextEditor/Plugins/CheckboxListPlugin/CheckboxListButton/index.tsx
+++ b/src/components/RichTextEditor/Plugins/CheckboxListPlugin/CheckboxListButton/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { getPluginType } from '@udecode/plate';
-import { IconListCheck, IconSize } from '@foundation/Icon';
+import { IconListCheck16 } from '@foundation/Icon/Generated';
 import { CheckboxListToolbarButton } from './CheckboxListToolbarButton';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
 import { PluginButtonProps } from '../../types';
@@ -11,7 +11,7 @@ export const CheckboxListButton = ({ editor, id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <CheckboxListToolbarButton
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconListCheck size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconListCheck16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
         />

--- a/src/components/RichTextEditor/Plugins/CodePlugin/CodeButton.tsx
+++ b/src/components/RichTextEditor/Plugins/CodePlugin/CodeButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextBrackets } from '@foundation/Icon';
+import { IconTextBrackets16 } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
@@ -12,7 +12,7 @@ export const CodeButton = ({ editor, id }: PluginButtonProps) => (
         <MarkToolbarButton
             tooltip={getTooltip('Code')}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconTextBrackets size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextBrackets16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/ColumnBreakButton/index.tsx
+++ b/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/ColumnBreakButton/index.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React from 'react';
-import { IconSize, IconTextColumnBreak } from '@foundation/Icon';
+import { IconTextColumnBreak16 } from '@foundation/Icon/Generated';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
 import { PluginButtonProps } from '../../types';
 import { ColumnBreakToolbarButton } from './ColumnBreakToolbarButton';
@@ -10,7 +10,7 @@ export const ColumnBreakButton = ({ id }: PluginButtonProps) => {
     return (
         <ButtonWrapper id={id}>
             <ColumnBreakToolbarButton
-                icon={<IconStylingWrapper icon={<IconTextColumnBreak size={IconSize.Size16} />} />}
+                icon={<IconStylingWrapper icon={<IconTextColumnBreak16 />} />}
                 classNames={buttonClassNames}
                 styles={buttonStyles}
             />

--- a/src/components/RichTextEditor/Plugins/EmojiPlugin/EmojiButton.tsx
+++ b/src/components/RichTextEditor/Plugins/EmojiPlugin/EmojiButton.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { EmojiToolbarDropdown, KEY_EMOJI } from '@udecode/plate';
-import { IconFaceHappy, IconSize } from '@foundation/Icon';
+import { IconFaceHappy16 } from '@foundation/Icon/Generated';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
 import { PluginButtonProps } from '../types';
 import { EmojiPicker } from './EmojiPicker';
@@ -11,7 +11,7 @@ export const EmojiButton = ({ id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <EmojiToolbarDropdown
             pluginKey={KEY_EMOJI}
-            icon={<IconStylingWrapper icon={<IconFaceHappy size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconFaceHappy16 />} />}
             styles={buttonStyles}
             classNames={buttonClassNames}
             EmojiPickerComponent={EmojiPicker}

--- a/src/components/RichTextEditor/Plugins/ItalicPlugin/ItalicButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ItalicPlugin/ItalicButton.tsx
@@ -2,7 +2,7 @@
 
 import { getHotkeyByPlatform } from '@components/RichTextEditor/helpers/getHotkeyByPlatform';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextFormatItalic } from '@foundation/Icon';
+import { IconTextFormatItalic16 } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
@@ -13,7 +13,7 @@ export const ItalicButton = ({ editor, id }: PluginButtonProps) => (
         <MarkToolbarButton
             tooltip={getTooltip(`Italic\n${getHotkeyByPlatform('Ctrl+I')}`)}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconTextFormatItalic size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextFormatItalic16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useFloatingLinkUrlInput } from '@udecode/plate';
-import { IconPen, IconTrashBin } from '@foundation/Icon';
+import { IconPen16, IconTrashBin16 } from '@foundation/Icon/Generated';
 import { FloatingLink } from '../FloatingLink';
 import { useRichTextEditorContext } from '@components/RichTextEditor/context/RichTextEditorContext';
 
@@ -24,7 +24,7 @@ export const EditModal = () => {
                         className="tw-transition tw-cursor-pointer tw-rounded hover:tw-bg-black-10 tw-p-1"
                     >
                         <FloatingLink.EditButton>
-                            <IconPen />
+                            <IconPen16 />
                         </FloatingLink.EditButton>
                     </span>
 
@@ -35,7 +35,7 @@ export const EditModal = () => {
                         className="tw-transition tw-cursor-pointer tw-rounded hover:tw-bg-black-10 tw-p-1"
                     >
                         <FloatingLink.UnlinkButton>
-                            <IconTrashBin />
+                            <IconTrashBin16 />
                         </FloatingLink.UnlinkButton>
                     </span>
                 </span>

--- a/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@components/Button/Button';
 import { Checkbox } from '@components/Checkbox';
 import { FormControl } from '@components/FormControl';
 import { TextInput } from '@components/TextInput';
-import { IconCheckMark } from '@foundation/Icon';
+import { IconCheckMark20 } from '@foundation/Icon/Generated';
 import React, { FC } from 'react';
 import { InsertModalStateProps } from './types';
 
@@ -81,7 +81,7 @@ export const InsertModal: FC<Props> = ({
                 <Button
                     onClick={onSave}
                     size={ButtonSize.Medium}
-                    icon={<IconCheckMark />}
+                    icon={<IconCheckMark20 />}
                     disabled={!isValidUrlOrEmpty() || !hasValues}
                 >
                     Save

--- a/src/components/RichTextEditor/Plugins/LinkPlugin/LinkButton.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/LinkButton.tsx
@@ -2,7 +2,7 @@
 
 import { getHotkeyByPlatform } from '@components/RichTextEditor/helpers/getHotkeyByPlatform';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconLink, IconSize } from '@foundation/Icon';
+import { IconLink16 } from '@foundation/Icon/Generated';
 import { LinkToolbarButton } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
@@ -12,7 +12,7 @@ export const LinkButton = ({ id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <LinkToolbarButton
             tooltip={getTooltip(`Link\n${getHotkeyByPlatform('Ctrl+K')}`)}
-            icon={<IconStylingWrapper icon={<IconLink size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconLink16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/ListPlugin/OrderedListPlugin/OrderedListButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/OrderedListPlugin/OrderedListButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconListNumbers, IconSize } from '@foundation/Icon';
+import { IconListNumbers16 } from '@foundation/Icon/Generated';
 import { ListToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
@@ -12,7 +12,7 @@ export const OrderedListButton = ({ editor, id }: PluginButtonProps) => (
         <ListToolbarButton
             tooltip={getTooltip('Ordered list')}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconListNumbers size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconListNumbers16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/ListPlugin/UnorderedListPlugin/UnorderedListButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/UnorderedListPlugin/UnorderedListButton.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { ListToolbarButton, getPluginType } from '@udecode/plate';
-import { IconListBullet, IconSize } from '@foundation/Icon';
+import { IconListBullet16 } from '@foundation/Icon/Generated';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
 import { PluginButtonProps } from '../../types';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
@@ -12,7 +12,7 @@ export const UnorderedListButton = ({ editor, id }: PluginButtonProps) => (
         <ListToolbarButton
             tooltip={getTooltip('Bullet list')}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconListBullet size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconListBullet16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/MentionPlugin/MentionCombobox/MentionComboboxItem.tsx
+++ b/src/components/RichTextEditor/Plugins/MentionPlugin/MentionCombobox/MentionComboboxItem.tsx
@@ -3,7 +3,7 @@
 import React, { ReactElement } from 'react';
 import { ComboboxItemProps } from '@udecode/plate';
 import { MentionItemData, MentionableCategory } from '../types';
-import { IconPeople, IconPerson, IconSize, IconTarget } from '@foundation/Icon';
+import { IconPeople12, IconPerson12, IconTarget12 } from '@foundation/Icon/Generated';
 
 type RenderAvatarProps = {
     category: MentionableCategory;
@@ -19,11 +19,11 @@ const RenderImage = ({ image, category, text, id }: RenderAvatarProps) => {
 
     switch (category) {
         case MentionableCategory.GROUP:
-            return <IconPeople size={IconSize.Size12} />;
+            return <IconPeople12 />;
         case MentionableCategory.ALL:
-            return <IconTarget size={IconSize.Size12} />;
+            return <IconTarget12 />;
         default:
-            return <IconPerson size={IconSize.Size12} />;
+            return <IconPerson12 />;
     }
 };
 

--- a/src/components/RichTextEditor/Plugins/MentionPlugin/MentionMarkupElement/MarkupElementNode.tsx
+++ b/src/components/RichTextEditor/Plugins/MentionPlugin/MentionMarkupElement/MarkupElementNode.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React from 'react';
-import { IconPeople, IconSize } from '@foundation/Icon';
+import { IconPeople12 } from '@foundation/Icon/Generated';
 import { MentionableCategory } from '../types';
 import { MarkupElementNodeComponentType, MarkupElementNodeType, MarkupElementProps } from './types';
 
@@ -38,7 +38,7 @@ const MarkupElementNodeGroup: MarkupElementNodeType = ({ children, ...props }) =
                 margin: '-1px 0',
             }}
         >
-            <IconPeople size={IconSize.Size12} />
+            <IconPeople12 />
         </span>
         {children}
     </MarkupElementNode>

--- a/src/components/RichTextEditor/Plugins/ResetFormattingPlugin/ResetFormattingButton/index.tsx
+++ b/src/components/RichTextEditor/Plugins/ResetFormattingPlugin/ResetFormattingButton/index.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React from 'react';
-import { IconEraser, IconSize } from '@foundation/Icon';
+import { IconEraser16 } from '@foundation/Icon/Generated';
 import { ResetFormattingToolbarButton } from './ResetFormattingToolbarButton';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
 import { PluginButtonProps } from '../../types';
@@ -9,7 +9,7 @@ import { PluginButtonProps } from '../../types';
 export const ResetFormattingButton = ({ id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <ResetFormattingToolbarButton
-            icon={<IconStylingWrapper icon={<IconEraser size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconEraser16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
         />

--- a/src/components/RichTextEditor/Plugins/StrikethroughPlugin/StrikethroughButton.tsx
+++ b/src/components/RichTextEditor/Plugins/StrikethroughPlugin/StrikethroughButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextFormatStrikethrough } from '@foundation/Icon';
+import { IconTextFormatStrikethrough } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
@@ -12,7 +12,7 @@ export const StrikethroughButton = ({ editor, id }: PluginButtonProps) => (
         <MarkToolbarButton
             tooltip={getTooltip('Strikethrough')}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconTextFormatStrikethrough size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextFormatStrikethrough />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/Plugins/TextStylePlugin/TextStyleDropdown/DropdownTrigger.tsx
+++ b/src/components/RichTextEditor/Plugins/TextStylePlugin/TextStyleDropdown/DropdownTrigger.tsx
@@ -3,7 +3,7 @@
 
 import React, { ForwardedRef, forwardRef } from 'react';
 import { getPreventDefaultHandler } from '@udecode/plate';
-import { IconCaretDown, IconSize } from '@foundation/Icon';
+import { IconCaretDown12 } from '@foundation/Icon/Generated';
 import { merge } from '@utilities/merge';
 import { DropdownTriggerProps } from './types';
 
@@ -26,7 +26,7 @@ export const DropdownTriggerComponent = (
         >
             <span className="tw-text-xs tw-truncate">{label}</span>
             <div className={merge(['tw-transition-transform', open && 'tw-rotate-180'])}>
-                <IconCaretDown size={IconSize.Size12} />
+                <IconCaretDown12 />
             </div>
         </div>
     </button>

--- a/src/components/RichTextEditor/Plugins/UnderlinePlugin/UnderlineButton.tsx
+++ b/src/components/RichTextEditor/Plugins/UnderlinePlugin/UnderlineButton.tsx
@@ -2,7 +2,7 @@
 
 import { getHotkeyByPlatform } from '@components/RichTextEditor/helpers/getHotkeyByPlatform';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
-import { IconSize, IconTextFormatUnderline } from '@foundation/Icon';
+import { IconTextFormatUnderline16 } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
 import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
@@ -13,7 +13,7 @@ export const UnderlineButton = ({ editor, id }: PluginButtonProps) => (
         <MarkToolbarButton
             tooltip={getTooltip(`Underline\n${getHotkeyByPlatform('Ctrl+U')}`)}
             type={getPluginType(editor, id)}
-            icon={<IconStylingWrapper icon={<IconTextFormatUnderline size={IconSize.Size16} />} />}
+            icon={<IconStylingWrapper icon={<IconTextFormatUnderline16 />} />}
             classNames={buttonClassNames}
             styles={buttonStyles}
             actionHandler="onMouseDown"

--- a/src/components/RichTextEditor/serializer/markdown/__tests__/MarkdownToSlate.spec.ts
+++ b/src/components/RichTextEditor/serializer/markdown/__tests__/MarkdownToSlate.spec.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { MarkdownToSlate } from '../';
+import { MarkdownToSlate } from '../MarkdownToSlate';
 import { Transform } from '../../transform';
 import {
     basicMarksMarkdown,

--- a/src/components/RichTextEditor/utils/__tests__/InitPlateEditor.spec.ts
+++ b/src/components/RichTextEditor/utils/__tests__/InitPlateEditor.spec.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { InitPlateEditor } from '../';
+import { InitPlateEditor } from '../InitPlateEditor';
 
 describe('InitPlateEditor', () => {
     it('should create with random id', () => {

--- a/src/components/RichTextEditor/utils/__tests__/isPlateValueEmpty.spec.ts
+++ b/src/components/RichTextEditor/utils/__tests__/isPlateValueEmpty.spec.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { isPlateValueEmpty } from '../';
+import { isPlateValueEmpty } from '../isPlateValueEmpty';
 
 const emptyValue = [{ type: 'something', children: [{ text: '' }] }];
 

--- a/src/components/Slider/Slider.cy.tsx
+++ b/src/components/Slider/Slider.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconTextAlignmentCentre, IconTextAlignmentLeft, IconTextAlignmentRight } from '@foundation/Icon';
+import { IconTextAlignmentCentre, IconTextAlignmentLeft, IconTextAlignmentRight } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import React, { FC, useState } from 'react';
 import { IconItem, Slider, TextOrNumberItem } from './Slider';

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -4,7 +4,7 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 import { Slider, SliderProps } from './Slider';
-import { IconTextAlignmentCentre, IconTextAlignmentLeft, IconTextAlignmentRight } from '@foundation/Icon';
+import { IconTextAlignmentCentre, IconTextAlignmentLeft, IconTextAlignmentRight } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Slider',

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 import React, { FC, useEffect, useState } from 'react';
 import { Column, Row, SelectionMode, SortDirection, Table, TableProps } from './Table';
-import { IconDotsVertical, IconFaceHappy } from '@foundation/Icon';
+import { IconDotsVertical, IconFaceHappy } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Table',

--- a/src/components/Table/TableColumnHeader.tsx
+++ b/src/components/Table/TableColumnHeader.tsx
@@ -6,7 +6,7 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import React, { Key, cloneElement, useEffect, useRef, useState } from 'react';
-import { IconArrowBidirectional, IconArrowDown, IconArrowUp } from '@foundation/Icon';
+import { IconArrowBidirectional, IconArrowDown, IconArrowUp } from '@foundation/Icon/Generated';
 import { SelectionMode, SortDirection } from '..';
 
 export enum TableColumnHeaderType {

--- a/src/components/Tabs/Tabs.cy.tsx
+++ b/src/components/Tabs/Tabs.cy.tsx
@@ -3,7 +3,8 @@
 import { BadgeStyle } from '@components/Badge';
 import { TabItem, TabItemProps } from '@components/Tabs/TabItem';
 import { TabSize, Tabs, TabsPaddingX } from '@components/Tabs/Tabs';
-import { IconIcon, IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
+import { IconIcon } from '@foundation/Icon/Generated';
 import React, { useState } from 'react';
 
 const data: TabItemProps[] = [

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -7,7 +7,8 @@ import { Button } from '@components/Button';
 import { Text } from '@typography/Text';
 import { Divider } from '@components/Divider';
 import { TabItem, TabItemProps } from '@components/Tabs/TabItem';
-import { IconIcon, IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
+import { IconIcon } from '@foundation/Icon/Generated';
 import { BadgeStyle } from '@components/Badge';
 import { Checkbox as CheckboxComponent, CheckboxProps, CheckboxState } from '@components/Checkbox/Checkbox';
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ import React, {
 } from 'react';
 import { TabItemProps } from '@components/Tabs/TabItem';
 import { merge } from '@utilities/merge';
-import { IconDotsHorizontal } from '@foundation/Icon';
+import { IconDotsHorizontal } from '@foundation/Icon/Generated';
 import { Badge } from '@components/Badge';
 import { motion } from 'framer-motion';
 import { useFocusRing } from '@react-aria/focus';

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -7,7 +7,7 @@ import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import React, { MouseEvent, useRef } from 'react';
-import { IconCross } from '@foundation/Icon';
+import { IconCross } from '@foundation/Icon/Generated';
 
 export enum TagType {
     Suggested = 'Suggested',

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -5,7 +5,7 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { Meta, StoryFn } from '@storybook/react';
 import { TextInput, TextInputProps, TextInputType } from './TextInput';
 import { Validation } from '@utilities/validation';
-import { IconIcon } from '@foundation/Icon';
+import { IconIcon } from '@foundation/Icon/Generated';
 
 export default {
     title: 'Components/Text Input',

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -16,7 +16,7 @@ import {
     IconExclamationMarkTriangle,
     IconEye,
     IconEyeOff,
-} from '@foundation/Icon';
+} from '@foundation/Icon/Generated';
 
 export enum TextInputType {
     Text = 'text',

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -9,7 +9,7 @@ import { Validation, validationClassMap } from '@utilities/validation';
 import { LoadingCircle, LoadingCircleSize } from '@components/LoadingCircle';
 import React, { FC, FocusEvent, FormEvent, ReactNode } from 'react';
 import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize';
-import { IconExclamationMarkTriangle } from '@foundation/Icon';
+import { IconExclamationMarkTriangle } from '@foundation/Icon/Generated';
 
 export type TextareaProps = {
     id?: string;

--- a/src/components/Tooltip/BrightHeader.tsx
+++ b/src/components/Tooltip/BrightHeader.tsx
@@ -7,8 +7,8 @@ import {
     IconDocument,
     IconExclamationMarkCircle,
     IconExclamationMarkTriangle,
-    IconSize,
-} from '@foundation/Icon';
+} from '@foundation/Icon/Generated';
+import { IconSize } from '@foundation/Icon/IconSize';
 
 export enum BrightHeaderStyle {
     Information = 'Information',

--- a/src/components/Tooltip/Tooltip.cy.tsx
+++ b/src/components/Tooltip/Tooltip.cy.tsx
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconExclamationMarkCircle, IconIcon, IconSize } from '@foundation/Icon';
+import { IconSize } from '@foundation/Icon/IconSize';
+import { IconExclamationMarkCircle, IconIcon } from '@foundation/Icon/Generated';
 import { mount } from 'cypress/react';
 import React from 'react';
 import { BrightHeaderStyle, brightHeaderBackgroundColors } from './BrightHeader';

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 import { BrightHeaderStyle } from './BrightHeader';
 import { Tooltip, TooltipAlignment, TooltipPosition, TooltipProps } from './Tooltip';
-import { IconExclamationMarkCircle16Filled, IconExclamationMarkTriangle16, IconIcon } from '@foundation/Icon';
+import { IconExclamationMarkCircle16Filled, IconExclamationMarkTriangle16, IconIcon } from '@foundation/Icon/Generated';
 import { useOverlayTriggerState } from '@react-stately/overlays';
 import { Button, ButtonEmphasis, ButtonStyle } from '@components/Button';
 import { Modal } from '@components/Modal';

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -5,7 +5,8 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { Tooltip, TooltipProps } from '@components/Tooltip/Tooltip';
 import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import { IconProps, IconQuestionMarkCircle } from '@foundation/Icon';
+import { IconProps } from '@foundation/Icon/IconProps';
+import { IconQuestionMarkCircle } from '@foundation/Icon/Generated';
 
 export type TooltipIconProps = {
     tooltip?: TooltipProps;

--- a/src/components/Tree/Tree.stories.tsx
+++ b/src/components/Tree/Tree.stories.tsx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/react';
 import { Tree, Tree as TreeComponent, TreeItem } from '@components/Tree';
 import { TreeNodeItem, treeNodesMock } from '@components/Tree/utils';
 import type { TreeItemProps, TreeProps } from '@components/Tree/types';
-import { IconDocument } from '@foundation/Icon';
+import { IconDocument } from '@foundation/Icon/Generated';
 import { DraggableItem } from '@utilities/dnd';
 
 export default {

--- a/src/components/Tree/utils/mocks.tsx
+++ b/src/components/Tree/utils/mocks.tsx
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React, { ReactElement, ReactNode } from 'react';
-import { IconDocument16, IconFaceExtraHappy16, IconFolder16, IconPlus, IconPlus16, IconProps } from '@foundation/Icon';
+import { IconDocument16, IconFaceExtraHappy16, IconFolder16, IconPlus, IconPlus16 } from '@foundation/Icon/Generated';
+import { IconProps } from '@foundation/Icon/IconProps';
 
 import { Badge, BadgeProps } from '@components/Badge';
 import { Button, ButtonSize } from '@components/Button';

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -1,13 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconCaretDown } from '@foundation/Icon/Generated';
+import { IconCaretDown, IconCross, IconExclamationMarkTriangle, IconTrashBin } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE, FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
 import React, { FC, HTMLAttributes } from 'react';
-import { IconCross, IconExclamationMarkTriangle, IconTrashBin } from '@foundation/Icon/Generated';
 
 export enum TriggerSize {
     Small = 'Small',

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -7,7 +7,7 @@ import { FOCUS_STYLE, FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
 import React, { FC, HTMLAttributes } from 'react';
-import { IconCross, IconExclamationMarkTriangle, IconTrashBin } from '@foundation/Icon';
+import { IconCross, IconExclamationMarkTriangle, IconTrashBin } from '@foundation/Icon/Generated';
 
 export enum TriggerSize {
     Small = 'Small',


### PR DESCRIPTION
Use the `/Generated` path whereever possible to have the cached bundled available
Use regex instead of 2 replace in enum generation