### PR TITLE
fix: align not draggable items on tree

### DIFF
--- a/src/components/Tree/Tree.cy.tsx
+++ b/src/components/Tree/Tree.cy.tsx
@@ -45,9 +45,9 @@ describe('Tree Component', () => {
     it('expands and shrinks the tree on toggle click (uncontrolled)', () => {
         cy.mount(<TreeComponent />);
 
-        cy.get(TREE_ITEM_ID).should('have.length', 2);
+        cy.get(TREE_ITEM_ID).should('have.length', 3);
         cy.get(TREE_ITEM_TOGGLE_ID).first().click();
-        cy.get(TREE_ITEM_ID).should('have.length', 5);
+        cy.get(TREE_ITEM_ID).should('have.length', 6);
     });
 
     it('renders all tree items', () => {
@@ -57,7 +57,7 @@ describe('Tree Component', () => {
         cy.get(TREE_ITEM_TOGGLE_ID).eq(2).click();
         cy.get(TREE_ITEM_TOGGLE_ID).eq(1).click();
 
-        cy.get(TREE_ITEM_ID).should('have.length', 11);
+        cy.get(TREE_ITEM_ID).should('have.length', 12);
     });
 
     it('calls the onSelect callback', () => {

--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -296,7 +296,7 @@ export const TreeItem = ({
                 {showDragHandle ? (
                     <DragHandle ref={setActivatorNodeRef} active={isSelected} {...listeners} {...attributes} />
                 ) : (
-                    <div className="tw-w-6 tw-min-w-[24px]" />
+                    <div className="tw-w-5 tw-ml-2 tw-min-w-[20px]" />
                 )}
 
                 <ExpandButton

--- a/src/components/Tree/utils/mocks.ts
+++ b/src/components/Tree/utils/mocks.ts
@@ -77,4 +77,9 @@ export const treeItemsMock: TreeItemMock[] = [
         id: '2',
         label: 'Design System Testing - Root Childless',
     },
+    {
+        id: '3',
+        label: 'Design System Testing - Not draggable',
+        draggable: false,
+    },
 ];


### PR DESCRIPTION
Align non-draggable items on tree: cover page and all brands link.
Including a non-draggable item on storybook as well

Before:
<img width="239" alt="Screenshot 2023-04-24 at 13 58 50" src="https://user-images.githubusercontent.com/357211/234246318-aa75d492-a5a7-40ed-93eb-43227ed9705c.png">

After:
<img width="260" alt="Screenshot 2023-04-25 at 12 15 14" src="https://user-images.githubusercontent.com/357211/234247017-77d67033-479c-4011-87f1-c7eaeac0ea23.png">


https://app.clickup.com/t/862jp8qqf