### PR TITLE
fix: add `aria-label` on drag handle

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -620,7 +620,10 @@ export const Tree = memo(
                         onDragMove={handleDragMove}
                         onDragStart={handleDragStart}
                         onDragCancel={handleDragCancel}
-                        accessibility={{ announcements }}
+                        accessibility={{
+                            announcements,
+                            container: document.getElementById(id)?.parentElement ?? document.body,
+                        }}
                         collisionDetection={closestCenter}
                     >
                         <SortableContext items={items} strategy={verticalListSortingStrategy}>

--- a/src/components/Tree/TreeItem/DragHandle.tsx
+++ b/src/components/Tree/TreeItem/DragHandle.tsx
@@ -15,7 +15,7 @@ export const DragHandle = forwardRef(
     ({ active, className, ...props }: DragHandleProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
         return (
             <button
-                aria-labelledby="DraggableLabel"
+                aria-label="Draggable item"
                 {...props}
                 ref={ref}
                 className={merge([

--- a/src/components/Tree/TreeItem/DragHandle.tsx
+++ b/src/components/Tree/TreeItem/DragHandle.tsx
@@ -15,6 +15,7 @@ export const DragHandle = forwardRef(
     ({ active, className, ...props }: DragHandleProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
         return (
             <button
+                aria-labelledby="DraggableLabel"
                 {...props}
                 ref={ref}
                 className={merge([


### PR DESCRIPTION
Fixes a couple of accessibility issues:
- the aria-description and language (`<div>`) were added into the `<ul>`, they are added outside the `<ul>` now
- the drag button has no aria-label, it will have now a `aria-labeledby` controlled from clarify

https://app.clickup.com/t/8676zm491


