### PR TITLE
feat(TreeItem): Content hover fix

### DIFF
--- a/src/components/Tree/TreeItem.tsx
+++ b/src/components/Tree/TreeItem.tsx
@@ -232,7 +232,7 @@ export const TreeItem = ({
                             ? 'tw-font-medium tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover hover:tw-text-box-neutral-strong-inverse-hover'
                             : 'tw-text-text hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',
                         FOCUS_VISIBLE_STYLE,
-                        'tw-leading-5 tw-no-underline tw-flex',
+                        'tw-relative tw-z-30 tw-leading-5 tw-no-underline tw-flex',
                     ])}
                     data-test-id="tree-item-content"
                     style={{


### PR DESCRIPTION
Temporary fix until the dnd-kit stuff is finalized. Basically, the Dropzone is positioned over the TreeItem so the hoverable area is clunky.