### PR TITLE
fix: tooltip race condition

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -248,6 +248,9 @@ export const Tooltip = ({
           };
 
     useEffect(() => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
         setIsOpen(shouldPreventTooltipOpening ? false : open);
     }, [open, shouldPreventTooltipOpening]);
 


### PR DESCRIPTION
Fixes a missing tooltip race condition caused by the setTimeout being triggered  just before the tooltip was disabled, which sets the tooltip back to 'open' even if it is disabled