### PR TITLE
feat(RTE): make first line on tooltip bold

### DIFF
--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonToolbarButton.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/components/ButtonToolbarButton.tsx
@@ -34,7 +34,7 @@ export const ButtonToolbarButton = ({ id, type, ...props }: LinkToolbarButtonPro
         <ToolbarButton
             tooltip={getTooltip(
                 isEnabled
-                    ? `Button\n${getHotkeyByPlatform('Shift+Ctrl+k')}`
+                    ? `Button\n${getHotkeyByPlatform('Ctrl+Shift+K')}`
                     : 'Buttons can only be set for a single text block.',
             )}
             classNames={getButtonClassNames(isEnabled)}

--- a/src/components/RichTextEditor/helpers/getTooltip.tsx
+++ b/src/components/RichTextEditor/helpers/getTooltip.tsx
@@ -11,7 +11,6 @@ export const getTooltip: GetToolip = (content, placement) => {
         className:
             'tw-bg-text tw-border tw-border-line-strong tw-text-box-neutral-strong-inverse tw-py-2 tw-px-3 -tw-mb-1 tw-rounded tw-shadow-lg tw-text-xs',
         content: contentItems.map((item, index) => {
-            console.log('length', contentItems.length);
             return (
                 <div key={index}>
                     {contentItems.length > 1 && index === 0 ? <strong>{item}</strong> : item}

--- a/src/components/RichTextEditor/helpers/getTooltip.tsx
+++ b/src/components/RichTextEditor/helpers/getTooltip.tsx
@@ -12,10 +12,10 @@ export const getTooltip: GetToolip = (content, placement) => {
             'tw-bg-text tw-border tw-border-line-strong tw-text-box-neutral-strong-inverse tw-py-2 tw-px-3 -tw-mb-1 tw-rounded tw-shadow-lg tw-text-xs',
         content: contentItems.map((item, index) => {
             return (
-                <div key={index}>
+                <span key={item}>
                     {contentItems.length > 1 && index === 0 ? <strong>{item}</strong> : item}
                     <br />
-                </div>
+                </span>
             );
         }),
         placement,

--- a/src/components/RichTextEditor/helpers/getTooltip.tsx
+++ b/src/components/RichTextEditor/helpers/getTooltip.tsx
@@ -5,17 +5,21 @@ import React from 'react';
 
 type GetToolip = (content: string, placement?: Placement) => ToolbarButtonProps['tooltip'];
 
-export const getTooltip: GetToolip = (content, placement) => ({
-    className:
-        'tw-bg-text tw-border tw-border-line-strong tw-text-box-neutral-strong-inverse tw-py-2 tw-px-3 -tw-mb-1 tw-rounded tw-shadow-lg tw-text-xs',
-    content: content.split('\n').map((item) => {
-        return (
-            <span key={item}>
-                {item}
-                <br />
-            </span>
-        );
-    }),
-    placement,
-    delay: 300,
-});
+export const getTooltip: GetToolip = (content, placement) => {
+    const contentItems = content.split('\n');
+    return {
+        className:
+            'tw-bg-text tw-border tw-border-line-strong tw-text-box-neutral-strong-inverse tw-py-2 tw-px-3 -tw-mb-1 tw-rounded tw-shadow-lg tw-text-xs',
+        content: contentItems.map((item, index) => {
+            console.log('length', contentItems.length);
+            return (
+                <div key={index}>
+                    {contentItems.length > 1 && index === 0 ? <strong>{item}</strong> : item}
+                    <br />
+                </div>
+            );
+        }),
+        placement,
+        delay: 300,
+    };
+};


### PR DESCRIPTION
- Adjust tooltip of button to design
- Make first line of tooltip text bold

Design: https://www.figma.com/file/pevuvey1joCsopTRr9f4OE/Fondue---Components?t=ztBDUH5mf6Xip7lO-0
Ticket: https://app.clickup.com/t/8677hy3g9

<img width="100" alt="Bildschirm­foto 2023-03-20 um 15 26 54" src="https://user-images.githubusercontent.com/11270687/226370363-ffbcc4f9-a49f-4f11-a34c-ce531bdb3d33.png">