### PR TITLE
chore(workflows): remove duplicated step

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -160,12 +160,6 @@ jobs:
                   version: latest
                   run_install: false
 
-            - name: Use pnpm
-              uses: pnpm/action-setup@v2.2.4
-              with:
-                  version: latest
-                  run_install: false
-
             - name: Get pnpm store directory
               id: pnpm-cache
               run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"


### PR DESCRIPTION
Removed superfluous step "Use pnpm", because it was there twice .