### PR TITLE
chore(release-skip): only print release notes preview to job console

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,6 +27,8 @@ jobs:
         steps:
             - name: Checkout current commit
               uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
             - name: Create release-preview branch
               uses: peterjgrainger/action-create-branch@v2.2.0
@@ -39,6 +41,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                   ref: release-preview
+                  fetch-depth: 0
 
             - name: Use Node.js ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v3
@@ -73,7 +76,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
-                  unset GITHUB_ACTIONS && pnpm exec semantic-release --debug --dry-run --no-ci --branches main,release-preview @semantic-release/exec --generateNotesCmd 'echo "${nextRelease.notes}" >> $GITHUB_STEP_SUMMARY'
+                  unset GITHUB_ACTIONS && pnpm exec semantic-release --debug --dry-run --no-ci --branches main,release-preview
 
             - name: Checkout PR commit
               uses: actions/checkout@v3


### PR DESCRIPTION
Saving the Release Notes to the step summary was failing due to invalid characters in the returned markdown.
Until we find a good solution for this issue, printing the release notes preview markdown to the console (default behaviour of `semantic-release --dry-run --no-ci`) is enough.

We can copy the markdown output and paste as the PR into `main` description and edit it there until we have the proper documentation for making the release.