### PR TITLE
feat: apply alternative hover class to TreeItem

### DIFF
--- a/src/components/Tree/TreeItem.tsx
+++ b/src/components/Tree/TreeItem.tsx
@@ -230,7 +230,7 @@ export const TreeItem = ({
                     className={merge([
                         treeState.selectedIds.has(id)
                             ? 'tw-font-medium tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover hover:tw-text-box-selected-strong-inverse-hover'
-                            : 'tw-text-text hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',
+                            : 'tw-text-text hover:tw-bg-base-alt hover:tw-text-box-neutral-inverse-hover',
                         FOCUS_VISIBLE_STYLE,
                         'tw-leading-5 tw-no-underline tw-flex',
                     ])}


### PR DESCRIPTION
Since the TreeItem can contain buttons there is not enough contrast difference for Default emphasis buttons, so changing the className slightly increases contrast as per design request