### PR TITLE
feat(RTE): export context

### DIFF
--- a/src/components/RichTextEditor/context/index.ts
+++ b/src/components/RichTextEditor/context/index.ts
@@ -1,0 +1,4 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './EditorResizeContext';
+export * from './RichTextEditorContext';

--- a/src/components/RichTextEditor/index.ts
+++ b/src/components/RichTextEditor/index.ts
@@ -9,3 +9,4 @@ export * from './RichTextEditor';
 export * from './utils';
 export * from './Plugins';
 export * from './serializer';
+export * from './context';


### PR DESCRIPTION
Export RTE context, so we can reuse it in `guideline-blocks`