### PR TITLE
chore(typescript): Replace React.FC and React.PropsWithChildren

### DIFF
--- a/scripts/templates/component.ts
+++ b/scripts/templates/component.ts
@@ -8,12 +8,11 @@ export const setup = (componentName: string): ComponentFileBuilderResponse => ({
 
 import React, { ReactNode } from "react";
 
-export type ${componentName}Props = { foo: string; children?: ReactNode; };
+export type ${componentName}Props = { children?: ReactNode; };
 
-export const ${componentName} = ({ foo, children }: ${componentName}Props) => {
+export const ${componentName} = ({ children }: ${componentName}Props) => {
     return (
         <div data-test-id="${toKebabCase(componentName)}">
-            <div>{foo}</div>
             {children}
         </div>
     );

--- a/scripts/templates/component.ts
+++ b/scripts/templates/component.ts
@@ -6,9 +6,9 @@ import { toKebabCase } from '../transforms';
 export const setup = (componentName: string): ComponentFileBuilderResponse => ({
     content: `/* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { PropsWithChildren } from "react";
+import React, { ReactNode } from "react";
 
-export type ${componentName}Props = PropsWithChildren<{ foo: string }>;
+export type ${componentName}Props = { foo: string; children?: ReactNode; };
 
 export const ${componentName} = ({ foo, children }: ${componentName}Props) => {
     return (

--- a/src/components/Accordion/Accordion.cy.tsx
+++ b/src/components/Accordion/Accordion.cy.tsx
@@ -2,7 +2,7 @@
 
 import { TextInput } from '@components/TextInput/TextInput';
 import { IconIcon } from '@foundation/Icon/Generated';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { AccordionHeaderProps } from '.';
 import { Accordion, AccordionItem } from './Accordion';
 
@@ -16,7 +16,7 @@ const itemClasses = ['tw-divide-y tw-divide-black-10'];
 const accordionWithBorderClasses = ['tw-border-b', 'tw-border-t', 'tw-border-black-10'];
 const accordionWithDividerClasses = ['tw-divide-y tw-divide-black-10'];
 
-const TestHeader: FC<AccordionHeaderProps> = ({ isOpen, disabled, children }) => (
+const TestHeader = ({ isOpen, disabled, children }: AccordionHeaderProps): ReactElement => (
     <div data-test-id="test-header" data-state={isOpen ? 'open' : 'closed'} data-disabled={disabled}>
         {children}
     </div>
@@ -250,7 +250,7 @@ describe('Accordion Component', () => {
     });
 });
 
-const TestAccordion = () => {
+const TestAccordion = (): ReactElement => {
     const accordionItems = [
         <AccordionItem key={0} header={{ children: '1' }}>
             1

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -22,7 +22,7 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 import { merge } from '@utilities/merge';
-import React, { FC, ReactNode, useState } from 'react';
+import React, { ReactElement, ReactNode, useState } from 'react';
 import { Color } from '../../types';
 import { EXAMPLE_IMAGES } from '../AssetInput/example-assets';
 import { Accordion as AccordionComponent, AccordionItem } from './Accordion';
@@ -132,7 +132,7 @@ export const WithDifferentAccordionItems: StoryFn<AccordionProps> = () => {
     );
 };
 
-const customHeader: FC<AccordionHeaderProps> = ({ isOpen, children }) => (
+const customHeader = ({ isOpen, children }: AccordionHeaderProps): ReactElement => (
     <div
         className={merge([
             'tw-px-6 tw-py-4 tw-bg-black-5 tw-flex tw-justify-between tw-font-bold tw-items-center',
@@ -144,11 +144,11 @@ const customHeader: FC<AccordionHeaderProps> = ({ isOpen, children }) => (
     </div>
 );
 
-const Code: FC = ({ children }) => (
+const Code = ({ children }: { children: ReactNode }): ReactElement => (
     <code className="tw-bg-black-5 tw-rounded tw-px-2 tw-text-box-negative-strong tw-text-s">{children}</code>
 );
 
-const PropsTable: FC<{ rows: [ReactNode, ReactNode, ReactNode][] }> = ({ rows }) => (
+const PropsTable = ({ rows }: { rows: [ReactNode, ReactNode, ReactNode][] }): ReactElement => (
     <table className="tw-table-fixed tw-border tw-border-black-10 tw-my-4">
         <thead className="tw-bg-black-5">
             <tr className="tw-p-3 tw-border-b tw-border-b-black-10">

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -8,21 +8,21 @@ import { Item as StatelyItem } from '@react-stately/collections';
 import { useTreeState } from '@react-stately/tree';
 import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { Children, FC, Key, KeyboardEvent, ReactElement, isValidElement, useEffect, useRef } from 'react';
+import React, { Children, Key, KeyboardEvent, ReactElement, isValidElement, useEffect, useRef } from 'react';
 import { AccordionHeader } from './AccordionHeader';
 import { AccordionItemProps, AccordionProps, AriaAccordionItemProps } from './types';
 
 const ACCORDION_ID = 'accordion';
 const ACCORDION_ITEM_ID = 'accordion-item';
 
-const AriaAccordionItem: FC<AriaAccordionItemProps> = ({
+const AriaAccordionItem = ({
     item,
     state,
     header,
     padding = true,
     divider = false,
     headerComponent: HeaderComponent = AccordionHeader,
-}) => {
+}: AriaAccordionItemProps): ReactElement => {
     const { size, active, ...headerProps } = header;
     const triggerRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps, regionProps } = useAccordionItem({ item }, state, triggerRef);
@@ -109,7 +109,7 @@ const lastChildrenActive = (children: React.ReactNode | undefined): boolean | un
     return childrenArray[childrenArray.length - 1]?.props?.header?.active === true;
 };
 
-export const Accordion: FC<AccordionProps> = (props) => {
+export const Accordion = (props: AccordionProps): ReactElement => {
     const { divider = true, border = true } = props;
     const children = filterValidChildren(props);
     const ariaProps = mapToAriaProps(children);

--- a/src/components/Accordion/AccordionHeaderIcon.tsx
+++ b/src/components/Accordion/AccordionHeaderIcon.tsx
@@ -1,13 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { FieldsetHeaderSize, FieldsetHeaderType, renderFieldsetHeaderIconType } from '@components/FieldsetHeader';
-import { FC } from 'react';
+import { ReactElement } from 'react';
 import { AccordionHeaderIconProps, AccordionHeaderIconSize } from './types';
 
-export const AccordionHeaderIcon: FC<AccordionHeaderIconProps> = ({
+export const AccordionHeaderIcon = ({
     size = AccordionHeaderIconSize.Medium,
     isOpen,
     disabled = false,
     type = FieldsetHeaderType.Accordion,
-}) => renderFieldsetHeaderIconType(type, '', FieldsetHeaderSize[AccordionHeaderIconSize[size]], isOpen, disabled);
+}: AccordionHeaderIconProps): Nullable<ReactElement> =>
+    renderFieldsetHeaderIconType(type, '', FieldsetHeaderSize[AccordionHeaderIconSize[size]], isOpen, disabled);
 AccordionHeaderIcon.displayName = 'FondueAccordionHeaderIcon';

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { TreeState } from '@react-stately/tree';
-import { FC, PropsWithChildren, ReactNode } from 'react';
+import { PropsWithChildren, ReactElement, ReactNode } from 'react';
 import { Node } from '@react-types/shared';
 import { FieldsetHeaderSize, FieldsetHeaderType } from '@components/FieldsetHeader';
 
@@ -17,14 +17,14 @@ export type AriaAccordionItemProps = {
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
-    headerComponent?: FC<AccordionHeaderProps>;
+    headerComponent?: (props: AccordionHeaderProps) => ReactElement;
 };
 
 export type AccordionItemProps = PropsWithChildren<{
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
-    headerComponent?: FC<AccordionHeaderProps>;
+    headerComponent?: (props: AccordionHeaderProps) => ReactElement;
 }>;
 
 export enum AccordionHeaderIconSize {

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -17,14 +17,14 @@ export type AriaAccordionItemProps = {
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
-    headerComponent?: (props: AccordionHeaderProps) => ReactElement;
+    headerComponent?: (props: AccordionHeaderProps) => ReactElement | null;
 };
 
 export type AccordionItemProps = PropsWithChildren<{
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
-    headerComponent?: (props: AccordionHeaderProps) => ReactElement;
+    headerComponent?: (props: AccordionHeaderProps) => ReactElement | null;
 }>;
 
 export enum AccordionHeaderIconSize {

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { TreeState } from '@react-stately/tree';
-import { PropsWithChildren, ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { Node } from '@react-types/shared';
 import { FieldsetHeaderSize, FieldsetHeaderType } from '@components/FieldsetHeader';
 
@@ -20,12 +20,13 @@ export type AriaAccordionItemProps = {
     headerComponent?: (props: AccordionHeaderProps) => ReactElement | null;
 };
 
-export type AccordionItemProps = PropsWithChildren<{
+export type AccordionItemProps = {
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
     headerComponent?: (props: AccordionHeaderProps) => ReactElement | null;
-}>;
+    children?: ReactNode;
+};
 
 export enum AccordionHeaderIconSize {
     Small = 'Small',

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -17,14 +17,14 @@ export type AriaAccordionItemProps = {
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
-    headerComponent?: (props: AccordionHeaderProps) => ReactElement | null;
+    headerComponent?: (props: AccordionHeaderProps) => ReactElement;
 };
 
 export type AccordionItemProps = {
     header: Omit<AccordionHeaderProps, 'isOpen'> & { active?: boolean; onClick?: () => void };
     padding?: boolean;
     divider?: boolean;
-    headerComponent?: (props: AccordionHeaderProps) => ReactElement | null;
+    headerComponent?: (props: AccordionHeaderProps) => ReactElement;
     children?: ReactNode;
 };
 

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -56,4 +56,5 @@ export type AccordionHeaderIconProps = {
     /** @deprecated Icon type will be fixed to FieldsetHeaderType.Accordion.
      Use headerComponent prop for custom header styles */
     type?: FieldsetHeaderType;
+    children?: ReactNode;
 };

--- a/src/components/ActionMenu/ActionMenu/ActionMenu.cy.tsx
+++ b/src/components/ActionMenu/ActionMenu/ActionMenu.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { MenuItemContentSize } from '@components/MenuItem';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { ActionMenu } from './ActionMenu';
 
 const MENU_ITEM_ID = '[data-test-id=menu-item]';
@@ -45,7 +45,7 @@ const MENU_BLOCKS = [
     },
 ];
 
-const TestComponent: FC = () => {
+const TestComponent = (): ReactElement => {
     const [menuBlocks, setMenuBlocks] = useState(MENU_BLOCKS);
 
     const addBlock = () =>

--- a/src/components/ActionMenu/Aria/AriaMenuItem.tsx
+++ b/src/components/ActionMenu/Aria/AriaMenuItem.tsx
@@ -9,7 +9,7 @@ import { TreeState } from '@react-stately/tree';
 import { Node } from '@react-types/shared';
 import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, ReactElement, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import { MenuItemType } from '@components/Dropdown';
 import { ActionMenuItemType, ActionMenuSwitchItemType } from '@components/ActionMenu';
 
@@ -60,7 +60,7 @@ const useSwitch = (isSwitch: boolean, initialValue: boolean) => {
     return switchObject;
 };
 
-export const AriaMenuItem: FC<AriaOptionProps> = ({ menuItem, node, state, isSelected, onClick }) => {
+export const AriaMenuItem = ({ menuItem, node, state, isSelected, onClick }: AriaOptionProps): ReactElement => {
     const ref = useRef<HTMLLIElement | null>(null);
     const initialValue = isActionMenuSwitchItem(menuItem) ? menuItem.initialValue : false;
     const {

--- a/src/components/ActionMenu/Aria/AriaSection.tsx
+++ b/src/components/ActionMenu/Aria/AriaSection.tsx
@@ -1,13 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useMenuSection } from '@react-aria/menu';
-import React, { FC } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 export type AriaSectionProps = {
     ariaLabel?: string;
+    children: ReactNode;
 };
 
-export const AriaSection: FC<AriaSectionProps> = ({ ariaLabel, children }) => {
+export const AriaSection = ({ ariaLabel, children }: AriaSectionProps): ReactElement => {
     const { itemProps, groupProps } = useMenuSection({ 'aria-label': ariaLabel });
 
     return (

--- a/src/components/AddBlockButton/AddBlockButton.tsx
+++ b/src/components/AddBlockButton/AddBlockButton.tsx
@@ -7,7 +7,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 
 export enum AddBlockButtonDirection {
     Horizontal = 'Horizontal',
@@ -20,11 +20,11 @@ export type AddBlockButtonProps = {
     orientation?: AddBlockButtonDirection;
 };
 
-export const AddBlockButton: FC<AddBlockButtonProps> = ({
+export const AddBlockButton = ({
     onClick,
     title,
     orientation = AddBlockButtonDirection.Horizontal,
-}) => {
+}: AddBlockButtonProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
     const ref = useRef<HTMLButtonElement | null>(null);
     const { buttonProps } = useButton({ onPress: () => onClick() }, ref);

--- a/src/components/AssetInput/AssetInput.tsx
+++ b/src/components/AssetInput/AssetInput.tsx
@@ -7,7 +7,7 @@ import { IconProps } from '@foundation/Icon/IconProps';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { merge } from '@utilities/merge';
-import React, { ChangeEvent, FC, ReactElement } from 'react';
+import React, { ChangeEvent, ReactElement } from 'react';
 import { MultiAssetPreview } from './MultiAssetPreview';
 import { SelectedAsset } from './SingleAsset/SelectedAsset';
 
@@ -73,7 +73,7 @@ export type AssetInputProps = {
     acceptFileType?: string;
 };
 
-export const AssetInput: FC<AssetInputProps> = ({
+export const AssetInput = ({
     assets = [],
     numberOfLocations = 1,
     actions = [],
@@ -85,7 +85,7 @@ export const AssetInput: FC<AssetInputProps> = ({
     onUploadClick,
     onMultiAssetClick,
     acceptFileType,
-}) => {
+}: AssetInputProps): ReactElement => {
     const assetsLength = assets.length;
     const id = useMemoizedId();
 

--- a/src/components/AssetInput/AssetThumbnail.tsx
+++ b/src/components/AssetInput/AssetThumbnail.tsx
@@ -2,7 +2,7 @@
 
 import { IconSize } from '@foundation/Icon/IconSize';
 import { merge } from '@utilities/merge';
-import React, { FC, cloneElement } from 'react';
+import React, { ReactElement, cloneElement } from 'react';
 import { AssetInputProps, AssetInputSize } from './AssetInput';
 import { SelectedAssetProps } from './SingleAsset/SelectedAsset';
 import { IconMusicNote } from '@foundation/Icon/Generated';
@@ -25,7 +25,12 @@ const getIconSizeClassNames = (size: AssetInputSize, isMultiAsset: boolean) => {
     }
 };
 
-export const AssetThumbnail: FC<AssetThumbnailProps> = ({ asset, size, isActive = false, isMultiAsset = false }) => {
+export const AssetThumbnail = ({
+    asset,
+    size,
+    isActive = false,
+    isMultiAsset = false,
+}: AssetThumbnailProps): ReactElement => {
     const thumbnailVariant = asset.type === 'icon' || asset.type === 'audio' ? asset.type : 'default';
 
     return (

--- a/src/components/AssetInput/MultiAssetPreview/MultiAssetPreview.tsx
+++ b/src/components/AssetInput/MultiAssetPreview/MultiAssetPreview.tsx
@@ -7,7 +7,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 import { AssetType } from '../AssetInput';
 import { SelectedAssetsThumbnail } from './SelectedAssetsThumbnail';
 
@@ -19,7 +19,7 @@ export type MultiAssetPreviewProps = {
 
 // const FOCUS_STYLE = "tw-border-black-90 dark:tw-border-black-10";
 
-export const MultiAssetPreview: FC<MultiAssetPreviewProps> = ({ numberOfLocations, assets, onClick }) => {
+export const MultiAssetPreview = ({ numberOfLocations, assets, onClick }: MultiAssetPreviewProps): ReactElement => {
     const buttonRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps } = useButton({ onPress: onClick }, buttonRef);
     const { isFocusVisible, focusProps } = useFocusRing();

--- a/src/components/AssetInput/MultiAssetPreview/SelectedAssetsThumbnail.tsx
+++ b/src/components/AssetInput/MultiAssetPreview/SelectedAssetsThumbnail.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { AssetInputSize, AssetType, ImageAsset, LibrarySource } from '../AssetInput';
 import { AssetThumbnail } from '../AssetThumbnail';
 import { MultiAssetPreviewProps } from './MultiAssetPreview';
@@ -9,7 +9,7 @@ import { MultiAssetPreviewProps } from './MultiAssetPreview';
 const isImageAsset = (asset: AssetType): asset is ImageAsset & LibrarySource =>
     asset.type === 'image' || asset.type === 'logo';
 
-export const SelectedAssetsThumbnail: FC<Pick<MultiAssetPreviewProps, 'assets'>> = ({ assets }) => {
+export const SelectedAssetsThumbnail = ({ assets }: Pick<MultiAssetPreviewProps, 'assets'>): ReactElement => {
     const assetslength = assets.length;
     const previewAssets = assets.slice(0, 4);
 

--- a/src/components/AssetInput/SingleAsset/AssetSubline.tsx
+++ b/src/components/AssetInput/SingleAsset/AssetSubline.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { AssetInputProps } from '../AssetInput';
 import { SelectedAssetProps } from './SelectedAsset';
 import { IconArrowCircleUp, IconImageStack } from '@foundation/Icon/Generated';
@@ -8,12 +8,12 @@ import { IconArrowCircleUp, IconImageStack } from '@foundation/Icon/Generated';
 type AssetSublineProps = Pick<AssetInputProps, 'isLoading' | 'hideSize' | 'hideExtension'> &
     Pick<SelectedAssetProps, 'asset'>;
 
-export const AssetSubline: FC<AssetSublineProps> = ({
+export const AssetSubline = ({
     asset,
     isLoading = false,
     hideSize = false,
     hideExtension = false,
-}) => {
+}: AssetSublineProps): ReactElement => {
     let title = isLoading ? 'Uploading' : 'Uploaded';
     if (asset?.source === 'library') {
         title = asset.sourceName;
@@ -36,7 +36,7 @@ export const AssetSubline: FC<AssetSublineProps> = ({
 };
 AssetSubline.displayName = 'FondueAssetSubline';
 
-const FileInfo: FC<{ label?: string | number; hide: boolean }> = ({ label, hide }) => {
+const FileInfo = ({ label, hide }: { label?: string | number; hide: boolean }): Nullable<ReactElement> => {
     if (hide || !label) {
         return null;
     }

--- a/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -13,7 +13,7 @@ import { useMenuTriggerState } from '@react-stately/menu';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import { AssetInputProps, AssetInputSize, AssetType } from '../AssetInput';
 import { AssetThumbnail } from '../AssetThumbnail';
 import { AssetSubline } from './AssetSubline';
@@ -26,10 +26,15 @@ export type SelectedAssetProps = Pick<
     asset: AssetType;
 };
 
-export const SelectedAsset: FC<
-    Required<Omit<SelectedAssetProps, 'hideSize' | 'hideExtension'>> &
-        Pick<SelectedAssetProps, 'hideSize' | 'hideExtension'>
-> = ({ asset, size, actions, isLoading, hideSize = false, hideExtension = false }) => {
+export const SelectedAsset = ({
+    asset,
+    size,
+    actions,
+    isLoading,
+    hideSize = false,
+    hideExtension = false,
+}: Required<Omit<SelectedAssetProps, 'hideSize' | 'hideExtension'>> &
+    Pick<SelectedAssetProps, 'hideSize' | 'hideExtension'>): ReactElement => {
     const menuId = useMemoizedId();
     const labelId = useMemoizedId();
     const buttonRef = useRef<HTMLButtonElement | null>(null);

--- a/src/components/AssetInput/SingleAsset/SpinningCircle.tsx
+++ b/src/components/AssetInput/SingleAsset/SpinningCircle.tsx
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { AssetInputProps, AssetInputSize } from '..';
 
-export const SpinningCircle: FC<Pick<AssetInputProps, 'size'>> = ({ size }) => (
+export const SpinningCircle = ({ size }: Pick<AssetInputProps, 'size'>): ReactElement => (
     <svg
         className={merge(['tw-animate-spin', size === AssetInputSize.Large ? 'tw-w-16 tw-h-16' : 'tw-w-5 tw-h-5'])}
         width="100%"

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -4,12 +4,12 @@ import { IconCross } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, ReactNode, cloneElement } from 'react';
+import React, { ReactElement, ReactNode, cloneElement } from 'react';
 import { BadgeStatusIcon } from './BadgeStatusIcon';
 import { getCircularSizeClasses, getSizeClasses, getStyleClasses } from './helpers';
 import { BadgeEmphasis, BadgeProps, BadgeStyle } from './types';
 
-export const Badge: FC<BadgeProps> = ({
+export const Badge = ({
     children,
     status,
     icon,
@@ -19,7 +19,7 @@ export const Badge: FC<BadgeProps> = ({
     disabled = false,
     onClick,
     onDismiss,
-}) => {
+}: BadgeProps): Nullable<ReactElement> => {
     if (!children && !icon && !status) {
         return null;
     }

--- a/src/components/Badge/types.ts
+++ b/src/components/Badge/types.ts
@@ -1,12 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconProps } from '@foundation/Icon/IconProps';
-import { PropsWithChildren, ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { Color } from '../../types';
 
 export type BadgeSize = 'small' | 'medium';
 
-export type BadgeProps = PropsWithChildren<{
+export type BadgeProps = {
     style?: BadgeStyle;
     icon?: ReactElement<IconProps>;
     status?: BadgeStatusIconProps['status'];
@@ -15,7 +15,8 @@ export type BadgeProps = PropsWithChildren<{
     disabled?: boolean;
     emphasis?: BadgeEmphasis;
     size?: BadgeSize;
-}>;
+    children?: ReactNode;
+};
 
 export type BadgeStatusIconProps = { status: BadgeStatus | Color | string; disabled: boolean };
 

--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -6,7 +6,7 @@ import { mergeProps } from '@react-aria/utils';
 import { getItemElementType } from '@utilities/elements';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, RefObject, useRef } from 'react';
+import React, { RefObject, useRef } from 'react';
 import { Breadcrumb } from './Breadcrumbs';
 
 const Separator = () => (

--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -6,7 +6,7 @@ import { mergeProps } from '@react-aria/utils';
 import { getItemElementType } from '@utilities/elements';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { RefObject, useRef } from 'react';
+import React, { ReactElement, RefObject, useRef } from 'react';
 import { Breadcrumb } from './Breadcrumbs';
 
 const Separator = () => (
@@ -27,7 +27,7 @@ type BreadcrumbItemProps = Pick<Breadcrumb, 'label' | 'link' | 'onClick'> & {
     showSeparator: boolean;
 };
 
-export const BreadcrumbItem: FC<BreadcrumbItemProps> = ({ label, link, onClick, showSeparator }) => {
+export const BreadcrumbItem = ({ label, link, onClick, showSeparator }: BreadcrumbItemProps): ReactElement => {
     const ref = useRef<HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null>(null);
 
     const contentElementType = getItemElementType(link, onClick);

--- a/src/components/Breadcrumbs/Breadcrumbs.cy.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.cy.tsx
@@ -20,16 +20,19 @@ const BREADCRUMB_ITEMS_MIXED_ELEMENTS = [
     { label: 'item with link', link: '/some-third-link' },
 ];
 
-const ChangingBreadcrumbs = ({}: BreadcrumbsProps): ReactElement => {
-    const [items, setItems] = useState(BREADCRUMB_ITEMS);
+const ChangingBreadcrumbs = ({ items }: BreadcrumbsProps): ReactElement => {
+    const [breadcrumbItems, setBreadcrumbItems] = useState(items);
 
     return (
         <div>
-            <Breadcrumbs items={items} />
+            <Breadcrumbs items={breadcrumbItems} />
             <button
                 data-test-id="add-item-button"
                 onClick={() => {
-                    setItems(() => [...items, { label: 'Some fourth label', link: '/some-fourth-link' }]);
+                    setBreadcrumbItems(() => [
+                        ...breadcrumbItems,
+                        { label: 'Some fourth label', link: '/some-fourth-link' },
+                    ]);
                 }}
             >
                 Add Block

--- a/src/components/Breadcrumbs/Breadcrumbs.cy.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { BreadcrumbsProps } from '.';
 import { Breadcrumbs } from './Breadcrumbs';
 
@@ -20,7 +20,7 @@ const BREADCRUMB_ITEMS_MIXED_ELEMENTS = [
     { label: 'item with link', link: '/some-third-link' },
 ];
 
-const ChangingBreadcrumbs: FC<BreadcrumbsProps> = () => {
+const ChangingBreadcrumbs = ({}: BreadcrumbsProps): ReactElement => {
     const [items, setItems] = useState(BREADCRUMB_ITEMS);
 
     return (

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -3,7 +3,7 @@
 import { BadgeProps } from '@components/Badge';
 import { IconProps } from '@foundation/Icon/IconProps';
 import { AriaBreadcrumbsProps, useBreadcrumbs } from '@react-aria/breadcrumbs';
-import React, { FC, MouseEvent, ReactElement } from 'react';
+import React, { MouseEvent, ReactElement } from 'react';
 import { BreadcrumbItem } from './BreadcrumbItem';
 import { CurrentBreadcrumbItem } from './CurrentBreadcrumbItem';
 
@@ -28,7 +28,7 @@ export type BreadcrumbsProps = {
     items: Breadcrumb[];
 };
 
-export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items }) => {
+export const Breadcrumbs = ({ items }: BreadcrumbsProps): ReactElement => {
     const props = mapBreadcrumbsToAriaProps(items);
     const { navProps } = useBreadcrumbs(props as AriaBreadcrumbsProps);
 

--- a/src/components/Breadcrumbs/CurrentBreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/CurrentBreadcrumbItem.tsx
@@ -6,11 +6,11 @@ import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, RefObject, useRef } from 'react';
+import React, { ReactElement, ReactNode, RefObject, useRef } from 'react';
 import { Breadcrumb } from './Breadcrumbs';
 import { getItemElementType } from '@utilities/elements';
 
-const ItemWithBadges: FC<{ badges?: BadgeProps[] }> = ({ badges, children }) => (
+const ItemWithBadges = ({ badges, children }: { badges?: BadgeProps[]; children: ReactNode }): ReactElement => (
     <span className="tw-inline-flex tw-gap-x-2 tw-items-center">
         {children}
 
@@ -24,14 +24,14 @@ const ItemWithBadges: FC<{ badges?: BadgeProps[] }> = ({ badges, children }) => 
 
 type CurrentBreadcrumbItemProps = Breadcrumb;
 
-export const CurrentBreadcrumbItem: FC<CurrentBreadcrumbItemProps> = ({
+export const CurrentBreadcrumbItem = ({
     label,
     badges,
     bold,
     decorator,
     link,
     onClick,
-}) => {
+}: CurrentBreadcrumbItemProps): ReactElement => {
     const ref = useRef<HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null>(null);
     const contentElementType = getItemElementType(link, onClick);
     const { itemProps } = useBreadcrumbItem(

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { Children, PropsWithChildren, ReactElement, cloneElement, isValidElement } from 'react';
+import React, { Children, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
 import { ButtonProps, ButtonSize } from '@components/Button';
 import { merge } from '@utilities/merge';
 
-export type ButtonGroupProps = PropsWithChildren<{ size: ButtonSize }>;
+export type ButtonGroupProps = { size: ButtonSize; children?: ReactNode };
 
 const spacing: Record<ButtonSize, string> = {
     [ButtonSize.Small]: 'tw-gap-x-1',

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { Children, FC, PropsWithChildren, ReactElement, cloneElement, isValidElement } from 'react';
+import React, { Children, PropsWithChildren, ReactElement, cloneElement, isValidElement } from 'react';
 import { ButtonProps, ButtonSize } from '@components/Button';
 import { merge } from '@utilities/merge';
 
@@ -12,7 +12,7 @@ const spacing: Record<ButtonSize, string> = {
     [ButtonSize.Large]: 'tw-gap-x-3',
 };
 
-export const ButtonGroup: FC<ButtonGroupProps> = ({ children, size }) => {
+export const ButtonGroup = ({ children, size }: ButtonGroupProps): ReactElement => {
     return (
         <div data-test-id="button-group" className={merge(['tw-display tw-inline-flex tw-flex-row', spacing[size]])}>
             {Children.map(children, (child) => {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,7 +2,7 @@
 
 import { useButton } from '@react-aria/button';
 import { merge } from '@utilities/merge';
-import React, { FC, ReactNode, useRef } from 'react';
+import React, { ReactElement, ReactNode, useRef } from 'react';
 import { PressEvent } from '@react-types/shared';
 import { mergeProps } from '@react-aria/utils';
 import { useFocusRing } from '@react-aria/focus';
@@ -14,7 +14,7 @@ export type CardProps = {
     onClick?: (event: PressEvent) => void;
 };
 
-export const Card: FC<CardProps> = ({ hoverable = false, children, onClick }) => {
+export const Card = ({ hoverable = false, children, onClick }: CardProps): ReactElement => {
     const ref = useRef<HTMLDivElement | null>(null);
     const { buttonProps } = useButton(
         { elementType: 'div', onPress: (event: PressEvent) => onClick && onClick(event) },

--- a/src/components/Checkbox/Checkbox.cy.tsx
+++ b/src/components/Checkbox/Checkbox.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Checkbox, CheckboxProps, CheckboxSize, CheckboxState } from './Checkbox';
 
 const CHECKBOX_LABEL = 'Checkbox label';
@@ -15,7 +15,7 @@ const CHECKBOX_HELPER_TEXT_ID = '[data-test-id=checkbox-helper-text]';
 const CHECKBOX_ICON_BOX_ID = '[data-test-id=checkbox-icon-box]';
 const CHECKBOX_LABEL_ID = '[data-test-id=checkbox-label]';
 
-const CheckboxComponent: FC<CheckboxProps> = (props) => {
+const CheckboxComponent = (props: CheckboxProps): ReactElement => {
     const [checked, setChecked] = useState(props.state);
 
     return (

--- a/src/components/Checklist/Checklist.cy.tsx
+++ b/src/components/Checklist/Checklist.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { CheckboxState } from '@components/Checkbox/Checkbox';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Checklist, ChecklistDirection, Columns } from './Checklist';
 
 const CHECKBOXES = [
@@ -24,7 +24,7 @@ const CHECKBOXES = [
 
 const CHECKLIST_ID = '[data-test-id=checklist]';
 
-const Component: FC<{ direction: ChecklistDirection; columns?: Columns }> = ({ direction, columns }) => {
+const Component = ({ direction, columns }: { direction: ChecklistDirection; columns?: Columns }): ReactElement => {
     const [activeBoxes, setActiveBoxes] = useState<string[]>([]);
 
     return direction === ChecklistDirection.Horizontal ? (

--- a/src/components/CollapsibleWrap/CollapsibleWrap.cy.tsx
+++ b/src/components/CollapsibleWrap/CollapsibleWrap.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Button } from '@components/Button';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { CollapsibleWrap as CollapsibleWrapComponent } from './CollapsibleWrap';
 import { CollapsibleWrapProps } from './types';
 
@@ -9,11 +9,11 @@ const CONTENT_ID = '[data-test-id="collapsible-wrap-content"]';
 const WRAP_ID = '[data-test-id="collapsible-wrap"]';
 const BUTTON_ID = '[data-test-id="button"]';
 
-const CollapsibleWrap: FC<Partial<CollapsibleWrapProps>> = ({
+const CollapsibleWrap = ({
     preventInitialAnimation = false,
     isOpen: externalIsOpen = false,
     animateOpacity = true,
-}) => {
+}: Partial<CollapsibleWrapProps>): ReactElement => {
     const [isOpen, setIsOpen] = useState(externalIsOpen);
     return (
         <>

--- a/src/components/CollapsibleWrap/CollapsibleWrap.tsx
+++ b/src/components/CollapsibleWrap/CollapsibleWrap.tsx
@@ -1,15 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { CollapsibleWrapProps } from './types';
 
-export const CollapsibleWrap: FC<CollapsibleWrapProps> = ({
+export const CollapsibleWrap = ({
     children,
     isOpen = false,
     preventInitialAnimation = false,
     animateOpacity = true,
-}) => (
+}: CollapsibleWrapProps): ReactElement => (
     <AnimatePresence initial={preventInitialAnimation ? false : undefined}>
         {isOpen && children && (
             <motion.div

--- a/src/components/CollapsibleWrap/types.ts
+++ b/src/components/CollapsibleWrap/types.ts
@@ -1,7 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ReactNode } from 'react';
+
 export type CollapsibleWrapProps = {
     isOpen: boolean;
     preventInitialAnimation?: boolean;
     animateOpacity?: boolean;
+    children?: ReactNode;
 };

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getColorDisplayValue, toShortRgb } from '@utilities/colors';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import tinycolor from 'tinycolor2';
 import { Color, ColorFormat } from '../../types/colors';
 
@@ -10,7 +10,7 @@ type Props = {
     format: ColorFormat;
 };
 
-export const ColorInputTitle: FC<Props> = ({ currentColor, format }) => {
+export const ColorInputTitle = ({ currentColor, format }: Props): ReactElement => {
     const { name, alpha } = currentColor;
     const parsedColor = tinycolor(toShortRgb(currentColor));
     const colorValue = getColorDisplayValue(currentColor, format, false);

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.cy.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.cy.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import type { Color, Palette } from '../../types/colors';
 import { EXAMPLE_PALETTES } from '../ColorPicker/example-palettes';
 import { ColorPickerFlyout } from './ColorPickerFlyout';
@@ -17,11 +17,11 @@ const CLEAR_BUTTON_ID = '[data-test-id=dropdown-clear-button]';
 
 type Props = {
     palettes?: Palette[];
-    currentColor?: Color;
+    currentColor?: Nullable<Color>;
     clearable?: boolean;
 };
 
-const Component: FC<Props> = ({ palettes, currentColor = null, clearable = false }) => {
+const Component = ({ palettes, currentColor = null, clearable = false }: Props): ReactElement => {
     const [temporaryColor, setTemporaryColor] = useState<Color | null>(null);
     const [selectedColor, setSelectedColor] = useState<Color | null>(currentColor);
 

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -3,7 +3,7 @@
 import { ColorPreview } from '@components/ColorPicker';
 import { ColorPicker, ColorPickerProps } from '@components/ColorPicker/ColorPicker';
 import { Flyout } from '@components/Flyout/Flyout';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Color, ColorFormat } from '../../types/colors';
 import { ColorInputTrigger } from './ColorPickerTrigger';
 
@@ -18,7 +18,7 @@ export type ColorPickerFlyoutProps = Pick<ColorPickerProps, 'palettes' | 'onSele
     onDelete?: () => void;
 };
 
-export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
+export const ColorPickerFlyout = ({
     id,
     onClick,
     onClose,
@@ -29,7 +29,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
     clearable = false,
     onClear,
     onDelete,
-}) => {
+}: ColorPickerFlyoutProps): ReactElement => {
     const [open, setOpen] = useState(false);
     const [currentFormat, setCurrentFormat] = useState(ColorFormat.Hex);
 

--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -8,7 +8,7 @@ import { useMemoizedId } from '@hooks/useMemoizedId';
 import { useFocusRing } from '@react-aria/focus';
 import { toShortRgb } from '@utilities/colors';
 import { merge } from '@utilities/merge';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import tinycolor from 'tinycolor2';
 import { ColorFormat } from '../../types/colors';
 import { ColorInputTitle } from './ColorInputTitle';
@@ -22,7 +22,7 @@ type ColorInputTriggerProps = Pick<ColorPickerFlyoutProps, 'id' | 'currentColor'
     onDelete?: () => void;
 };
 
-export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
+export const ColorInputTrigger = ({
     id,
     currentColor,
     format,
@@ -31,7 +31,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
     clearable = false,
     onClear,
     onDelete,
-}) => {
+}: ColorInputTriggerProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
     const backgroundColor = currentColor ? tinycolor(toShortRgb(currentColor)).toRgbString() : '';
 

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -6,7 +6,7 @@ import { IconCheckMark, IconGridRegular, IconMagnifier, IconStackVertical } from
 import { IconSize } from '@foundation/Icon/IconSize';
 import { isColorLight, toShortRgb } from '@utilities/colors';
 import { merge } from '@utilities/merge';
-import React, { FC, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import tinycolor from 'tinycolor2';
 import { ColorPickerProps } from './ColorPicker';
 
@@ -20,7 +20,7 @@ enum BrandColorView {
 
 type Props = Omit<ColorPickerProps, 'currentFormat' | 'setFormat'>;
 
-export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], currentColor, onSelect }) => {
+export const BrandColorPicker = ({ palettes: defaultPalettes = [], currentColor, onSelect }: Props): ReactElement => {
     const views = [
         { id: BrandColorView.Grid, icon: <IconGridRegular />, ariaLabel: 'Grid' },
         { id: BrandColorView.List, icon: <IconStackVertical />, ariaLabel: 'List' },

--- a/src/components/ColorPicker/ColorInput.tsx
+++ b/src/components/ColorPicker/ColorInput.tsx
@@ -5,7 +5,7 @@ import { useMemoizedId } from '@hooks/useMemoizedId';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, KeyboardEvent, useRef } from 'react';
+import React, { KeyboardEvent, ReactElement, useRef } from 'react';
 
 export type ColorInputProps = { min?: number; max?: number; decoratorPosition?: DecoratorPosition } & Pick<
     TextInputBaseProps,
@@ -17,7 +17,7 @@ export enum DecoratorPosition {
     Right = 'Right',
 }
 
-export const ColorInput: FC<ColorInputProps> = ({
+export const ColorInput = ({
     min,
     max,
     decorator,
@@ -28,7 +28,7 @@ export const ColorInput: FC<ColorInputProps> = ({
     value = '',
     decoratorPosition = DecoratorPosition.Left,
     type = TextInputType.Text,
-}) => {
+}: ColorInputProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing({ within: true, isTextInput: true });
     const inputElement = useRef<HTMLInputElement | null>(null);
     const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/ColorPicker/ColorPreview.tsx
+++ b/src/components/ColorPicker/ColorPreview.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { toShortRgb } from '@utilities/colors';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import tinycolor from 'tinycolor2';
 import { Color } from '../../types/colors';
 
@@ -9,7 +9,7 @@ type ColorPreviewProps = {
     color: Color;
 };
 
-export const ColorPreview: FC<ColorPreviewProps> = ({ color }) => {
+export const ColorPreview = ({ color }: ColorPreviewProps): ReactElement => {
     const parsedColor = tinycolor(toShortRgb(color));
     const backgroundColor = parsedColor.toRgbString();
 

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -3,7 +3,7 @@
 import { Dropdown } from '@components/Dropdown/Dropdown';
 import { TextInputType } from '@components/TextInput/TextInput';
 import { toLongRgb, toShortRgb } from '@utilities/colors';
-import React, { FC, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { RgbaColorPicker } from 'react-colorful';
 import tinycolor from 'tinycolor2';
 import { Color, ColorFormat } from '../../types';
@@ -12,12 +12,12 @@ import { ColorPickerProps } from './ColorPicker';
 
 const convertToHex = (color: Color) => tinycolor(toShortRgb(color)).toHex();
 
-export const CustomColorPicker: FC<Omit<ColorPickerProps, 'palette'>> = ({
+export const CustomColorPicker = ({
     currentColor,
     currentFormat,
     setFormat,
     onSelect,
-}) => {
+}: Omit<ColorPickerProps, 'palette'>): ReactElement => {
     const formatMenuBlock = [
         {
             id: 'color-picker-format-dropdown-block',

--- a/src/components/DatePicker/DatePickerTrigger.tsx
+++ b/src/components/DatePicker/DatePickerTrigger.tsx
@@ -5,9 +5,9 @@ import { IconCalendar } from '@foundation/Icon/Generated';
 import { IconCaretDown, IconCaretUp, IconSize } from '@foundation/Icon/index';
 import { merge } from '@utilities/merge';
 import { Validation } from '@utilities/validation';
-import React, { PropsWithChildren, forwardRef } from 'react';
+import React, { ReactNode, forwardRef } from 'react';
 
-type DatePickerTriggerProps = PropsWithChildren<{
+type DatePickerTriggerProps = {
     placeHolder?: string;
     value?: string;
     isClearable?: boolean;
@@ -15,7 +15,8 @@ type DatePickerTriggerProps = PropsWithChildren<{
     onClick?: () => void;
     validation?: Validation;
     onDateChanged?: ((date: [Date | null, Date | null] | null) => void) | ((date: Date | null) => void);
-}>;
+    children?: ReactNode;
+};
 
 export const DatePickerTrigger = forwardRef<HTMLDivElement, DatePickerTriggerProps>(
     (

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 
 export enum DividerStyle {
     NoLine = 'noline',
@@ -28,11 +28,11 @@ const styleMap = {
     [DividerStyle.Dotted]: 'tw-border-dotted',
 };
 
-export const Divider: FC<DividerProps> = ({
+export const Divider = ({
     style = DividerStyle.Solid,
     height = DividerHeight.Small,
     color: borderTopColor = '#CCC',
-}) => (
+}: DividerProps): ReactElement => (
     <div className="tw-flex tw-items-center" style={{ height }} data-test-id="divider">
         <hr
             className={`tw-border-t tw-m-0 tw-w-full ${styleMap[style]}`}

--- a/src/components/Dropdown/Dropdown.cy.tsx
+++ b/src/components/Dropdown/Dropdown.cy.tsx
@@ -5,7 +5,7 @@ import { MenuItemContentSize } from '@components/MenuItem';
 import { IconIcon } from '@foundation/Icon/Generated';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { Validation } from '@utilities/validation';
-import React, { FC, ReactElement, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Dropdown } from './Dropdown';
 
 const DROPDOWN_TRIGGER_ID = '[data-test-id=dropdown-trigger]';

--- a/src/components/Dropdown/Dropdown.cy.tsx
+++ b/src/components/Dropdown/Dropdown.cy.tsx
@@ -65,7 +65,7 @@ type Props = {
     validation?: Validation;
 };
 
-const Component: FC<Props> = ({
+const Component = ({
     menuBlocks,
     placeholder,
     initialActiveId,
@@ -74,7 +74,7 @@ const Component: FC<Props> = ({
     decorator,
     autoResize = true,
     validation = Validation.Default,
-}) => {
+}: Props): ReactElement => {
     const [activeItemId, setActiveItemId] = useState(initialActiveId);
     return (
         <Dropdown

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -21,7 +21,7 @@ import { mergeProps } from '@react-aria/utils';
 import { useSelectState } from '@react-stately/select';
 import { merge } from '@utilities/merge';
 import { Validation } from '@utilities/validation';
-import React, { FC, ReactElement, useEffect, useRef } from 'react';
+import React, { ReactElement, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 import { DEFAULT_DROPDOWN_MAX_HEIGHT, useDropdownAutoHeight } from './useDropdownAutoHeight';
@@ -76,7 +76,7 @@ const getActiveItem = (blocks: MenuBlock[], activeId: string | number): MenuItem
     );
 };
 
-export const Dropdown: FC<DropdownProps> = ({
+export const Dropdown = ({
     id: propId,
     menuBlocks,
     onChange,
@@ -93,7 +93,7 @@ export const Dropdown: FC<DropdownProps> = ({
     position = DropdownPosition.Bottom,
     emphasis = TriggerEmphasis.Default,
     flip = false,
-}) => {
+}: DropdownProps): ReactElement => {
     const activeItem = !!activeItemId ? getActiveItem(menuBlocks, activeItemId) : null;
     const props = mapToAriaProps(ariaLabel, menuBlocks);
     const state = useSelectState({

--- a/src/components/Dropdown/SelectMenu/SelectMenuItem.tsx
+++ b/src/components/Dropdown/SelectMenu/SelectMenuItem.tsx
@@ -7,7 +7,7 @@ import { ListState } from '@react-stately/list';
 import { Node } from '@react-types/shared';
 import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 import { MenuItem } from '../../MenuItem';
 import { MenuItemType } from './SelectMenu';
 
@@ -17,7 +17,7 @@ type SelectMenuItemProps = {
     node: Node<object>;
 };
 
-export const SelectMenuItem: FC<SelectMenuItemProps> = ({ state, menuItem, node }) => {
+export const SelectMenuItem = ({ state, menuItem, node }: SelectMenuItemProps): ReactElement => {
     const ref = useRef<HTMLLIElement | null>(null);
     const { optionProps, isSelected } = useOption(
         {

--- a/src/components/Dropdown/SelectMenu/SelectMenuSection.tsx
+++ b/src/components/Dropdown/SelectMenu/SelectMenuSection.tsx
@@ -1,13 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useListBoxSection } from '@react-aria/listbox';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactElement } from 'react';
 
 type SelectMenuSectionProps = PropsWithChildren<{
     ariaLabel?: string;
 }>;
 
-export const SelectMenuSection: FC<SelectMenuSectionProps> = ({ ariaLabel, children }) => {
+export const SelectMenuSection = ({ ariaLabel, children }: SelectMenuSectionProps): ReactElement => {
     const { itemProps, groupProps } = useListBoxSection({ 'aria-label': ariaLabel });
 
     return (

--- a/src/components/Dropdown/SelectMenu/SelectMenuSection.tsx
+++ b/src/components/Dropdown/SelectMenu/SelectMenuSection.tsx
@@ -1,11 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useListBoxSection } from '@react-aria/listbox';
-import React, { PropsWithChildren, ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
-type SelectMenuSectionProps = PropsWithChildren<{
+type SelectMenuSectionProps = {
     ariaLabel?: string;
-}>;
+    children?: ReactNode;
+};
 
 export const SelectMenuSection = ({ ariaLabel, children }: SelectMenuSectionProps): ReactElement => {
     const { itemProps, groupProps } = useListBoxSection({ 'aria-label': ariaLabel });

--- a/src/components/FieldsetHeader/FieldsetHeader.tsx
+++ b/src/components/FieldsetHeader/FieldsetHeader.tsx
@@ -3,7 +3,7 @@
 import { Switch, SwitchSize } from '@components/Switch/Switch';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { merge } from '@utilities/merge';
-import React, { FC, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
+import React, { ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
 import { IconCaretDown, IconMinus, IconPlus } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { IconProps } from '@foundation/Icon';
@@ -112,7 +112,7 @@ export const renderFieldsetHeaderIconType = (
     return null;
 };
 
-export const FieldsetHeader: FC<FieldsetHeaderProps> = ({
+export const FieldsetHeader = ({
     size = FieldsetHeaderSize.Large,
     active = true,
     decorator,
@@ -123,7 +123,7 @@ export const FieldsetHeader: FC<FieldsetHeaderProps> = ({
     onClick,
     as: Heading = 'label',
     tabIndex = -1,
-}) => {
+}: FieldsetHeaderProps): ReactElement => {
     const id = useMemoizedId();
     const clickOnNotDisabled = () => !disabled && onClick && onClick();
 

--- a/src/components/Flyout/Flyout.cy.tsx
+++ b/src/components/Flyout/Flyout.cy.tsx
@@ -2,7 +2,7 @@
 
 import { ButtonEmphasis, ButtonStyle } from '@components/Button';
 import { TextInput } from '@components/TextInput/TextInput';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Flyout, FlyoutProps } from './Flyout';
 import { FlyoutFooter } from './FlyoutFooter';
 
@@ -12,12 +12,12 @@ const BUTTON_ID = '[data-test-id=button]';
 const FIELDSET_HEADER_ID = '[data-test-id=fieldset-header]';
 const TEXT_INPUT_ID = '[data-test-id=text-input]';
 
-const Component: FC<Pick<FlyoutProps, 'onConfirm' | 'onCancel' | 'badges' | 'legacyFooter'>> = ({
+const Component = ({
     onConfirm,
     onCancel,
     badges,
     legacyFooter,
-}) => {
+}: Pick<FlyoutProps, 'onConfirm' | 'onCancel' | 'badges' | 'legacyFooter'>): ReactElement => {
     const [open, setOpen] = useState(false);
     return (
         <Flyout

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -9,16 +9,7 @@ import { mergeProps } from '@react-aria/utils';
 import { useOverlayTriggerState } from '@react-stately/overlays';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, {
-    HTMLAttributes,
-    MouseEvent,
-    MutableRefObject,
-    PropsWithChildren,
-    ReactElement,
-    ReactNode,
-    useEffect,
-    useRef,
-} from 'react';
+import React, { HTMLAttributes, MouseEvent, MutableRefObject, ReactElement, ReactNode, useEffect, useRef } from 'react';
 import { LegacyFlyoutFooter } from '.';
 import { useContainScroll } from './hooks/useContainScroll';
 import { useOverlayPositionWithBottomMargin } from './hooks/useOverlayPositionWithBottomMargin';
@@ -38,7 +29,7 @@ export enum FlyoutPlacement {
     Left = 'left',
 }
 
-export type FlyoutProps = PropsWithChildren<{
+export type FlyoutProps = {
     trigger:
         | ReactNode
         | ((
@@ -67,7 +58,8 @@ export type FlyoutProps = PropsWithChildren<{
     offset?: number;
     updatePositionOnContentChange?: boolean;
     isTriggerDisabled?: boolean;
-}>;
+    children?: ReactNode;
+};
 
 export const Flyout = ({
     trigger,

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -10,11 +10,11 @@ import { useOverlayTriggerState } from '@react-stately/overlays';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import React, {
-    FC,
     HTMLAttributes,
     MouseEvent,
     MutableRefObject,
     PropsWithChildren,
+    ReactElement,
     ReactNode,
     useEffect,
     useRef,
@@ -69,7 +69,7 @@ export type FlyoutProps = PropsWithChildren<{
     isTriggerDisabled?: boolean;
 }>;
 
-export const Flyout: FC<FlyoutProps> = ({
+export const Flyout = ({
     trigger,
     isTriggerDisabled = false,
     decorator,
@@ -89,7 +89,7 @@ export const Flyout: FC<FlyoutProps> = ({
     placement = FlyoutPlacement.BottomLeft,
     offset,
     updatePositionOnContentChange = false,
-}) => {
+}: FlyoutProps): ReactElement => {
     const state = useOverlayTriggerState({ isOpen, onOpenChange });
     const { toggle, close } = state;
     const triggerRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/Flyout/FlyoutFooter.tsx
+++ b/src/components/Flyout/FlyoutFooter.tsx
@@ -3,14 +3,15 @@
 import { Button, ButtonEmphasis, ButtonProps, ButtonSize, ButtonStyle } from '@components/Button';
 import { IconCheckMark } from '@foundation/Icon/Generated';
 import { merge } from '@utilities/merge';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
-export type FlyoutFooterProps = PropsWithChildren<{
+export type FlyoutFooterProps = {
     buttons: [ButtonProps, ButtonProps] | [ButtonProps];
     border?: boolean;
-}>;
+    children?: ReactNode;
+};
 
-export const FlyoutFooter: FC<FlyoutFooterProps> = ({ buttons, border = true }) => {
+export const FlyoutFooter = ({ buttons, border = true }: FlyoutFooterProps): ReactElement => {
     return (
         <div
             className={merge([
@@ -30,7 +31,13 @@ export const FlyoutFooter: FC<FlyoutFooterProps> = ({ buttons, border = true }) 
 };
 FlyoutFooter.displayName = 'FondueFlyoutFooter';
 
-export const LegacyFlyoutFooter = ({ onConfirm, onCancel }: { onConfirm?: () => void; onCancel?: () => void }) => (
+export const LegacyFlyoutFooter = ({
+    onConfirm,
+    onCancel,
+}: {
+    onConfirm?: () => void;
+    onCancel?: () => void;
+}): ReactElement => (
     <FlyoutFooter
         buttons={
             onConfirm

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -3,7 +3,7 @@
 import { InputLabel, InputLabelProps } from '@components/InputLabel/InputLabel';
 import { merge } from '@utilities/merge';
 import { Validation } from '@utilities/validation';
-import React, { FC, PropsWithChildren, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
+import React, { PropsWithChildren, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
 
 export enum FormControlStyle {
     Primary = 'Primary',
@@ -24,7 +24,7 @@ const inputValidation: Record<FormControlStyle, Validation> = {
     [FormControlStyle.Danger]: Validation.Error,
 };
 
-const HelperText: FC<HelperTextProps> = ({ text, disabled, style, fullWidth = false }) => {
+const HelperText = ({ text, disabled, style, fullWidth = false }: HelperTextProps): ReactElement => {
     let textColorClass;
 
     switch (true) {
@@ -74,7 +74,7 @@ export type FormControlProps = PropsWithChildren<{
     name?: string;
 }>;
 
-export const FormControl: FC<FormControlProps> = ({
+export const FormControl = ({
     label,
     children,
     extra,
@@ -84,7 +84,7 @@ export const FormControl: FC<FormControlProps> = ({
     clickable,
     direction = FormControlDirection.Vertical,
     style = FormControlStyle.Primary,
-}) => {
+}: FormControlProps): ReactElement => {
     const isHelperBefore = helper?.position === HelperPosition.Before;
 
     return (

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -3,7 +3,7 @@
 import { InputLabel, InputLabelProps } from '@components/InputLabel/InputLabel';
 import { merge } from '@utilities/merge';
 import { Validation } from '@utilities/validation';
-import React, { PropsWithChildren, ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
+import React, { ReactElement, ReactNode, cloneElement, isValidElement } from 'react';
 
 export enum FormControlStyle {
     Primary = 'Primary',
@@ -63,7 +63,7 @@ export enum FormControlDirection {
     Vertical = 'Vertical',
 }
 
-export type FormControlProps = PropsWithChildren<{
+export type FormControlProps = {
     direction?: FormControlDirection;
     disabled?: boolean;
     clickable?: boolean;
@@ -72,7 +72,8 @@ export type FormControlProps = PropsWithChildren<{
     helper?: Omit<HelperTextProps, 'disabled' | 'style'> & { position?: HelperPosition };
     style?: FormControlStyle;
     name?: string;
-}>;
+    children?: ReactNode;
+};
 
 export const FormControl = ({
     label,

--- a/src/components/FrontifyPattern/FrontifyPattern.tsx
+++ b/src/components/FrontifyPattern/FrontifyPattern.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, cloneElement } from 'react';
+import React, { ReactElement, cloneElement } from 'react';
 import { merge } from '@utilities/merge';
 import {
     PatternDesign,
@@ -19,12 +19,12 @@ export type FrontifyPatternProps = {
     foregroundColor?: PatternTheme;
 };
 
-export const FrontifyPattern: FC<FrontifyPatternProps> = ({
+export const FrontifyPattern = ({
     pattern = PatternDesign.DigitalAssets,
     scale = PatternScale.SM,
     scaleOrigin = ['top', 'left'],
     foregroundColor = PatternTheme.Black,
-}) => {
+}: FrontifyPatternProps): ReactElement => {
     return (
         <div
             data-test-id="frontify-pattern"

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -4,7 +4,7 @@ import { TooltipProps } from '@components/Tooltip/Tooltip';
 import { TooltipIcon, TooltipIconProps } from '@components/TooltipIcon/TooltipIcon';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { merge } from '@utilities/merge';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactElement } from 'react';
 
 export type InputLabelTooltipProps =
     | (TooltipProps & Pick<TooltipIconProps, 'triggerStyle' | 'triggerIcon'>)
@@ -19,7 +19,7 @@ export type InputLabelProps = PropsWithChildren<{
     bold?: boolean;
 }>;
 
-export const InputLabel: FC<InputLabelProps> = ({
+export const InputLabel = ({
     children,
     htmlFor,
     required = false,
@@ -27,7 +27,7 @@ export const InputLabel: FC<InputLabelProps> = ({
     clickable = false,
     tooltip = [],
     bold,
-}) => {
+}: InputLabelProps): ReactElement => {
     const tooltips = Array.isArray(tooltip) ? tooltip : [tooltip];
 
     const tooltipsWithKeys = tooltips.map((tooltip, index) => ({

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -4,20 +4,21 @@ import { TooltipProps } from '@components/Tooltip/Tooltip';
 import { TooltipIcon, TooltipIconProps } from '@components/TooltipIcon/TooltipIcon';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { merge } from '@utilities/merge';
-import React, { PropsWithChildren, ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 export type InputLabelTooltipProps =
     | (TooltipProps & Pick<TooltipIconProps, 'triggerStyle' | 'triggerIcon'>)
     | (TooltipProps & Pick<TooltipIconProps, 'triggerStyle' | 'triggerIcon'>)[];
 
-export type InputLabelProps = PropsWithChildren<{
+export type InputLabelProps = {
     htmlFor: string;
     required?: boolean;
     disabled?: boolean;
     clickable?: boolean;
     tooltip?: InputLabelTooltipProps;
     bold?: boolean;
-}>;
+    children?: ReactNode;
+};
 
 export const InputLabel = ({
     children,

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -18,7 +18,7 @@ import { useComboBoxState } from '@react-stately/combobox';
 import { Validation } from '@utilities/validation';
 import { useMachine } from '@xstate/react';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { FC, Key, MouseEvent, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Key, MouseEvent, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NavigationMenu } from './NavigationMenu';
 import { Popover } from './Popover';
 import { SearchInput } from './SearchInput';
@@ -46,7 +46,7 @@ export const CUSTOM_LINK_ID = 'custom-link';
 export const MAX_STORED_ITEMS = 5;
 export const QUERIES_STORAGE_KEY = 'queries';
 
-export const LinkChooser: FC<LinkChooserProps> = ({
+export const LinkChooser = ({
     getGlobalByQuery = getDefaultData,
     openPreview = window.open,
     clipboardOptions = navigator.clipboard,
@@ -62,7 +62,7 @@ export const LinkChooser: FC<LinkChooserProps> = ({
     clearable,
     required,
     validation = Validation.Default,
-}) => {
+}: LinkChooserProps): ReactElement => {
     const [{ context, matches, value }, send, service] = useMachine(() =>
         linkChooserMachine.withContext({
             searchResults: [],

--- a/src/components/LinkChooser/NavigationMenu.tsx
+++ b/src/components/LinkChooser/NavigationMenu.tsx
@@ -7,12 +7,12 @@ import { getInteractionModality } from '@react-aria/interactions';
 import { useOption } from '@react-aria/listbox';
 import { merge } from '@utilities/merge';
 import { useActor } from '@xstate/react';
-import React, { FC, useMemo, useRef } from 'react';
+import React, { ReactElement, useMemo, useRef } from 'react';
 import { defaultSection } from './sections';
 import { DropdownState, LinkChooserState } from './state/types';
 import { NavigationMenuItemProps, NavigationMenuProps } from './types';
 
-export const NavigationMenu: FC<NavigationMenuProps> = ({ machineService, state }) => {
+export const NavigationMenu = ({ machineService, state }: NavigationMenuProps): Nullable<ReactElement> => {
     const [{ matches, context }, send] = useActor(machineService);
 
     return matches(`${LinkChooserState.Focused}.${DropdownState.Default}`) ? (
@@ -34,12 +34,12 @@ export const NavigationMenu: FC<NavigationMenuProps> = ({ machineService, state 
     ) : null;
 };
 
-export const NavigationMenuItem: FC<NavigationMenuItemProps> = ({
+export const NavigationMenuItem = ({
     section: { id, title },
     onPress,
     state,
     direction = 'right',
-}) => {
+}: NavigationMenuItemProps): ReactElement => {
     const ref = useRef<HTMLLIElement>(null);
     const { isFocused } = useOption(
         {

--- a/src/components/LinkChooser/Popover.tsx
+++ b/src/components/LinkChooser/Popover.tsx
@@ -2,10 +2,10 @@
 
 import { DismissButton, useOverlay } from '@react-aria/overlays';
 import { mergeProps } from '@react-aria/utils';
-import React, { FC, MouseEvent, TouchEvent, useRef } from 'react';
+import React, { MouseEvent, ReactElement, TouchEvent, useRef } from 'react';
 import { PopoverProps } from './types';
 
-export const Popover: FC<PopoverProps> = (props) => {
+export const Popover = (props: PopoverProps): ReactElement => {
     const ref = useRef<HTMLDivElement>(null);
     const { popoverRef = ref, isOpen, onClose, children, maxHeight } = props;
 
@@ -20,7 +20,7 @@ export const Popover: FC<PopoverProps> = (props) => {
     );
 
     /* Focus must not be shifted to the popover when any buttons are pressed since this will close the input.
-    There is a blur event fired on the input when clicking inside the popover which gets fired twice *sometimes*, 
+    There is a blur event fired on the input when clicking inside the popover which gets fired twice *sometimes*,
     (once with a relatedTarget and once without). This way all blur events are prevented */
 
     const bubblingEventProps = {

--- a/src/components/LinkChooser/SearchInput.tsx
+++ b/src/components/LinkChooser/SearchInput.tsx
@@ -10,7 +10,7 @@ import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { useActor } from '@xstate/react';
-import React, { FC, MouseEvent, forwardRef } from 'react';
+import React, { MouseEvent, forwardRef, ReactElement } from 'react';
 import { IconButtonProps, SearchInputProps } from './types';
 import { IconArrowOutExternal, IconClipboard, IconCross } from '@foundation/Icon/Generated';
 
@@ -121,7 +121,15 @@ export const SearchInput = forwardRef<HTMLInputElement | null, SearchInputProps>
 );
 SearchInput.displayName = 'SearchInput';
 
-const IconButton: FC<IconButtonProps> = ({ disabled, title, ariaLabel, testId, icon, onClick, isComboBoxControl }) => {
+const IconButton = ({
+    disabled,
+    title,
+    ariaLabel,
+    testId,
+    icon,
+    onClick,
+    isComboBoxControl,
+}: IconButtonProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
 
     const handleClick = (event: MouseEvent<HTMLButtonElement>) => {

--- a/src/components/LinkChooser/SearchInput.tsx
+++ b/src/components/LinkChooser/SearchInput.tsx
@@ -10,7 +10,7 @@ import { mergeProps } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { useActor } from '@xstate/react';
-import React, { MouseEvent, forwardRef, ReactElement } from 'react';
+import React, { MouseEvent, ReactElement, forwardRef } from 'react';
 import { IconButtonProps, SearchInputProps } from './types';
 import { IconArrowOutExternal, IconClipboard, IconCross } from '@foundation/Icon/Generated';
 

--- a/src/components/LinkChooser/SearchResultOption.tsx
+++ b/src/components/LinkChooser/SearchResultOption.tsx
@@ -6,13 +6,18 @@ import { getInteractionModality } from '@react-aria/interactions';
 import { useOption } from '@react-aria/listbox';
 import { merge } from '@utilities/merge';
 import { useActor } from '@xstate/react';
-import React, { FC, useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 import { IconOptions } from './LinkChooser';
 import { DropdownState, LinkChooserState, SectionState } from './state/types';
 import { ImageMenuItemProps, SearchResult, SearchResultOptionProps } from './types';
 import { findSection } from './utils/helpers';
 
-export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, keyItemRecord, machineService }) => {
+export const SearchResultOption = ({
+    item,
+    state,
+    keyItemRecord,
+    machineService,
+}: SearchResultOptionProps): ReactElement => {
     const ref = useRef<HTMLLIElement>(null);
     const { optionProps, isDisabled, isSelected, isFocused } = useOption(
         {
@@ -58,7 +63,7 @@ export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, k
     );
 };
 
-const ImageMenuItem: FC<ImageMenuItemProps> = ({ title, subtitle, preview }) => (
+const ImageMenuItem = ({ title, subtitle, preview }: ImageMenuItemProps): ReactElement => (
     <div className="tw-flex tw-px-5 tw-py-1.5 tw-cursor-pointer">
         <div className="tw-flex tw-flex-shrink-0 tw-w-[75px] tw-h-[75px] tw-max-w-xs tw-bg-black-0 tw-rounded">
             {preview && <img className="tw-w-full tw-object-contain" src={preview} alt={title as string} />}

--- a/src/components/LinkChooser/SearchResultSection.tsx
+++ b/src/components/LinkChooser/SearchResultSection.tsx
@@ -1,16 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useListBoxSection } from '@react-aria/listbox';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { SearchResultSectionProps } from './types';
 import { SearchResultOption } from './SearchResultOption';
 
-export const SearchResultSection: FC<SearchResultSectionProps> = ({
+export const SearchResultSection = ({
     heading,
     state,
     keyItemRecord,
     machineService,
-}) => {
+}: SearchResultSectionProps): ReactElement => {
     const { itemProps, groupProps } = useListBoxSection({
         heading: heading.rendered,
         'aria-label': heading['aria-label'],

--- a/src/components/LinkChooser/SearchResultsList.tsx
+++ b/src/components/LinkChooser/SearchResultsList.tsx
@@ -3,7 +3,7 @@
 import { getKeyItemRecord, getMenuItems } from '@components/ActionMenu/Aria/helper';
 import { useListBox } from '@react-aria/listbox';
 import { useActor } from '@xstate/react';
-import React, { FC, useMemo, useRef } from 'react';
+import React, { ReactElement, useMemo, useRef } from 'react';
 import BackgroundIcon from './assets/background.svg';
 import NoResultsIcon from './assets/no-results.svg';
 import FetchingIcon from './assets/nook-animated.png';
@@ -14,7 +14,7 @@ import { SearchResultListProps } from './types';
 import { findSection } from './utils/helpers';
 import { isFetching, isUnsuccessful, shouldGoBack } from './utils/state';
 
-export const SearchResultsList: FC<SearchResultListProps> = (props) => {
+export const SearchResultsList = (props: SearchResultListProps): ReactElement => {
     const ref = useRef<HTMLUListElement>(null);
     const { listBoxRef = ref, state, menuBlocks, machineService } = props;
     const { listBoxProps } = useListBox(props, state, listBoxRef);
@@ -92,7 +92,7 @@ export const SearchResultsList: FC<SearchResultListProps> = (props) => {
     );
 };
 
-const EmptyResults: FC<{ prompt: string; icon: string }> = ({ prompt, icon }) => (
+const EmptyResults = ({ prompt, icon }: { prompt: string; icon: string }): ReactElement => (
     <div
         data-test-id="link-chooser-empty-results"
         className="tw-flex tw-flex-col tw-justify-center tw-items-center tw-h-[278px] tw-p-3"
@@ -102,7 +102,11 @@ const EmptyResults: FC<{ prompt: string; icon: string }> = ({ prompt, icon }) =>
     </div>
 );
 
-const FetchingError: FC<{ error?: string }> = ({ error = 'An error occurred while fetching the results' }) => (
+const FetchingError = ({
+    error = 'An error occurred while fetching the results',
+}: {
+    error?: string;
+}): ReactElement => (
     <div
         data-test-id="link-chooser-error"
         className="tw-flex tw-flex-col tw-justify-center tw-items-center tw-h-[278px] tw-p-3"
@@ -112,7 +116,7 @@ const FetchingError: FC<{ error?: string }> = ({ error = 'An error occurred whil
     </div>
 );
 
-const FetchingAnimation: FC = () => (
+const FetchingAnimation = (): ReactElement => (
     <div
         data-test-id="link-chooser-loader"
         className="tw-flex tw-flex-col tw-justify-center tw-items-center tw-h-[278px] tw-p-3"

--- a/src/components/LoadingCircle/LoadingCircle.tsx
+++ b/src/components/LoadingCircle/LoadingCircle.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 
 export enum LoadingCircleStyle {
     Progress = 'Progress',
@@ -34,10 +34,10 @@ export const sizeClasses: Record<LoadingCircleSize, string> = {
     [LoadingCircleSize.Large]: 'tw-w-16 tw-h-16',
 };
 
-export const LoadingCircle: FC<LoadingCircleProps> = ({
+export const LoadingCircle = ({
     style = LoadingCircleStyle.Progress,
     size = LoadingCircleSize.Medium,
-}) => {
+}: LoadingCircleProps): ReactElement => {
     return (
         <div
             data-test-id="loading-circle"

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { PropsWithChildren, ReactNode, RefObject, useCallback, useEffect, useState } from 'react';
+import React, { ReactNode, RefObject, useCallback, useEffect, useState } from 'react';
 import { usePopper } from 'react-popper';
 import { merge } from '@utilities/merge';
 import { useMenuKeyboardNavigation } from '@components/Menu/useMenuKeyboardNavigation';
@@ -15,7 +15,7 @@ interface Props {
     offset?: [number, number];
 }
 
-export type MenuProps = PropsWithChildren<Props>;
+export type MenuProps = Props;
 
 const CONTAINER_BASE_CLASSES = 'tw-relative tw-bg-base tw-rounded tw-py-2 tw-shadow-mid tw-z-[120000]';
 const CONTAINER_CLASSES = merge([CONTAINER_BASE_CLASSES, INSET_BORDER]);

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { MouseEvent, PropsWithChildren, useEffect, useState } from 'react';
+import React, { MouseEvent, ReactNode, useEffect, useState } from 'react';
 import { merge } from '@utilities/merge';
 import { IconCaretRight, IconCheckMark } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
@@ -18,6 +18,7 @@ export type MenuItemProps = {
     type?: string;
     link?: string;
     onClick?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
+    children?: ReactNode;
 } & Omit<MenuItemContentProps, 'iconSize'>;
 
 export const menuItemSizeClassMap: Record<MenuItemContentSize, string> = {
@@ -76,7 +77,7 @@ export const MenuItem = ({
     children,
     link,
     onClick,
-}: PropsWithChildren<MenuItemProps>) => {
+}: MenuItemProps) => {
     const currentIconSize = size === MenuItemContentSize.XSmall ? IconSize.Size16 : IconSize.Size20;
 
     const currentIcon = {

--- a/src/components/MenuItem/MenuItemContent.tsx
+++ b/src/components/MenuItem/MenuItemContent.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { HTMLAttributes, PropsWithChildren, ReactElement, ReactNode, cloneElement } from 'react';
+import React, { HTMLAttributes, ReactElement, ReactNode, cloneElement } from 'react';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { merge } from '@utilities/merge';
 import { MenuItemContentSize } from './types';
@@ -12,6 +12,7 @@ export type MenuItemContentProps = {
     subtitle?: string;
     size?: MenuItemContentSize;
     ariaProps?: HTMLAttributes<HTMLElement>;
+    children?: ReactNode;
 };
 
 /**
@@ -31,7 +32,7 @@ export const MenuItemContent = ({
     ariaProps,
     size = MenuItemContentSize.Small,
     children,
-}: PropsWithChildren<MenuItemContentProps>) => (
+}: MenuItemContentProps) => (
     <div
         {...ariaProps}
         data-test-id="menu-item-content"

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, memo, useRef } from 'react';
+import React, { ReactElement, memo, useRef } from 'react';
 import { merge } from '@utilities/merge';
 import { ModalProps, ModalWidth } from './types';
 import { ModalVisual } from './ModalVisual';
@@ -46,7 +46,7 @@ const widthMap: Record<ModalWidth, string> = {
 
 const DEFAULT_ZINDEX = 50;
 
-const ModalComponent: FC<ModalProps> = memo((props) => {
+const ModalComponent = memo((props: ModalProps): ReactElement => {
     const { visual, children, width = ModalWidth.Default, zIndex = DEFAULT_ZINDEX, compact = false } = props;
     const ref = useRef<HTMLDivElement>(null);
     const {

--- a/src/components/Modal/ModalBody.tsx
+++ b/src/components/Modal/ModalBody.tsx
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, useContext } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { ModalBodyProps } from './types';
 import { ScrollWrapper } from '@components/ScrollWrapper/ScrollWrapper';
 import { ModalLayout } from './context/ModalLayout';
 
-export const ModalBody: FC<ModalBodyProps> = ({ direction, children, horizontalPadding = true }) => {
+export const ModalBody = ({ direction, children, horizontalPadding = true }: ModalBodyProps): ReactElement => {
     const { padding } = useContext(ModalLayout);
 
     return (

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -1,18 +1,18 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, cloneElement, useContext } from 'react';
+import React, { ReactElement, cloneElement, useContext } from 'react';
 import { merge } from '@utilities/merge';
 import { ModalHeaderProps, ModalHeaderVariant, modalHeaderVariants } from './types';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { ModalTitle } from './context/ModalTitle';
 import { ModalLayout } from './context/ModalLayout';
 
-export const ModalHeader: FC<ModalHeaderProps> = ({
+export const ModalHeader = ({
     title,
     leadText,
     decorator,
     variant = ModalHeaderVariant.Default,
-}) => {
+}: ModalHeaderProps): ReactElement => {
     const ariaTitleProps = useContext(ModalTitle);
     const { padding, compact } = useContext(ModalLayout);
 

--- a/src/components/Modal/ModalVisual.tsx
+++ b/src/components/Modal/ModalVisual.tsx
@@ -1,12 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { merge } from '@utilities/merge';
 import { ModalVisualProps } from './types';
 import { FrontifyPattern } from '@components/FrontifyPattern/FrontifyPattern';
 import { PatternDesign, PatternScale, patternThemes } from '@foundation/Pattern';
 
-export const ModalVisual: FC<ModalVisualProps> = ({ pattern = PatternDesign.DigitalAssets, foregroundColor }) => {
+export const ModalVisual = ({
+    pattern = PatternDesign.DigitalAssets,
+    foregroundColor,
+}: ModalVisualProps): ReactElement => {
     return (
         <div
             data-test-id="modal-visual"

--- a/src/components/MultiInput/MultiInput.tsx
+++ b/src/components/MultiInput/MultiInput.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { Children, FC } from 'react';
+import React, { Children, ReactElement, ReactNode } from 'react';
 
 export enum MultiInputLayout {
     Columns = 'Columns',
@@ -10,9 +10,10 @@ export enum MultiInputLayout {
 export type MultiInputProps = {
     layout: MultiInputLayout;
     spanLastItem?: boolean;
+    children: ReactNode;
 };
 
-export const MultiInput: FC<MultiInputProps> = ({ layout, spanLastItem, children }) => {
+export const MultiInput = ({ layout, spanLastItem, children }: MultiInputProps): ReactElement => {
     const childrenArray = Children.toArray(children);
 
     return (

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -9,7 +9,7 @@ import { FocusScope, useFocusRing } from '@react-aria/focus';
 import { merge } from '@utilities/merge';
 import { Validation } from '@utilities/validation';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { ChangeEvent, FC, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, KeyboardEvent, ReactElement, useEffect, useRef, useState } from 'react';
 import { getInputWidth, getPaddingClasses } from './helpers';
 import { Menu } from '@components/Menu';
 import { MenuItem } from '@components/MenuItem';
@@ -76,7 +76,7 @@ export type Item = {
     ariaLabel?: string;
 };
 
-export const MultiSelect: FC<MultiSelectProps> = ({
+export const MultiSelect = ({
     items,
     activeItemKeys,
     onSelectionChange,
@@ -95,7 +95,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
     summarizedLabel: summarizedLabelFromProps,
     indeterminateItemKeys,
     flip = false,
-}) => {
+}: MultiSelectProps): ReactElement => {
     const [open, setOpen] = useState(false);
     const [checkboxes, setCheckboxes] = useState<Item[]>([]);
     const hasResults = !!checkboxes.find((item) => !item.isCategory && !item.isDivider);

--- a/src/components/OrderableList/utils/mocks.tsx
+++ b/src/components/OrderableList/utils/mocks.tsx
@@ -2,7 +2,7 @@
 
 import { OrderableListItem } from '@components/OrderableList';
 import { HighlightColor, HighlightProps, StoryListItem } from '@components/OrderableList/utils/types';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { merge } from '@utilities/merge';
 
 const HighlightClasses: Record<HighlightColor, string> = {
@@ -11,7 +11,7 @@ const HighlightClasses: Record<HighlightColor, string> = {
     [HighlightColor.Red]: 'tw-text-red-60',
 };
 
-const Highlight: FC<HighlightProps> = ({ color, children }) => (
+const Highlight = ({ color, children }: HighlightProps): ReactElement => (
     <span className={merge(['tw-font-medium', HighlightClasses[color]])}>{children}</span>
 );
 

--- a/src/components/RadioPill/RadioPill.tsx
+++ b/src/components/RadioPill/RadioPill.tsx
@@ -4,7 +4,7 @@ import { IconSize } from '@foundation/Icon/IconSize';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import React, { FC, MouseEvent, cloneElement } from 'react';
+import React, { MouseEvent, ReactElement, cloneElement } from 'react';
 
 export type RadioPillProps = {
     label: string;
@@ -13,7 +13,7 @@ export type RadioPillProps = {
     icon?: React.ReactElement;
 };
 
-export const RadioPill: FC<RadioPillProps> = ({ label, active, icon, onClick }) => {
+export const RadioPill = ({ label, active, icon, onClick }: RadioPillProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
 
     return (

--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/ButtonMarkupElement/ButtonMarkupElementNode.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/ButtonMarkupElement/ButtonMarkupElementNode.tsx
@@ -3,7 +3,7 @@
 import { useRichTextEditorContext } from '@components/RichTextEditor/context/RichTextEditorContext';
 import { DesignTokens } from '@components/RichTextEditor/types';
 import { HTMLPropsAs, PlateRenderElementProps, Value, useElementProps } from '@udecode/plate';
-import React, { CSSProperties, FC, ReactNode, useState } from 'react';
+import React, { CSSProperties, ReactElement, ReactNode, useState } from 'react';
 import { ButtonStyles } from '../../TextStylePlugin/TextStyles';
 import { RichTextButtonStyle, TButtonElement } from '../types';
 
@@ -70,7 +70,13 @@ type Props = {
     target?: React.HTMLAttributeAnchorTarget;
 };
 
-const HoverableButtonLink: FC<Props> = ({ attributes, styles = { hover: {} }, children, href = '#', target }) => {
+const HoverableButtonLink = ({
+    attributes,
+    styles = { hover: {} },
+    children,
+    href = '#',
+    target,
+}: Props): ReactElement => {
     const [hovered, setHovered] = useState(false);
 
     return (

--- a/src/components/RichTextEditor/Plugins/ButtonPlugin/components/FloatingButton/InsertButtonModal/InsertButtonModal.tsx
+++ b/src/components/RichTextEditor/Plugins/ButtonPlugin/components/FloatingButton/InsertButtonModal/InsertButtonModal.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { CSSProperties, FC, ReactNode, useState } from 'react';
+import React, { CSSProperties, ReactElement, ReactNode, useState } from 'react';
 
 import { FormControl } from '@components/FormControl';
 import { useInsertModal } from './useInsertModal';
@@ -67,7 +67,7 @@ type Props = {
     children: ReactNode;
 };
 
-const HoverableButton: FC<Props> = ({ id, styles, isActive, onClick, children }) => {
+const HoverableButton = ({ id, styles, isActive, onClick, children }: Props): ReactElement => {
     const [hovered, setHovered] = useState(false);
     const getStyles = () => (styles && styles.hover && hovered ? { ...styles, ...styles.hover } : styles);
 

--- a/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '@components/Checkbox';
 import { FormControl } from '@components/FormControl';
 import { TextInput } from '@components/TextInput';
 import { IconCheckMark20 } from '@foundation/Icon/Generated';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { InsertModalStateProps } from './types';
 
 type Props = {
@@ -22,7 +22,7 @@ type Props = {
     children?: React.ReactNode;
 };
 
-export const InsertModal: FC<Props> = ({
+export const InsertModal = ({
     state,
     onTextChange,
     onUrlChange,
@@ -33,7 +33,7 @@ export const InsertModal: FC<Props> = ({
     hasValues,
     testId,
     children,
-}) => (
+}: Props): ReactElement => (
     <div data-test-id={testId} className="tw-bg-white tw-rounded tw-shadow tw-p-7 tw-min-w-[400px] tw-overflow-y-auto">
         <FormControl
             label={{

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { ELEMENT_LINK, ELEMENT_PARAGRAPH } from '@udecode/plate';
-import React, { CSSProperties, FC, useState } from 'react';
+import React, { CSSProperties, ReactElement, useState } from 'react';
 import { orderedListValue } from '../helpers/exampleValues';
 import {
     AlignRightPlugin,
@@ -70,7 +70,7 @@ const selectTextValue = (value: string) => {
     });
 };
 
-const RichTextWithLink: FC<{ text: string; link: string }> = ({ text, link }) => {
+const RichTextWithLink = ({ text, link }: { text: string; link: string }): ReactElement => {
     return (
         <RichTextEditor
             value={JSON.stringify([
@@ -93,7 +93,7 @@ const RichTextWithLink: FC<{ text: string; link: string }> = ({ text, link }) =>
     );
 };
 
-const RichTextWithLegacyLink: FC<{ text: string; url: string }> = ({ text, url }) => {
+const RichTextWithLegacyLink = ({ text, url }: { text: string; url: string }): ReactElement => {
     return (
         <RichTextEditor
             value={JSON.stringify([
@@ -121,11 +121,15 @@ const RichTextWithLegacyLink: FC<{ text: string; url: string }> = ({ text, url }
     );
 };
 
-const RichTextWithButton: FC<{ text: string; link: string; buttonStyle: RichTextButtonStyle }> = ({
+const RichTextWithButton = ({
     text,
     link,
     buttonStyle,
-}) => {
+}: {
+    text: string;
+    link: string;
+    buttonStyle: RichTextButtonStyle;
+}): ReactElement => {
     return (
         <RichTextEditor
             value={JSON.stringify([
@@ -145,7 +149,7 @@ const RichTextWithButton: FC<{ text: string; link: string; buttonStyle: RichText
     );
 };
 
-const RichTextWithChangeDesignTokensButton: FC = () => {
+const RichTextWithChangeDesignTokensButton = (): ReactElement => {
     const [designTokens, setDesignTokens] = useState<DesignTokens>({
         custom1: {
             fontSize: '42px',
@@ -170,13 +174,15 @@ const RichTextWithChangeDesignTokensButton: FC = () => {
     );
 };
 
-const RichTextEditorWithValueSetOutside = ({ value }: { value: string }) => {
+const RichTextEditorWithValueSetOutside = ({ value }: { value: string }): ReactElement => {
     const [initialValue, setInitialValue] = useState(value);
 
     return <RichTextEditor onTextChange={(value) => setInitialValue(value)} value={initialValue} />;
 };
 
-const RichTextEditorWithOrderedListStyles = () => <RichTextEditor value={JSON.stringify([orderedListValue])} />;
+const RichTextEditorWithOrderedListStyles = (): ReactElement => (
+    <RichTextEditor value={JSON.stringify([orderedListValue])} />
+);
 
 const activeButtonClassNames = '!tw-bg-box-selected tw-rounded !tw-text-box-selected-inverse';
 const disabledButtonClassNames = '!tw-cursor-not-allowed !tw-opacity-50';

--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useFocusRing } from '@react-aria/focus';
-import React, { FC, useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 import { FOCUS_STYLE, merge } from '../..';
 import { useScrollWrapper } from './hooks/useScrollWrapper';
 import { ScrollWrapperDirection, ScrollWrapperProps, scrollWrapperDirections } from './types';
@@ -11,7 +11,10 @@ const GRADIENTS = {
     top: 'linear-gradient(0deg, rgba(232, 233, 233, 0) 0%, #E8E9E9 100%)',
 };
 
-export const ScrollWrapper: FC<ScrollWrapperProps> = ({ direction = ScrollWrapperDirection.Vertical, children }) => {
+export const ScrollWrapper = ({
+    direction = ScrollWrapperDirection.Vertical,
+    children,
+}: ScrollWrapperProps): ReactElement => {
     const scrollingContainer = useRef<HTMLDivElement>(null);
 
     const [{ showTopShadow, showBottomShadow }, scrollDivProps] = useScrollWrapper(scrollingContainer);

--- a/src/components/SegmentedControls/SegmentedControls.cy.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.cy.tsx
@@ -2,7 +2,7 @@
 
 import { IconTextAlignmentCentre, IconTextAlignmentLeft, IconTextAlignmentRight } from '@foundation/Icon/Generated';
 import { IconSize } from '@foundation/Icon/IconSize';
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { IconItem, SegmentedControls, TextOrNumberItem } from './SegmentedControls';
 
 const SEGMENTED_CONTROLS_ID = '[data-test-id=fondue-segmented-controls]';
@@ -34,7 +34,7 @@ type Props = {
     disabled?: boolean;
 };
 
-const Component: FC<Props> = ({ items, disabled = false }) => {
+const Component = ({ items, disabled = false }: Props): ReactElement => {
     const [active, setActive] = useState(items[0].id);
     return <SegmentedControls items={items} activeItemId={active} onChange={setActive} disabled={disabled} />;
 };

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -10,7 +10,7 @@ import { RadioGroupState, useRadioGroupState } from '@react-stately/radio';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { motion } from 'framer-motion';
-import React, { FC, ReactElement, useMemo, useRef } from 'react';
+import React, { ReactElement, useMemo, useRef } from 'react';
 
 export type IconItem = {
     id: string;
@@ -107,14 +107,14 @@ const SegmentedControlsItem = (props: SegmentedControlsItemProps) => {
     );
 };
 
-export const SegmentedControls: FC<SegmentedControlsProps> = ({
+export const SegmentedControls = ({
     id: propId,
     items,
     activeItemId,
     onChange,
     ariaLabel = 'SegmentedControls',
     disabled = false,
-}) => {
+}: SegmentedControlsProps): ReactElement => {
     const id = useMemoizedId(propId);
     const groupProps = { onChange, value: activeItemId, label: ariaLabel, isDisabled: disabled };
     const radioGroupState = useRadioGroupState(groupProps);

--- a/src/components/Switch/Switch.cy.tsx
+++ b/src/components/Switch/Switch.cy.tsx
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Switch, SwitchProps } from './Switch';
 
-const Component: FC<SwitchProps> = ({ mode = 'off', ...props }) => {
+const Component = ({ mode = 'off', ...props }: SwitchProps): ReactElement => {
     const [active, setActive] = useState(mode);
 
     return (

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, MouseEvent, useMemo } from 'react';
+import React, { MouseEvent, ReactElement, useMemo } from 'react';
 import { merge } from '@utilities/merge';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
@@ -48,7 +48,7 @@ export type SwitchProps = {
     onChange?: (e: MouseEvent) => void;
 };
 
-export const Switch: FC<SwitchProps> = ({
+export const Switch = ({
     id: propId,
     name,
     label,
@@ -59,7 +59,7 @@ export const Switch: FC<SwitchProps> = ({
     labelStyle = 'default',
     hug = false,
     tooltip,
-}) => {
+}: SwitchProps): ReactElement => {
     const id = useMemoizedId(propId);
     const { isFocusVisible, focusProps } = useFocusRing();
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -7,7 +7,7 @@ import { Button, ButtonEmphasis, ButtonSize, ButtonStyle } from '@components/But
 import { IconSize } from '@foundation/Icon/IconSize';
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
-import React, { FC, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Column, Row, SelectionMode, SortDirection, Table, TableProps } from './Table';
 import { IconDotsVertical, IconFaceHappy } from '@foundation/Icon/Generated';
 
@@ -26,7 +26,7 @@ export default {
     },
 } as Meta<TableProps>;
 
-const User: FC<{ name: string }> = ({ name }) => (
+const User = ({ name }: { name: string }): ReactElement => (
     <div className="tw-flex tw-gap-x-2 tw-items-center">
         <IconFaceHappy size={IconSize.Size32} />
         <div>
@@ -36,7 +36,7 @@ const User: FC<{ name: string }> = ({ name }) => (
     </div>
 );
 
-const ActionButton: FC = () => (
+const ActionButton = (): ReactElement => (
     <Button
         style={ButtonStyle.Default}
         emphasis={ButtonEmphasis.Default}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -9,7 +9,7 @@ import {
     TableStateProps,
     useTableState,
 } from '@react-stately/table';
-import React, { Key, PropsWithChildren, ReactNode, useRef, useState } from 'react';
+import React, { Key, ReactNode, useRef, useState } from 'react';
 import { TableCell, TableCellType } from './TableCell';
 import { TableColumnHeader, TableColumnHeaderType } from './TableColumnHeader';
 import { TableHeaderRow } from './TableHeaderRow';
@@ -41,7 +41,7 @@ export type Row = {
     actionElements?: ReactNode;
 };
 
-export type TableProps = PropsWithChildren<{
+export type TableProps = {
     columns: Column[];
     rows: Row[];
     onSelectionChange?: (ids?: Key[]) => void;
@@ -49,7 +49,8 @@ export type TableProps = PropsWithChildren<{
     selectionMode?: SelectionMode;
     selectedRowIds?: Key[];
     ariaLabel?: string;
-}>;
+    children?: ReactNode;
+};
 
 export enum SortDirection {
     Ascending = 'ascending',

--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, ReactElement, ReactNode, useRef } from 'react';
+import React, { ReactElement, ReactNode, useRef } from 'react';
 import { BadgeProps } from '@components/Badge';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
@@ -17,7 +17,7 @@ export type TabItemProps = {
     children: ReactNode;
 };
 
-export const TabItem: FC<TabItemProps & { active?: boolean }> = ({ active, disabled, children, id }) => {
+export const TabItem = ({ active, disabled, children, id }: TabItemProps & { active?: boolean }): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
     const ref = useRef<HTMLDivElement | null>(null);
     const hasInteractiveElements = checkIfContainInteractiveElements(ref.current);

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -2,8 +2,8 @@
 
 import React, {
     Children,
-    FC,
     KeyboardEvent,
+    ReactElement,
     ReactNode,
     cloneElement,
     isValidElement,
@@ -46,7 +46,7 @@ const paddingMap: Record<TabsPaddingX, string> = {
     [TabsPaddingX.Large]: 'tw-pl-l',
 };
 
-export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, onChange }) => {
+export const Tabs = ({ paddingX, size, activeItemId, children, onChange }: TabsProps): ReactElement => {
     const groupId = useMemoizedId();
     const tabNavRef = useRef<HTMLDivElement | null>(null);
     const [isOverflowing, setIsOverflowing] = useState(false);

--- a/src/components/TextInput/TextInput.cy.tsx
+++ b/src/components/TextInput/TextInput.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Validation } from '@utilities/validation';
-import React, { FC, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { TextInput, TextInputProps, TextInputType } from './TextInput';
 
 const TEXT_INPUT_COMPONENT = '[data-test-id=fondue-text-input-component]';
@@ -17,7 +17,7 @@ const DECORATOR_ID = '[data-test-id=decorator]';
 const VISIBILITY_ICON_ID = '[data-test-id=visibility-icon]';
 const EXCLAMATION_MARK_ICON_ID = '[data-test-id=error-state-exclamation-mark-icon]';
 
-const StatefulInput: FC<TextInputProps> = (props) => {
+const StatefulInput = (props: TextInputProps): ReactElement => {
     const [input, setInput] = useState<string>('');
 
     useEffect(() => {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -7,7 +7,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
-import React, { FC, FocusEvent, KeyboardEvent, ReactNode, useEffect, useRef, useState } from 'react';
+import React, { FocusEvent, KeyboardEvent, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
 import {
     IconCheckMark,
     IconClipboard,
@@ -65,7 +65,7 @@ export type TextInputProps =
           obfuscated?: boolean;
       } & TextInputBaseProps);
 
-export const TextInput: FC<TextInputProps> = ({
+export const TextInput = ({
     id: propId,
     type = TextInputType.Text,
     decorator,
@@ -89,7 +89,7 @@ export const TextInput: FC<TextInputProps> = ({
     readonly,
     focusOnMount,
     selectable = false,
-}) => {
+}: TextInputProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing({ within: true, isTextInput: true });
     const { isFocusVisible: clearButtonIsFocusVisible, focusProps: clearButtonFocusProps } = useFocusRing();
     const { isFocusVisible: passwordButtonIsFocusVisible, focusProps: passwordButtonFocusProps } = useFocusRing();

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -7,7 +7,7 @@ import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
 import { LoadingCircle, LoadingCircleSize } from '@components/LoadingCircle';
-import React, { FC, FocusEvent, FormEvent, ReactNode } from 'react';
+import React, { FocusEvent, FormEvent, ReactElement, ReactNode } from 'react';
 import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize';
 import { IconExclamationMarkTriangle } from '@foundation/Icon/Generated';
 
@@ -31,7 +31,7 @@ export type TextareaProps = {
     selectable?: boolean;
 };
 
-export const Textarea: FC<TextareaProps> = ({
+export const Textarea = ({
     id: propId,
     value,
     required = false,
@@ -47,7 +47,7 @@ export const Textarea: FC<TextareaProps> = ({
     resizeable = true,
     onFocus,
     selectable = false,
-}) => {
+}: TextareaProps): ReactElement => {
     const Component = autosize ? TextareaAutosize : 'textarea';
 
     const { isFocusVisible, focusProps } = useFocusRing({ isTextInput: true });

--- a/src/components/Tooltip/BrightHeader.tsx
+++ b/src/components/Tooltip/BrightHeader.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, ReactElement, cloneElement } from 'react';
+import React, { ReactElement, cloneElement } from 'react';
 import { merge } from '@utilities/merge';
 import {
     IconCheckMark,
@@ -42,7 +42,7 @@ type BrightHeaderProps = {
     headerStyle: BrightHeaderStyle;
 };
 
-export const BrightHeader: FC<BrightHeaderProps> = ({ headerStyle }) => {
+export const BrightHeader = ({ headerStyle }: BrightHeaderProps): ReactElement => {
     return (
         <div
             data-test-id="bright-header"

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -8,8 +8,6 @@ import { merge } from '@utilities/merge';
 import React, {
     FocusEvent,
     HTMLAttributes,
-    PropsWithChildren,
-    ReactChild,
     ReactElement,
     ReactNode,
     cloneElement,
@@ -30,7 +28,7 @@ export type TooltipButton = {
     action: () => void;
 };
 
-export type TooltipProps = PropsWithChildren<{
+export type TooltipProps = {
     triggerElement?: ReactElement;
     content: ReactNode;
     tooltipIcon?: ReactElement;
@@ -40,7 +38,7 @@ export type TooltipProps = PropsWithChildren<{
     linkLabel?: string;
     brightHeader?: BrightHeaderStyle;
     buttons?: [TooltipButton, TooltipButton] | [TooltipButton];
-    children?: ReactChild;
+    children?: ReactNode;
     position?: TooltipPosition;
     alignment?: TooltipAlignment;
     flip?: boolean;
@@ -51,7 +49,7 @@ export type TooltipProps = PropsWithChildren<{
     disabled?: boolean;
     /** @deprecated use disabled since the tooltip is always present in the DOM now so hidden has no effect anymore */
     hidden?: boolean;
-}>;
+};
 
 /**
  * This is a temporary workaround because for some yet unknown reasons `tailwindcss` in clarify purges the `tw-pb-3.5` and `tw-pt-3.5` class.

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, ReactElement, cloneElement } from 'react';
+import React, { ReactElement, cloneElement } from 'react';
 import { IconSize } from '@foundation/Icon/IconSize';
 import { Tooltip, TooltipProps } from '@components/Tooltip/Tooltip';
 import { FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
@@ -33,12 +33,12 @@ const tooltipHoverClasses = {
     [TooltipIconTriggerStyle.Primary]: 'hover:tw-text-text hover:tw-bg-box-neutral',
 };
 
-export const TooltipIcon: FC<TooltipIconProps> = ({
+export const TooltipIcon = ({
     tooltip,
     iconSize = IconSize.Size16,
     triggerIcon = <IconQuestionMarkCircle />,
     triggerStyle = TooltipIconTriggerStyle.Primary,
-}: TooltipIconProps) => {
+}: TooltipIconProps): ReactElement => {
     return (
         <div data-test-id="tooltip-icon">
             {tooltip && (

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -6,7 +6,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE, FOCUS_VISIBLE_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
-import React, { FC, HTMLAttributes } from 'react';
+import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 export enum TriggerSize {
     Small = 'Small',
@@ -20,6 +20,7 @@ export enum TriggerEmphasis {
 
 export type TriggerProps = {
     disabled?: boolean;
+    children?: ReactNode;
     isOpen?: boolean;
     onClear?: () => void;
     onDelete?: () => void;
@@ -53,7 +54,7 @@ const getTriggerClassNames = (
               ]),
     ]);
 
-export const Trigger: FC<TriggerProps> = ({
+export const Trigger = ({
     buttonProps,
     onClear,
     onDelete,
@@ -65,7 +66,7 @@ export const Trigger: FC<TriggerProps> = ({
     showClear = false,
     validation = Validation.Default,
     emphasis = TriggerEmphasis.Default,
-}) => {
+}: TriggerProps): ReactElement => {
     const { focusProps: clearableFocusProps, isFocusVisible: isClearFocusVisible } = useFocusRing();
     const { focusProps: onDeleteFocusProps, isFocusVisible: isOnDeleteFocusVisible } = useFocusRing();
 

--- a/src/layout/Stack/Stack.stories.tsx
+++ b/src/layout/Stack/Stack.stories.tsx
@@ -2,13 +2,16 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { merge } from '@utilities/merge';
-import React, { FC } from 'react';
+import React, { ReactElement } from 'react';
 import { Stack, StackProps } from './Stack';
 
-const Placeholder: FC<{ width?: 'auto' | 'large' | 'small'; height?: 'large' | 'small' }> = ({
+const Placeholder = ({
     width = 'auto',
     height = 'large',
-}) => (
+}: {
+    width?: 'auto' | 'large' | 'small';
+    height?: 'large' | 'small';
+}): ReactElement => (
     <div
         className={merge([
             width === 'auto' && 'tw-w-full',
@@ -53,7 +56,7 @@ export default {
     },
 } as Meta<StackProps>;
 
-const Template: StoryFn<StackProps> = (args) => (
+const Template: StoryFn<StackProps> = (args): ReactElement => (
     <div className="tw-bg-box-negative-inverse">
         <Stack {...args} />
     </div>

--- a/src/layout/Stack/Stack.tsx
+++ b/src/layout/Stack/Stack.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { PropsWithChildren, ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 export type StackSpacing = 'none' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 
@@ -9,14 +9,15 @@ export type StackJustify = 'start' | 'end' | 'center' | 'between' | 'around' | '
 
 export type StackAlign = 'start' | 'end' | 'stretch' | 'center';
 
-export type StackProps = PropsWithChildren<{
+export type StackProps = {
     padding: StackSpacing;
     spacing: StackSpacing;
     direction?: 'row' | 'column';
     wrap?: boolean;
     justify?: StackJustify;
     align?: StackAlign;
-}>;
+    children?: ReactNode;
+};
 
 const paddingMap: Record<StackSpacing, string> = {
     none: 'tw-p-0',

--- a/src/layout/Stack/Stack.tsx
+++ b/src/layout/Stack/Stack.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactElement } from 'react';
 
 export type StackSpacing = 'none' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 
@@ -56,7 +56,7 @@ const alignMap: Record<StackAlign, string> = {
     stretch: 'tw-items-stretch',
 };
 
-export const Stack: FC<StackProps> = ({
+export const Stack = ({
     children,
     padding,
     spacing,
@@ -64,7 +64,7 @@ export const Stack: FC<StackProps> = ({
     wrap = false,
     justify = 'start',
     align = 'stretch',
-}) => {
+}: StackProps): ReactElement => {
     return (
         <div
             data-test-id="stack"

--- a/src/typography/Code/Code.tsx
+++ b/src/typography/Code/Code.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { PropsWithChildren, ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 type CodeWeight = 'default' | 'strong';
 
@@ -9,12 +9,13 @@ type CodeSize = 'small' | 'medium' | 'large';
 
 type CodeColor = 'default' | 'weak' | 'x-weak' | 'disabled' | 'negative' | 'positive' | 'warning' | 'interactive';
 
-export type CodeProps = PropsWithChildren<{
+export type CodeProps = {
     size?: CodeSize;
     weight?: CodeWeight;
     as?: 'code' | 'pre' | 'span';
     color?: CodeColor;
-}>;
+    children?: ReactNode;
+};
 
 const weightMap: Record<CodeWeight, string> = {
     default: 'tw-font-regular',

--- a/src/typography/Code/Code.tsx
+++ b/src/typography/Code/Code.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactElement } from 'react';
 
 type CodeWeight = 'default' | 'strong';
 
@@ -38,13 +38,13 @@ const colorMap: Record<CodeColor, string> = {
     interactive: 'tw-text-text-interactive',
 };
 
-export const Code: FC<CodeProps> = ({
+export const Code = ({
     children,
     as: Tag = 'span',
     weight = 'default',
     size = 'medium',
     color = 'default',
-}) => {
+}: CodeProps): ReactElement => {
     return (
         <Tag data-test-id="code" className={merge(['tw-font-code', weightMap[weight], sizeMap[size], colorMap[color]])}>
             {children}

--- a/src/typography/Heading/Heading.tsx
+++ b/src/typography/Heading/Heading.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from '../shared/records';
 import { SharedTypographyProps } from '../shared/types';
 
@@ -9,14 +9,13 @@ type HeadingWeight = 'default' | 'strong';
 type HeadingSize = 'medium' | 'large' | 'x-large' | 'xx-large';
 type HeadingColor = 'default' | 'weak' | 'x-weak' | 'disabled' | 'negative' | 'positive' | 'warning' | 'interactive';
 
-export type HeadingProps = PropsWithChildren<
-    SharedTypographyProps & {
-        size?: HeadingSize;
-        weight?: HeadingWeight;
-        as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'p';
-        color?: HeadingColor;
-    }
->;
+export type HeadingProps = SharedTypographyProps & {
+    size?: HeadingSize;
+    weight?: HeadingWeight;
+    as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'p';
+    color?: HeadingColor;
+    children?: ReactNode;
+};
 
 const weightMap: Record<HeadingWeight, string> = {
     default: 'tw-font-medium',
@@ -41,7 +40,7 @@ const colorMap: Record<HeadingColor, string> = {
     interactive: 'tw-text-text-interactive',
 };
 
-export const Heading: FC<HeadingProps> = ({
+export const Heading = ({
     children,
     as: Tag = 'span',
     weight = 'default',
@@ -52,7 +51,7 @@ export const Heading: FC<HeadingProps> = ({
     wordBreak = 'normal',
     whitespace = 'normal',
     display,
-}) => (
+}: HeadingProps): ReactElement => (
     <Tag
         data-test-id="heading"
         className={merge([

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactElement } from 'react';
 import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from '../shared/records';
 import { SharedTypographyProps } from '../shared/types';
 
@@ -42,7 +42,7 @@ const colorMap: Record<TextColor, string> = {
     interactive: 'tw-text-text-interactive',
 };
 
-export const Text: FC<TextProps> = ({
+export const Text = ({
     children,
     as: Tag = 'span',
     weight = 'default',
@@ -53,7 +53,7 @@ export const Text: FC<TextProps> = ({
     whitespace = 'normal',
     overflow = 'visible',
     display,
-}) => (
+}: TextProps): ReactElement => (
     <Tag
         data-test-id="text"
         className={merge([

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { merge } from '@utilities/merge';
-import React, { PropsWithChildren, ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from '../shared/records';
 import { SharedTypographyProps } from '../shared/types';
 
@@ -9,14 +9,13 @@ type TextWeight = 'default' | 'strong' | 'x-strong';
 type TextSize = 'x-small' | 'small' | 'medium' | 'large';
 type TextColor = 'default' | 'weak' | 'x-weak' | 'disabled' | 'negative' | 'positive' | 'warning' | 'interactive';
 
-export type TextProps = PropsWithChildren<
-    SharedTypographyProps & {
-        size?: TextSize;
-        weight?: TextWeight;
-        as?: 'a' | 'abbr' | 'address' | 'em' | 'label' | 'li' | 'span' | 'strong' | 'time' | 'p';
-        color?: TextColor;
-    }
->;
+export type TextProps = SharedTypographyProps & {
+    size?: TextSize;
+    weight?: TextWeight;
+    as?: 'a' | 'abbr' | 'address' | 'em' | 'label' | 'li' | 'span' | 'strong' | 'time' | 'p';
+    color?: TextColor;
+    children?: ReactNode;
+};
 
 const weightMap: Record<TextWeight, string> = {
     default: 'tw-font-regular',


### PR DESCRIPTION
# Get types ready for React 18
@types/react at version 18 does not have implicit children property anymore so we decided to replace React.FC and Reac.PropsWithChildren with simple type definitions.

## Replacing React.FC
**Before:** 
`const MyComponent: FC<MyComponentProps> = ({ someProperty }) => ()`

**After:** (children only in use where needed)
`const MyComponent = ({ someProperty, children }: MyComponentProps): ReactElement => ()`

## Replacing PropsWithChildren
**Before:**
`export type MyComponentProps = PropsWithChildren<{
    emphasis?: Emphasis;
    size?: Size;
}>;`

**After:**
```
export type MyComponentProps = {
    emphasis?: Emphasis;
    size?: Size;
    children?: ReactNode;
};

```