### PR TITLE
fix: correct grab cursor hover tree grab icon 

### DIFF
--- a/src/components/Tree/TreeItem/DragHandle.tsx
+++ b/src/components/Tree/TreeItem/DragHandle.tsx
@@ -19,7 +19,7 @@ export const DragHandle = forwardRef(
                 ref={ref}
                 className={merge([
                     FOCUS_VISIBLE_STYLE,
-                    'tw-p-1 first:tw-ml-2 tw-text-text tw-opacity-0 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 tw-rounded-sm',
+                    'tw-p-1 first:tw-ml-2 tw-text-text tw-opacity-0 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 tw-rounded-sm hover:tw-cursor-grab',
                     active && 'tw-opacity-100 tw-text-white',
                 ])}
             >


### PR DESCRIPTION
How to test:
- on _fondue_ repo:
-- checkout this branch
-- run `pnpm run ci`
-- run `pnpm build`
- go to _clarify_ repo: 
-- run `pnpm link <path to your fondue repo>`
-- run `pnpm dev`

Any file generated on any of the repos from these operations should be discarded and avoid commit them