### PR TITLE
fix: nm active element colors on dnd

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -236,12 +236,10 @@ export const TreeItem = ({
                 FOCUS_VISIBLE_STYLE,
                 !isActive && !isSelected && 'focus-within:tw-bg-box-neutral',
                 'tw-outline-none tw-ring-inset tw-group tw-px-2.5 tw-no-underline tw-leading-5 tw-h-10',
-                isSelected
+                isSelected && !transform?.y
                     ? 'tw-font-medium tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover'
                     : 'hover:tw-bg-box-neutral tw-text-text',
-                (isSelected && isActive) || transform?.y
-                    ? 'tw-bg-box-neutral-strong-inverse tw-text-text tw-font-normal'
-                    : '',
+                transform?.y ? 'tw-bg-box-neutral-strong-inverse tw-text-text tw-font-normal' : '',
             ]),
         [isActive, isSelected, transform],
     );


### PR DESCRIPTION
Fixes issue about active item on nm is not visible when DnD item displace it:

<img width="315" alt="Screenshot 2023-04-28 at 14 33 46" src="https://user-images.githubusercontent.com/357211/235149047-c565e8cd-d036-4e21-a020-32fcd317cd77.png">

Before:
<img width="353" alt="Screenshot 2023-04-28 at 14 34 17" src="https://user-images.githubusercontent.com/357211/235149076-0bc25b60-b8a0-4cd6-8bf9-c99feefee9ff.png">

After:
<img width="342" alt="Screenshot 2023-04-28 at 14 40 22" src="https://user-images.githubusercontent.com/357211/235150144-681ac342-bf6b-4880-abad-b00e0931e0db.png">
