### PR TITLE
feat(RichTextEditor): disable link- and button-button when multiple blocks are selected

### DIFF
--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignCenterPlugin/AlignCenterButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignCenterPlugin/AlignCenterButton.tsx
@@ -4,7 +4,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextAlignmentCentre16 } from '@foundation/Icon/Generated';
 import { AlignToolbarButton, someNode, useEventPlateId, usePlateEditorState } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 
 export const AlignCenterButton = ({ id, editorId }: PluginButtonProps) => {
@@ -18,7 +18,7 @@ export const AlignCenterButton = ({ id, editorId }: PluginButtonProps) => {
                 tooltip={getTooltip('Align center')}
                 value="center"
                 icon={<IconStylingWrapper icon={<IconTextAlignmentCentre16 />} />}
-                classNames={buttonClassNames}
+                classNames={getButtonClassNames()}
                 styles={buttonStyles}
                 actionHandler="onMouseDown"
             />

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignJustifyPlugin/AlignJustifyButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignJustifyPlugin/AlignJustifyButton.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { AlignToolbarButton, someNode, useEventPlateId, usePlateEditorState } from '@udecode/plate';
 import { IconTextAlignmentJustify16 } from '@foundation/Icon/Generated';
 import { PluginButtonProps } from '../../types';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 
 export const AlignJustifyButton = ({ id, editorId }: PluginButtonProps) => {
@@ -17,7 +17,7 @@ export const AlignJustifyButton = ({ id, editorId }: PluginButtonProps) => {
                 tooltip={getTooltip('Justify')}
                 value="justify"
                 icon={<IconStylingWrapper icon={<IconTextAlignmentJustify16 />} />}
-                classNames={buttonClassNames}
+                classNames={getButtonClassNames()}
                 styles={buttonStyles}
                 actionHandler="onMouseDown"
             />

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignLeftPlugin/AlignLeftButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignLeftPlugin/AlignLeftButton.tsx
@@ -4,7 +4,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextAlignmentLeft16 } from '@foundation/Icon/Generated';
 import { AlignToolbarButton, someNode, useEventPlateId, usePlateEditorState } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 
 export const AlignLeftButton = ({ id, editorId }: PluginButtonProps) => {
@@ -18,7 +18,7 @@ export const AlignLeftButton = ({ id, editorId }: PluginButtonProps) => {
                 tooltip={getTooltip('Align left')}
                 value="left"
                 icon={<IconStylingWrapper icon={<IconTextAlignmentLeft16 />} />}
-                classNames={buttonClassNames}
+                classNames={getButtonClassNames()}
                 styles={buttonStyles}
                 actionHandler="onMouseDown"
             />

--- a/src/components/RichTextEditor/Plugins/AlignPlugin/AlignRightPlugin/AlignRightButton.tsx
+++ b/src/components/RichTextEditor/Plugins/AlignPlugin/AlignRightPlugin/AlignRightButton.tsx
@@ -4,7 +4,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextAlignmentRight16 } from '@foundation/Icon/Generated';
 import { AlignToolbarButton, someNode, useEventPlateId, usePlateEditorState } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 
 export const AlignRightButton = ({ id, editorId }: PluginButtonProps) => {
@@ -18,7 +18,7 @@ export const AlignRightButton = ({ id, editorId }: PluginButtonProps) => {
                 tooltip={getTooltip('Align right')}
                 value="right"
                 icon={<IconStylingWrapper icon={<IconTextAlignmentRight16 />} />}
-                classNames={buttonClassNames}
+                classNames={getButtonClassNames()}
                 styles={buttonStyles}
                 actionHandler="onMouseDown"
             />

--- a/src/components/RichTextEditor/Plugins/BoldPlugin/BoldButton.tsx
+++ b/src/components/RichTextEditor/Plugins/BoldPlugin/BoldButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import { IconTextFormatBold16 } from '@foundation/Icon/Generated';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { getHotkeyByPlatform } from '@components/RichTextEditor/helpers/getHotkeyByPlatform';
@@ -15,7 +15,7 @@ export const BoldButton = ({ editor, id }: PluginButtonProps) => (
             key={id}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconTextFormatBold16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonButton.tsx
@@ -1,19 +1,18 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React from 'react';
-import { getPluginType } from '@udecode/plate';
 import { IconButton16 } from '@foundation/Icon/Generated';
+import { getPluginType } from '@udecode/plate';
+import React from 'react';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles } from '../../helper';
 import { PluginButtonProps } from '../../types';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
-import { ButtonToolbarButton } from './ButtonToolbarButton';
 import { ELEMENT_BUTTON } from '../createButtonPlugin';
+import { ButtonToolbarButton } from './ButtonToolbarButton';
 
 export const ButtonButton = ({ editor, id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <ButtonToolbarButton
             type={getPluginType(editor, ELEMENT_BUTTON)}
             icon={<IconStylingWrapper icon={<IconButton16 />} />}
-            classNames={buttonClassNames}
             styles={buttonStyles}
         />
     </ButtonWrapper>

--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonToolbarButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonToolbarButton.tsx
@@ -1,11 +1,19 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import React from 'react';
-import { ToolbarButton, focusEditor, someNode, useEventPlateId, usePlateEditorState } from '@udecode/plate';
+import {
+    ToolbarButton,
+    focusEditor,
+    isRangeInSameBlock,
+    someNode,
+    useEventPlateId,
+    usePlateEditorState,
+} from '@udecode/plate';
 import { triggerFloatingButton } from '../utils';
 import { BlockToolbarButtonProps } from '@udecode/plate';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { getHotkeyByPlatform } from '@components/RichTextEditor/helpers/getHotkeyByPlatform';
+import { getButtonClassNames } from '../../helper';
 
 export interface LinkToolbarButtonProps extends BlockToolbarButtonProps {
     /**
@@ -16,12 +24,20 @@ export interface LinkToolbarButtonProps extends BlockToolbarButtonProps {
 
 export const ButtonToolbarButton = ({ id, type, ...props }: LinkToolbarButtonProps) => {
     const editor = usePlateEditorState(useEventPlateId(id));
+    const isEnabled = !!isRangeInSameBlock(editor, {
+        at: editor.selection,
+    });
 
     const isLink = !!editor?.selection && someNode(editor, { match: { type } });
 
     return (
         <ToolbarButton
-            tooltip={getTooltip(`Button\n${getHotkeyByPlatform('Shift+Ctrl+k')}`)}
+            tooltip={getTooltip(
+                isEnabled
+                    ? `Button\n${getHotkeyByPlatform('Shift+Ctrl+k')}`
+                    : 'Buttons can only be set for a single text block.',
+            )}
+            classNames={getButtonClassNames(isEnabled)}
             active={isLink}
             onMouseDown={async (event) => {
                 if (!editor) {

--- a/src/components/RichTextEditor/Plugins/CheckboxListPlugin/CheckboxListButton/index.tsx
+++ b/src/components/RichTextEditor/Plugins/CheckboxListPlugin/CheckboxListButton/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { getPluginType } from '@udecode/plate';
 import { IconListCheck16 } from '@foundation/Icon/Generated';
 import { CheckboxListToolbarButton } from './CheckboxListToolbarButton';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 
 export const CheckboxListButton = ({ editor, id }: PluginButtonProps) => (
@@ -12,7 +12,7 @@ export const CheckboxListButton = ({ editor, id }: PluginButtonProps) => (
         <CheckboxListToolbarButton
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconListCheck16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
         />
     </ButtonWrapper>

--- a/src/components/RichTextEditor/Plugins/CodePlugin/CodeButton.tsx
+++ b/src/components/RichTextEditor/Plugins/CodePlugin/CodeButton.tsx
@@ -4,7 +4,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextBrackets16 } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 
 export const CodeButton = ({ editor, id }: PluginButtonProps) => (
@@ -13,7 +13,7 @@ export const CodeButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip('Code')}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconTextBrackets16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/ColumnBreakButton/ColumnBreakToolbarButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/ColumnBreakButton/ColumnBreakToolbarButton.tsx
@@ -10,7 +10,7 @@ import {
     usePlateEditorState,
 } from '@udecode/plate';
 import React from 'react';
-import { buttonClassNames } from '../../helper';
+import { getButtonClassNames } from '../../helper';
 import { toggleColumnBreak } from '../onKeyDownColumnBreak';
 import { getColumnBreakCount } from '../utils/getColumnBreakCount';
 
@@ -24,6 +24,7 @@ export const ColumnBreakToolbarButton = ({ id, ...props }: ToolbarButtonProps) =
 
     const columnCount = Number(columns) || 1;
     const canBreakAfter = isColumnBreakEnabled(editor, columnCount, isActive);
+    const buttonClassNames = getButtonClassNames(canBreakAfter);
 
     return (
         <ToolbarButton
@@ -33,10 +34,7 @@ export const ColumnBreakToolbarButton = ({ id, ...props }: ToolbarButtonProps) =
             )}
             onMouseDown={(event) => toggleColumnBreak(editor, columnCount, event)}
             {...props}
-            classNames={{
-                root: `${buttonClassNames.root} ${canBreakAfter ? '' : '!tw-cursor-not-allowed !tw-opacity-50'}`,
-                active: buttonClassNames.active,
-            }}
+            classNames={buttonClassNames}
         />
     );
 };

--- a/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/ColumnBreakButton/index.tsx
+++ b/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/ColumnBreakButton/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { IconTextColumnBreak16 } from '@foundation/Icon/Generated';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 import { ColumnBreakToolbarButton } from './ColumnBreakToolbarButton';
 
@@ -11,7 +11,7 @@ export const ColumnBreakButton = ({ id }: PluginButtonProps) => {
         <ButtonWrapper id={id}>
             <ColumnBreakToolbarButton
                 icon={<IconStylingWrapper icon={<IconTextColumnBreak16 />} />}
-                classNames={buttonClassNames}
+                classNames={getButtonClassNames()}
                 styles={buttonStyles}
             />
         </ButtonWrapper>

--- a/src/components/RichTextEditor/Plugins/EmojiPlugin/EmojiButton.tsx
+++ b/src/components/RichTextEditor/Plugins/EmojiPlugin/EmojiButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { EmojiToolbarDropdown, KEY_EMOJI } from '@udecode/plate';
 import { IconFaceHappy16 } from '@foundation/Icon/Generated';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 import { EmojiPicker } from './EmojiPicker';
 
@@ -13,7 +13,7 @@ export const EmojiButton = ({ id }: PluginButtonProps) => (
             pluginKey={KEY_EMOJI}
             icon={<IconStylingWrapper icon={<IconFaceHappy16 />} />}
             styles={buttonStyles}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             EmojiPickerComponent={EmojiPicker}
         />
     </ButtonWrapper>

--- a/src/components/RichTextEditor/Plugins/ItalicPlugin/ItalicButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ItalicPlugin/ItalicButton.tsx
@@ -5,7 +5,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextFormatItalic16 } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 
 export const ItalicButton = ({ editor, id }: PluginButtonProps) => (
@@ -14,7 +14,7 @@ export const ItalicButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip(`Italic\n${getHotkeyByPlatform('Ctrl+I')}`)}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconTextFormatItalic16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/LinkPlugin/LinkButton.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/LinkButton.tsx
@@ -3,19 +3,31 @@
 import { getHotkeyByPlatform } from '@components/RichTextEditor/helpers/getHotkeyByPlatform';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconLink16 } from '@foundation/Icon/Generated';
-import { LinkToolbarButton } from '@udecode/plate';
+import { LinkToolbarButton, isRangeInSameBlock, useEventPlateId, usePlateEditorState } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 
-export const LinkButton = ({ id }: PluginButtonProps) => (
-    <ButtonWrapper id={id}>
-        <LinkToolbarButton
-            tooltip={getTooltip(`Link\n${getHotkeyByPlatform('Ctrl+K')}`)}
-            icon={<IconStylingWrapper icon={<IconLink16 />} />}
-            classNames={buttonClassNames}
-            styles={buttonStyles}
-            actionHandler="onMouseDown"
-        />
-    </ButtonWrapper>
-);
+export const LinkButton = ({ id, editorId }: PluginButtonProps) => {
+    const editor = usePlateEditorState(useEventPlateId(editorId));
+    const isEnabled = !!isRangeInSameBlock(editor, {
+        at: editor.selection,
+    });
+    const buttonClassNames = getButtonClassNames(isEnabled);
+
+    return (
+        <ButtonWrapper id={id}>
+            <LinkToolbarButton
+                tooltip={getTooltip(
+                    isEnabled
+                        ? `Link\n${getHotkeyByPlatform('Ctrl+K')}`
+                        : 'Links can only be set for a single text block.',
+                )}
+                icon={<IconStylingWrapper icon={<IconLink16 />} />}
+                classNames={buttonClassNames}
+                styles={buttonStyles}
+                actionHandler="onMouseDown"
+            />
+        </ButtonWrapper>
+    );
+};

--- a/src/components/RichTextEditor/Plugins/ListPlugin/OrderedListPlugin/OrderedListButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/OrderedListPlugin/OrderedListButton.tsx
@@ -4,7 +4,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconListNumbers16 } from '@foundation/Icon/Generated';
 import { ListToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 
 export const OrderedListButton = ({ editor, id }: PluginButtonProps) => (
@@ -13,7 +13,7 @@ export const OrderedListButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip('Ordered list')}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconListNumbers16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/ListPlugin/UnorderedListPlugin/UnorderedListButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/UnorderedListPlugin/UnorderedListButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { ListToolbarButton, getPluginType } from '@udecode/plate';
 import { IconListBullet16 } from '@foundation/Icon/Generated';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 
@@ -13,7 +13,7 @@ export const UnorderedListButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip('Bullet list')}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconListBullet16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/ResetFormattingPlugin/ResetFormattingButton/index.tsx
+++ b/src/components/RichTextEditor/Plugins/ResetFormattingPlugin/ResetFormattingButton/index.tsx
@@ -3,14 +3,14 @@
 import React from 'react';
 import { IconEraser16 } from '@foundation/Icon/Generated';
 import { ResetFormattingToolbarButton } from './ResetFormattingToolbarButton';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../../helper';
 import { PluginButtonProps } from '../../types';
 
 export const ResetFormattingButton = ({ id }: PluginButtonProps) => (
     <ButtonWrapper id={id}>
         <ResetFormattingToolbarButton
             icon={<IconStylingWrapper icon={<IconEraser16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
         />
     </ButtonWrapper>

--- a/src/components/RichTextEditor/Plugins/StrikethroughPlugin/StrikethroughButton.tsx
+++ b/src/components/RichTextEditor/Plugins/StrikethroughPlugin/StrikethroughButton.tsx
@@ -4,7 +4,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextFormatStrikethrough } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 
 export const StrikethroughButton = ({ editor, id }: PluginButtonProps) => (
@@ -13,7 +13,7 @@ export const StrikethroughButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip('Strikethrough')}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconTextFormatStrikethrough />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/UnderlinePlugin/UnderlineButton.tsx
+++ b/src/components/RichTextEditor/Plugins/UnderlinePlugin/UnderlineButton.tsx
@@ -5,7 +5,7 @@ import { getTooltip } from '@components/RichTextEditor/helpers/getTooltip';
 import { IconTextFormatUnderline16 } from '@foundation/Icon/Generated';
 import { MarkToolbarButton, getPluginType } from '@udecode/plate';
 import React from 'react';
-import { ButtonWrapper, IconStylingWrapper, buttonClassNames, buttonStyles } from '../helper';
+import { ButtonWrapper, IconStylingWrapper, buttonStyles, getButtonClassNames } from '../helper';
 import { PluginButtonProps } from '../types';
 
 export const UnderlineButton = ({ editor, id }: PluginButtonProps) => (
@@ -14,7 +14,7 @@ export const UnderlineButton = ({ editor, id }: PluginButtonProps) => (
             tooltip={getTooltip(`Underline\n${getHotkeyByPlatform('Ctrl+U')}`)}
             type={getPluginType(editor, id)}
             icon={<IconStylingWrapper icon={<IconTextFormatUnderline16 />} />}
-            classNames={buttonClassNames}
+            classNames={getButtonClassNames()}
             styles={buttonStyles}
             actionHandler="onMouseDown"
         />

--- a/src/components/RichTextEditor/Plugins/helper.tsx
+++ b/src/components/RichTextEditor/Plugins/helper.tsx
@@ -7,10 +7,13 @@ export const IconStylingWrapper = ({ icon }: IconStylingWrapperProps) => (
     <span className="tw-p-2 tw-h-8 tw-justify-center tw-items-center tw-flex">{icon}</span>
 );
 
-export const buttonClassNames = {
-    root: 'tw-ml-0.5 !tw-text-text-weak hover:!tw-bg-box-selected hover:!tw-text-box-selected-inverse hover:tw-rounded',
+const buttonRootClassNames =
+    'tw-ml-0.5 !tw-text-text-weak hover:!tw-bg-box-selected hover:!tw-text-box-selected-inverse hover:tw-rounded';
+
+export const getButtonClassNames = (isEnabled = true) => ({
+    root: isEnabled ? buttonRootClassNames : '!tw-text-text-weak !tw-cursor-not-allowed !tw-opacity-50',
     active: '!tw-bg-box-selected tw-rounded !tw-text-box-selected-inverse',
-};
+});
 export const buttonStyles = { root: { width: '24px', height: '24px' } };
 
 export const ButtonGroupWrapper = ({ index, children }: ButtonGroupProps) => (

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -7,7 +7,9 @@ import {
     AlignRightPlugin,
     BoldPlugin,
     BreakAfterPlugin,
+    ButtonPlugin,
     ELEMENT_BUTTON,
+    LinkPlugin,
     OrderedListPlugin,
     ParagraphPlugin,
     PluginComposer,
@@ -40,6 +42,7 @@ import {
     RICH_TEXT_EDITOR,
     TEXTSTYLE_DROPDOWN_TRIGGER,
     TEXTSTYLE_OPTION,
+    TOOLBAR_BUTTON,
     TOOLBAR_FLOATING,
     TOOLBAR_GROUP_1,
     TOOLBAR_GROUP_2,
@@ -174,6 +177,9 @@ const RichTextEditorWithValueSetOutside = ({ value }: { value: string }) => {
 };
 
 const RichTextEditorWithOrderedListStyles = () => <RichTextEditor value={JSON.stringify([orderedListValue])} />;
+
+const activeButtonClassNames = '!tw-bg-box-selected tw-rounded !tw-text-box-selected-inverse';
+const disabledButtonClassNames = '!tw-cursor-not-allowed !tw-opacity-50';
 
 describe('RichTextEditor Component', () => {
     describe('Rendering', () => {
@@ -687,6 +693,17 @@ describe('RichTextEditor Component', () => {
             cy.get('[contenteditable=true] a').should('have.attr', 'href', link + additionalLink);
             cy.get('[contenteditable=true] a').should('have.attr', 'target', '_self');
         });
+
+        it('should disable link-button when multiple blocks are selected', () => {
+            const plugins = new PluginComposer();
+            plugins.setPlugin([new LinkPlugin()]);
+
+            cy.mount(<RichTextEditor plugins={plugins} />);
+
+            cy.get('[contenteditable=true]').click().type('block1{enter}block2{selectall}');
+            cy.get(TOOLBAR_FLOATING).should('be.visible');
+            cy.get(`${TOOLBAR_FLOATING} ${TOOLBAR_BUTTON}`).should('have.class', disabledButtonClassNames);
+        });
     });
 
     describe('button plugin', () => {
@@ -786,6 +803,17 @@ describe('RichTextEditor Component', () => {
 
             cy.get('[contenteditable=true]').should('contain.text', text);
             cy.get('[contenteditable=true] a').should('not.exist');
+        });
+
+        it('should disable button-button when multiple blocks are selected', () => {
+            const plugins = new PluginComposer();
+            plugins.setPlugin([new ButtonPlugin()]);
+
+            cy.mount(<RichTextEditor plugins={plugins} />);
+
+            cy.get('[contenteditable=true]').click().type('block1{enter}block2{selectall}');
+            cy.get(TOOLBAR_FLOATING).should('be.visible');
+            cy.get(`${TOOLBAR_FLOATING} ${TOOLBAR_BUTTON}`).should('have.class', disabledButtonClassNames);
         });
     });
 
@@ -987,9 +1015,6 @@ describe('RichTextEditor Component', () => {
             />
         );
     };
-
-    const activeButtonClassNames = '!tw-bg-box-selected tw-rounded !tw-text-box-selected-inverse';
-    const disabledButtonClassNames = '!tw-cursor-not-allowed !tw-opacity-50';
 
     describe('column break plugin', () => {
         it('it should add column break on paragraph', () => {

--- a/src/components/RichTextEditor/__tests__/fixtures/selectors.ts
+++ b/src/components/RichTextEditor/__tests__/fixtures/selectors.ts
@@ -20,3 +20,4 @@ export const FLOATING_BUTTON_EDIT = '[data-test-id=floating-button-edit]';
 export const FLOATING_BUTTON_SECONDARY = '[data-test-id=floating-button-insert-secondary]';
 export const BUTTON = '[data-test-id=button]';
 export const CHECKBOX_INPUT_ID = '[data-test-id=checkbox-input]';
+export const TOOLBAR_BUTTON = '[data-testid=ToolbarButton]';


### PR DESCRIPTION
Disables a link-button or button-button when multiple blocks are selected in the rich text editor, since it's not yet supported by the rich text editor plugin itself.