### PR TITLE
fix: nm tree dangling deleted item

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -140,7 +140,12 @@ const reducer = produce((draft: TreeState, action: TreeStateAction) => {
                     ...draft.nodes.slice(0, sliceIndex),
                     ...children,
                     ...draft.nodes.slice(sliceIndex),
-                ].filter((node, index, self) => index === self.findIndex((item) => item.key === node.key));
+                ].filter(
+                    (node, index, self) =>
+                        index === self.findIndex((item) => item.key === node.key) &&
+                        ((node.props.parentId === id && newNodeChildrenIds.includes(node.key)) ||
+                            node.props.parentId !== id),
+                );
 
                 draft.nodes = nodes;
             }


### PR DESCRIPTION
This PR fixes the issue present when an item gets deleted and stays dangling around in the tree because it stays registered but it doesn't actually belongs to any parent.

Adds a filter for the nodes array to remove those items not belonging anymore to its parent.


https://app.clickup.com/t/861mqzbb8