### PR TITLE
fix: stop link to propagate

### DIFF
--- a/src/components/RichTextEditor/serializer/nodes/link.ts
+++ b/src/components/RichTextEditor/serializer/nodes/link.ts
@@ -13,7 +13,9 @@ export const linkNode = (node: TElement, children: string, designTokens: DesignT
             chosenLink?.openInNewTab ? '_blank' : '_self'
         } href="${escapeHtml(chosenLink?.searchResult?.link)}">${children}</a>`;
     }
-    return `<a class="${defaultClassNames}" style="${reactCssPropsToCss(designTokens.link)}" target="${
-        node?.target ?? '_self'
-    }" href="${escapeHtml(node.url as string)}">${children}</a>`;
+    return `<a class="${defaultClassNames}" style="${reactCssPropsToCss(
+        designTokens.link,
+    )}" onClick="((event)=>{event.stopPropagation()})(event)" target="${node?.target ?? '_blank'}" href="${escapeHtml(
+        node.url as string,
+    )}">${children}</a>`;
 };

--- a/src/components/RichTextEditor/serializer/nodes/link.ts
+++ b/src/components/RichTextEditor/serializer/nodes/link.ts
@@ -13,9 +13,7 @@ export const linkNode = (node: TElement, children: string, designTokens: DesignT
             chosenLink?.openInNewTab ? '_blank' : '_self'
         } href="${escapeHtml(chosenLink?.searchResult?.link)}">${children}</a>`;
     }
-    return `<a class="${defaultClassNames}" style="${reactCssPropsToCss(
-        designTokens.link,
-    )}" onClick="((event)=>{event.stopPropagation()})(event)" target="${node?.target ?? '_blank'}" href="${escapeHtml(
-        node.url as string,
-    )}">${children}</a>`;
+    return `<a class="${defaultClassNames}" style="${reactCssPropsToCss(designTokens.link)}" target="${
+        node?.target ?? '_blank'
+    }" href="${escapeHtml(node.url as string)}">${children}</a>`;
 };


### PR DESCRIPTION
At transformation to HTML the link when clicked is set to not propagate.
If the link is inside container which is event action the link should not bubble events to the parent.