### PR TITLE
fix(Date Picker): fixed arrow position when dropdown is open

### DIFF
--- a/src/components/DatePicker/DatePicker.css
+++ b/src/components/DatePicker/DatePicker.css
@@ -2,9 +2,9 @@
 @import url('react-datepicker/dist/react-datepicker.min.css');
 
 .react-datepicker-popper {
-    /** 
+    /**
      *  The Modal default z-index is 50 (vide Modal.tsx file)
-     *  so it's better to place the DatePicker in a smaller z-index 
+     *  so it's better to place the DatePicker in a smaller z-index
      */
     z-index: 49;
 }
@@ -26,6 +26,7 @@
     left: var(--space-xxl) !important;
     z-index: 1;
 }
+
 .react-datepicker-wrap .react-datepicker__month-container {
     padding: var(--space-m);
 }

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -42,17 +42,31 @@ const TemplateWithFormControl: StoryFn<DatePickerProps> = (args: DatePickerProps
 
     return (
         <div className="tw-flex tw-flex-col">
-            <div className="tw-px-5 tw-py-3 tw-flex tw-flex-col tw-gap-3">
-                <FormControl>
-                    <DatePicker
-                        {...args}
-                        variant="single"
-                        startDate={null}
-                        endDate={null}
-                        value={selectedDate as Date}
-                        onChange={(date) => setSelectedDate(date)}
-                    />
-                </FormControl>
+            <div className="tw-flex tw-flex-row tw-justify-between">
+                <div className="tw-px-5 tw-py-3 tw-flex tw-flex-col tw-gap-3">
+                    <FormControl>
+                        <DatePicker
+                            {...args}
+                            variant="single"
+                            startDate={null}
+                            endDate={null}
+                            value={selectedDate as Date}
+                            onChange={(date) => setSelectedDate(date)}
+                        />
+                    </FormControl>
+                </div>
+                <div className="tw-px-5 tw-py-3 tw-flex tw-flex-col tw-gap-3">
+                    <FormControl>
+                        <DatePicker
+                            {...args}
+                            variant="single"
+                            startDate={null}
+                            endDate={null}
+                            value={selectedDate as Date}
+                            onChange={(date) => setSelectedDate(date)}
+                        />
+                    </FormControl>
+                </div>
             </div>
             <div className="tw-px-5 tw-py-3 tw-flex tw-flex-col tw-gap-3">
                 <FormControl>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -167,6 +167,22 @@ export const DatePicker = forwardRef<ReactDatePicker<never, boolean>, DatePicker
                             />
                         </div>
                     )}
+                    popperModifiers={[
+                        {
+                            name: 'arrow',
+                            options: {
+                                padding: ({ popper, reference, placement }) => {
+                                    const side = placement.includes('end') ? 'left' : 'right';
+                                    const padding = {
+                                        [`${side}`]:
+                                            Math.max(popper.width, Math.min(popper.width, reference.width)) - 40,
+                                    };
+
+                                    return padding;
+                                },
+                            },
+                        },
+                    ]}
                 >
                     {children}
                 </DatepickerComponent>


### PR DESCRIPTION
If the Reference field is smaller and positioned right in the browser then the Arrow should be also positioned right.
This PR fixes it.