### PR TITLE
fix(RTE): quotes in serializer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8840,8 +8840,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2

--- a/src/components/RichTextEditor/Plugins/ListPlugin/ListItemContentMarkupElement.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/ListItemContentMarkupElement.tsx
@@ -25,7 +25,7 @@ export const getUnderlineClassNames = (designTokens: DesignTokens, element: TEle
 export const getLicElementClassNames = (element: TElement) =>
     merge([
         getColumnBreakClasses(element),
-        element.align ? justifyClassNames[element.align as string] : 'tw-justify-start tw-flex',
+        element.align ? justifyClassNames[element.align as string] : 'tw-justify-start',
         'tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]',
     ]);
 

--- a/src/components/RichTextEditor/Plugins/ListPlugin/OrderedListPlugin/OrderedListMarkupElement.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/OrderedListPlugin/OrderedListMarkupElement.tsx
@@ -13,9 +13,9 @@ import React from 'react';
 import { MarkupElement } from '../../MarkupElement';
 
 const LIST_TYPES = [
-    '[&>li>p]:before:tw-content-[counter(count,decimal)_"._"]',
-    '[&>li>p]:before:tw-content-[counter(count,_lower-alpha)_"._"]',
-    '[&>li>p]:before:tw-content-[counter(count,lower-roman)_"._"]',
+    "[&>li>p]:before:tw-content-[counter(count,decimal)_'._']",
+    "[&>li>p]:before:tw-content-[counter(count,_lower-alpha)_'._']",
+    "[&>li>p]:before:tw-content-[counter(count,lower-roman)_'._']",
 ];
 
 const getNestingLevel = (editor: PlateEditor, element: TElement) => {

--- a/src/components/RichTextEditor/Plugins/ListPlugin/UnorderedListPlugin/UnorderedListMarkupElement.tsx
+++ b/src/components/RichTextEditor/Plugins/ListPlugin/UnorderedListPlugin/UnorderedListMarkupElement.tsx
@@ -5,7 +5,7 @@ import { ELEMENT_UL, PlateRenderLeafProps } from '@udecode/plate';
 import { MarkupElement } from '../../MarkupElement';
 
 export const UL_CLASSES =
-    '[&>li>p]:before:tw-content-["•"] [&>li>p]:before:tw-px-2 tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px]';
+    "[&>li>p]:before:tw-content-['•'] [&>li>p]:before:tw-px-2 tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px]";
 
 export const UnorderedListMarkupElementNode = ({ attributes, children }: PlateRenderLeafProps) => (
     <ul className={UL_CLASSES} {...attributes}>

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -341,19 +341,19 @@ describe('RichTextEditor Component', () => {
 
             cy.get('[contenteditable=true] ol').should(
                 'have.class',
-                '[&>li>p]:before:tw-content-[counter(count,decimal)_"._"]',
+                "[&>li>p]:before:tw-content-[counter(count,decimal)_'._']",
             );
             cy.get('[contenteditable=true] ol ol').should(
                 'have.class',
-                '[&>li>p]:before:tw-content-[counter(count,_lower-alpha)_"._"]',
+                "[&>li>p]:before:tw-content-[counter(count,_lower-alpha)_'._']",
             );
             cy.get('[contenteditable=true] ol ol ol').should(
                 'have.class',
-                '[&>li>p]:before:tw-content-[counter(count,lower-roman)_"._"]',
+                "[&>li>p]:before:tw-content-[counter(count,lower-roman)_'._']",
             );
             cy.get('[contenteditable=true] ol ol ol ol').should(
                 'have.class',
-                '[&>li>p]:before:tw-content-[counter(count,decimal)_"._"]',
+                "[&>li>p]:before:tw-content-[counter(count,decimal)_'._']",
             );
         });
 

--- a/src/components/RichTextEditor/serializer/utils/reactCssPropsToCss.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/reactCssPropsToCss.spec.ts
@@ -15,4 +15,14 @@ describe('reactCssPropsToCss()', () => {
             'font-size: 12px; text-align: center; font-weight: bold; font-family: Arial;',
         );
     });
+
+    it('converts css props with quotes correctly to inline style css', () => {
+        const props: CSSProperties = {
+            fontFamily:
+                '"Mier B", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+        };
+        expect(reactCssPropsToCss(props)).to.equal(
+            "font-family: 'Mier B', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';",
+        );
+    });
 });

--- a/src/components/RichTextEditor/serializer/utils/reactCssPropsToCss.ts
+++ b/src/components/RichTextEditor/serializer/utils/reactCssPropsToCss.ts
@@ -13,5 +13,6 @@ export const reactCssPropsToCss = (props?: CSSProperties): string => {
             const value = props[key as keyof CSSProperties];
             return value ? `${acc}${convertCamelCaseToKebabCase(key)}: ${value}; ` : acc;
         }, '')
-        .trim();
+        .trim()
+        .replaceAll('"', "'");
 };

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
@@ -132,10 +132,10 @@ describe('serializeNodeToHtmlRecursive()', () => {
                 },
             ],
         };
-        const result = serializeNodeToHtmlRecursive(node, { designTokens: defaultDesignTokens });
+        const result = serializeNodeToHtmlRecursive(node, { designTokens: {} });
 
-        expect(result).to.match(
-            /<ul.*><li.*><p.*><span .*>This comes first.<\/span><\/p><\/li><li.*><p.*><span.*>This comes second.<\/span><\/p><\/li><\/ul>/,
+        expect(result).to.be.equal(
+            '<ul class="[&>li>p]:before:tw-content-[\'•\'] [&>li>p]:before:tw-px-2 tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] tw-break-words"><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes first.</span></p></li><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes second.</span></p></li></ul>',
         );
     });
 

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
@@ -25,7 +25,7 @@ describe('serializeNodeToHtmlRecursive()', () => {
                     children: [
                         {
                             type: ELEMENT_LIC,
-                            children: [{ text: 'This comes first.' }],
+                            children: [{ text: 'First item' }],
                         },
                     ],
                 },
@@ -34,7 +34,7 @@ describe('serializeNodeToHtmlRecursive()', () => {
                     children: [
                         {
                             type: ELEMENT_LIC,
-                            children: [{ text: 'This comes second.' }],
+                            children: [{ text: 'Second item' }],
                         },
                     ],
                 },
@@ -43,7 +43,7 @@ describe('serializeNodeToHtmlRecursive()', () => {
         const result = serializeNodeToHtmlRecursive(node, { designTokens: {} });
 
         expect(result).to.be.equal(
-            '<ol class="tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] [&>li>p]:before:tw-pr-1 [&>li>p]:before:tw-content-[counter(count,decimal)_\'._\'] tw-break-words" style="counter-reset: count;"><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes first.</span></p></li><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes second.</span></p></li></ol>',
+            '<ol class="tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] [&>li>p]:before:tw-pr-1 [&>li>p]:before:tw-content-[counter(count,decimal)_\'._\'] tw-break-words" style="counter-reset: count;"><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">First item</span></p></li><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">Second item</span></p></li></ol>',
         );
     });
 
@@ -121,21 +121,12 @@ describe('serializeNodeToHtmlRecursive()', () => {
                         },
                     ],
                 },
-                {
-                    type: ELEMENT_LI,
-                    children: [
-                        {
-                            type: ELEMENT_LIC,
-                            children: [{ text: 'This comes second.' }],
-                        },
-                    ],
-                },
             ],
         };
         const result = serializeNodeToHtmlRecursive(node, { designTokens: {} });
 
         expect(result).to.be.equal(
-            '<ul class="[&>li>p]:before:tw-content-[\'•\'] [&>li>p]:before:tw-px-2 tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] tw-break-words"><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes first.</span></p></li><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes second.</span></p></li></ul>',
+            '<ul class="[&>li>p]:before:tw-content-[\'•\'] [&>li>p]:before:tw-px-2 tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] tw-break-words"><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes first.</span></p></li></ul>',
         );
     });
 

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
@@ -40,11 +40,11 @@ describe('serializeNodeToHtmlRecursive()', () => {
                 },
             ],
         };
-        const result = serializeNodeToHtmlRecursive(node, { designTokens: defaultDesignTokens });
+        const result = serializeNodeToHtmlRecursive(node, { designTokens: {} });
 
-        expect(result).to.match(/<ol class=".*(count,decimal)*"/);
-        expect(result).to.match(/<li .*><p .*><span .*>This comes first\.<\/span><\/p><\/li>/);
-        expect(result).to.match(/<li .*><p .*><span .*>This comes second\.<\/span><\/p><\/li>/);
+        expect(result).to.be.equal(
+            '<ol class="tw-list-none tw-pl-[10px] tw-mb-[10px] tw-ml-[15px] [&>li>p]:before:tw-pr-1 [&>li>p]:before:tw-content-[counter(count,decimal)_\'._\'] tw-break-words" style="counter-reset: count;"><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes first.</span></p></li><li class="tw-break-words [&>p]:before:tw-flex [&>p]:before:tw-justify-end [&>p]:before:tw-w-[1.2em] !tw-no-underline" style="counter-increment: count;"><p class="tw-break-words tw-justify-start tw-grid tw-grid-cols-[min-content_repeat(3,_auto)]"><span class="">This comes second.</span></p></li></ol>',
+        );
     });
 
     it('serializes active break after column element to html', () => {

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
@@ -42,7 +42,7 @@ describe('serializeNodeToHtmlRecursive()', () => {
         };
         const result = serializeNodeToHtmlRecursive(node, { designTokens: defaultDesignTokens });
 
-        expect(result).to.match(/<ol class='.*(count,decimal)*'/);
+        expect(result).to.match(/<ol class=".*(count,decimal)*"/);
         expect(result).to.match(/<li .*><p .*><span .*>This comes first\.<\/span><\/p><\/li>/);
         expect(result).to.match(/<li .*><p .*><span .*>This comes second\.<\/span><\/p><\/li>/);
     });
@@ -405,4 +405,28 @@ describe('serializeNodeToHtmlRecursive()', () => {
             expect(result).to.include(`margin-left:${entry.outcome};`);
         });
     }
+
+    it('serializes design tokens with quotes in them correctly', () => {
+        const node = {
+            type: ELEMENT_PARAGRAPH,
+            children: [
+                {
+                    type: ELEMENT_LINK,
+                    children: [{ text: 'This is a Link.' }],
+                    url: 'https://frontify.com',
+                },
+            ],
+        };
+        const result = serializeNodeToHtmlRecursive(node, {
+            designTokens: {
+                link: {
+                    fontFamily: '"Mier B", -apple-system, BlinkMacSystemFont',
+                },
+            },
+        });
+
+        expect(result).to.be.equal(
+            '<p class="tw-break-words" style=""><a class="tw-break-words" style="font-family: \'Mier B\', -apple-system, BlinkMacSystemFont;" target="_blank" href="https://frontify.com">This is a Link.</a></p>',
+        );
+    });
 });

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
@@ -87,43 +87,43 @@ export const serializeNodeToHtmlRecursive = (
 
     switch (node.type) {
         case TextStyles.ELEMENT_HEADING1:
-            return `<h1 class="${classNames}" style='${reactCssPropsToCss(designTokens.heading1)}'>${children}</h1>`;
+            return `<h1 class="${classNames}" style="${reactCssPropsToCss(designTokens.heading1)}">${children}</h1>`;
         case TextStyles.ELEMENT_HEADING2:
-            return `<h2 class='${classNames}' style='${reactCssPropsToCss(designTokens.heading2)}'>${children}</h2>`;
+            return `<h2 class="${classNames}" style="${reactCssPropsToCss(designTokens.heading2)}">${children}</h2>`;
         case TextStyles.ELEMENT_HEADING3:
-            return `<h3 class='${classNames}' style='${reactCssPropsToCss(designTokens.heading3)}'>${children}</h3>`;
+            return `<h3 class="${classNames}" style="${reactCssPropsToCss(designTokens.heading3)}">${children}</h3>`;
         case TextStyles.ELEMENT_HEADING4:
-            return `<h4 class='${classNames}' style='${reactCssPropsToCss(designTokens.heading4)}'>${children}</h4>`;
+            return `<h4 class="${classNames}" style="${reactCssPropsToCss(designTokens.heading4)}">${children}</h4>`;
         case TextStyles.ELEMENT_CUSTOM1:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.custom1)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.custom1)}">${children}</p>`;
         case TextStyles.ELEMENT_CUSTOM2:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.custom2)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.custom2)}">${children}</p>`;
         case TextStyles.ELEMENT_CUSTOM3:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.custom3)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.custom3)}">${children}</p>`;
         case TextStyles.ELEMENT_QUOTE:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.quote)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.quote)}">${children}</p>`;
         case ELEMENT_PARAGRAPH:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.p)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.p)}">${children}</p>`;
         case TextStyles.ELEMENT_IMAGE_TITLE:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.imageTitle)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.imageTitle)}">${children}</p>`;
         case TextStyles.ELEMENT_IMAGE_CAPTION:
-            return `<p class='${classNames}' style='${reactCssPropsToCss(designTokens.imageCaption)}'>${children}</p>`;
+            return `<p class="${classNames}" style="${reactCssPropsToCss(designTokens.imageCaption)}">${children}</p>`;
         case ELEMENT_UL:
-            return `<ul class='${UL_CLASSES} ${classNames}'>${children}</ul>`;
+            return `<ul class="${UL_CLASSES} ${classNames}">${children}</ul>`;
         case ELEMENT_OL:
             const nestingLevel = Math.max(rootNestingCount - countNodesOfType([node], ELEMENT_OL), 0);
-            return `<ol class='${getOrderedListClasses(nestingLevel)} ${classNames}' style='${reactCssPropsToCss(
+            return `<ol class="${getOrderedListClasses(nestingLevel)} ${classNames}" style="${reactCssPropsToCss(
                 OL_STYLES,
-            )}'>${children}</ol>`;
+            )}">${children}</ol>`;
         case ELEMENT_LI:
-            return `<li class='${classNames} ${LI_CLASSNAMES}' style='${reactCssPropsToCss(
+            return `<li class="${classNames} ${LI_CLASSNAMES}" style="${reactCssPropsToCss(
                 getLiStyles(designTokens, node),
-            )}'>${children}</li>`;
+            )}">${children}</li>`;
         case ELEMENT_LIC:
             const underline = getUnderlineClassNames(designTokens, node);
-            return `<p class='${classNames} ${getLicElementClassNames(
+            return `<p class="${classNames} ${getLicElementClassNames(
                 node,
-            )}'><span class='${underline}'>${children}</span></p>`;
+            )}"><span class="${underline}">${children}</span></p>`;
         case ELEMENT_LINK:
             return linkNode(node, children, designTokens, classNames);
         case ELEMENT_BUTTON:


### PR DESCRIPTION
Replace all double quotes to single quotes in css values, because otherwise it causes issues:

<img width="454" alt="Bildschirm­foto 2023-03-23 um 10 32 58" src="https://user-images.githubusercontent.com/11270687/227161654-2a04968d-37e6-4f30-8675-65bcd3abacb4.png">

Ticket: https://app.clickup.com/t/8677k32g3
