### PR TITLE
chore(setup): replace preinstall script with engine definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "version": "12.0.0-beta.38",
     "description": "Design system of Frontify",
     "engines": {
-        "node": ">=16"
+        "node": ">=16",
+        "pnpm": ">=7",
+        "npm": "<=0"
     },
     "main": "dist/index.umd.js",
     "unpkg": "dist/index.umd.js",
@@ -26,7 +28,6 @@
         "./dist/*": "./dist/*"
     },
     "scripts": {
-        "preinstall": "npx -y only-allow pnpm",
         "build": "pnpm clean && pnpm generate:icons && pnpm build:library && pnpm build:extractedThirdPartyStyles",
         "build:extractedThirdPartyStyles": "concat src/components/**/*.css | postcss > dist/extractedThirdPartyStyles.css",
         "build:library": "vite build",


### PR DESCRIPTION
### Goal
Preinstall script gets executed on target systems as well and takes around 10s to execute or even more. We get the same result by using engine definitions for PNPM and block NPM by defining a not available version.

### Espected result
- NPM should not be able to do the installation
- PNPM should install the project like before