### PR TITLE
feat: add `parentType` in the drop callback

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -107,8 +107,8 @@ export const TreeItem = memo(
                     return;
                 }
 
-                if (isActive && over && canDrop) {
-                    onDrop?.({
+                if (isActive && over && canDrop && onDrop) {
+                    onDrop({
                         id: active.id,
                         parentId: projection.parentId,
                         sort: projection.position,

--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -108,7 +108,12 @@ export const TreeItem = memo(
                 }
 
                 if (isActive && over && canDrop) {
-                    onDrop?.({ id: active.id, parentId: projection.parentId, sort: projection.position });
+                    onDrop?.({
+                        id: active.id,
+                        parentId: projection.parentId,
+                        sort: projection.position,
+                        parentType: projection.type,
+                    });
                 }
             },
             [canDrop, isActive, onDrop, projection],

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -14,7 +14,12 @@ export type SensorContext = MutableRefObject<{
 
 export type OnSelectCallback = (id: string) => void;
 export type OnExpandCallback = (id: string) => void;
-export type OnTreeDropCallback = (args: { id: string; parentId: Nullable<string>; sort: number }) => void;
+export type OnTreeDropCallback = (args: {
+    id: string;
+    parentId: Nullable<string>;
+    sort: number;
+    parentType?: string;
+}) => void;
 
 export type TreeProps = {
     id: string;


### PR DESCRIPTION
Adds the possibility to get the `parentType` of the zone we drop in