### PR TITLE
feat: add new emphasis and size to match new design

### DIFF
--- a/src/components/Checkbox/Checkbox.cy.tsx
+++ b/src/components/Checkbox/Checkbox.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { ReactElement, useState } from 'react';
 import { Checkbox, CheckboxProps, CheckboxSize, CheckboxState } from './Checkbox';
+import React, { ReactElement, useState } from 'react';
 
 const CHECKBOX_LABEL = 'Checkbox label';
 const HELPER_TEXT = 'Note about this input';
@@ -109,6 +109,12 @@ describe('Checkbox component', () => {
         cy.mount(<CheckboxComponent label={CHECKBOX_LABEL} size={CheckboxSize.Large} />);
 
         cy.get(CHECKBOX_ICON_BOX_ID).should('have.class', 'tw-h-5').should('have.class', 'tw-w-5');
+    });
+
+    it('renders with X-large size', () => {
+        cy.mount(<CheckboxComponent label={CHECKBOX_LABEL} size={CheckboxSize.Large} />);
+
+        cy.get(CHECKBOX_ICON_BOX_ID).should('have.class', 'tw-h-8').should('have.class', 'tw-w-8');
     });
 
     it('renders without a label when hideLabel is true', () => {

--- a/src/components/Checkbox/Checkbox.cy.tsx
+++ b/src/components/Checkbox/Checkbox.cy.tsx
@@ -112,7 +112,7 @@ describe('Checkbox component', () => {
     });
 
     it('renders with X-large size', () => {
-        cy.mount(<CheckboxComponent label={CHECKBOX_LABEL} size={CheckboxSize.Large} />);
+        cy.mount(<CheckboxComponent label={CHECKBOX_LABEL} size={CheckboxSize.XLarge} />);
 
         cy.get(CHECKBOX_ICON_BOX_ID).should('have.class', 'tw-h-8').should('have.class', 'tw-w-8');
     });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -5,6 +5,7 @@ import { InputLabel, InputLabelTooltipProps } from '@components/InputLabel/Input
 import React, { ForwardRefRenderFunction, HTMLAttributes, ReactNode, forwardRef, useEffect, useState } from 'react';
 
 import { FOCUS_STYLE } from '@utilities/focusStyle';
+import { IconSize } from '@foundation/Icon';
 import { merge } from '@utilities/merge';
 import { mergeProps } from '@react-aria/utils';
 import { useCheckbox } from '@react-aria/checkbox';
@@ -121,7 +122,9 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
     };
 
     const stateMap: Record<CheckboxState, ReactNode> = {
-        [CheckboxState.Checked]: <IconCheckMark />,
+        [CheckboxState.Checked]: (
+            <IconCheckMark size={size === CheckboxSize.XLarge ? IconSize.Size24 : IconSize.Size16} />
+        ),
         [CheckboxState.Mixed]: <IconMinus />,
         [CheckboxState.Unchecked]: null,
     };

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,8 +2,7 @@
 
 import { IconCheckMark, IconMinus } from '@foundation/Icon/Generated';
 import { InputLabel, InputLabelTooltipProps } from '@components/InputLabel/InputLabel';
-import React, { ForwardRefRenderFunction, HTMLAttributes, forwardRef } from 'react';
-import { useEffect, useState } from 'react';
+import React, { ForwardRefRenderFunction, HTMLAttributes, ReactNode, forwardRef, useEffect, useState } from 'react';
 
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
@@ -115,20 +114,40 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
         inputRef,
     );
 
-    const getCheckboxSize = () => {
-        switch (size) {
-            case CheckboxSize.Large: {
-                return 'tw-h-5 tw-w-5';
-            }
-            case CheckboxSize.XLarge: {
-                return 'tw-h-8 tw-w-8';
-            }
-            case CheckboxSize.Default:
-            default: {
-                return 'tw-h-4 tw-w-4';
-            }
-        }
+    const sizeClassesMap: Record<CheckboxSize, string> = {
+        [CheckboxSize.Default]: 'tw-h-4 tw-w-4',
+        [CheckboxSize.Large]: 'tw-h-5 tw-w-5',
+        [CheckboxSize.XLarge]: 'tw-h-8 tw-w-8',
     };
+
+    const stateMap: Record<CheckboxState, ReactNode> = {
+        [CheckboxState.Checked]: <IconCheckMark />,
+        [CheckboxState.Mixed]: <IconMinus />,
+        [CheckboxState.Unchecked]: null,
+    };
+
+    const checkedOrMixed = isCheckedOrMixed(state);
+
+    const disabledClasses = merge([
+        'tw-bg-box-disabled tw-pointer-events-none',
+        !checkedOrMixed && 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
+        checkedOrMixed && 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
+    ]);
+
+    const enabledClasses = merge([
+        !checkedOrMixed && 'tw-bg-base hover:tw-bg-box-neutral',
+        !checkedOrMixed && emphasis !== CheckboxEmphasis.Strong && 'tw-border tw-border-line-xx-strong',
+        !checkedOrMixed && emphasis === CheckboxEmphasis.Strong && 'tw-border-2 tw-border-box-selected-strong',
+        checkedOrMixed &&
+            emphasis === CheckboxEmphasis.Weak &&
+            'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
+        checkedOrMixed &&
+            emphasis === CheckboxEmphasis.Default &&
+            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
+        checkedOrMixed &&
+            emphasis === CheckboxEmphasis.Strong &&
+            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
+    ]);
 
     return (
         <div className="tw-gap-1 tw-transition-colors" data-test-id="checkbox">
@@ -139,7 +158,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                     htmlFor={id}
                     tooltip={tooltip ?? undefined}
                     required={required}
-                    bold={isCheckedOrMixed(state)}
+                    bold={checkedOrMixed}
                 >
                     <span className="tw-flex tw-items-center">
                         <span className="tw-inline-flex tw-mr-1.5">
@@ -159,37 +178,11 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                 aria-hidden="true"
                                 className={merge([
                                     'tw-leading-3 tw-p-2 tw-relative tw-flex tw-items-center tw-justify-center tw-rounded tw-shrink-0 tw-flex-none',
-                                    getCheckboxSize(),
-                                    disabled
-                                        ? merge([
-                                              'tw-bg-box-disabled tw-pointer-events-none',
-                                              !isCheckedOrMixed(state) &&
-                                                  'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
-                                              isCheckedOrMixed(state) &&
-                                                  'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
-                                          ])
-                                        : merge([
-                                              !isCheckedOrMixed(state) && 'tw-bg-base hover:tw-bg-box-neutral',
-                                              !isCheckedOrMixed(state) &&
-                                                  emphasis !== CheckboxEmphasis.Strong &&
-                                                  'tw-border tw-border-line-xx-strong',
-                                              !isCheckedOrMixed(state) &&
-                                                  emphasis === CheckboxEmphasis.Strong &&
-                                                  'tw-border-2 tw-border-box-selected-strong',
-                                              isCheckedOrMixed(state) &&
-                                                  emphasis === CheckboxEmphasis.Weak &&
-                                                  'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
-                                              isCheckedOrMixed(state) &&
-                                                  emphasis === CheckboxEmphasis.Default &&
-                                                  'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-                                              isCheckedOrMixed(state) &&
-                                                  emphasis === CheckboxEmphasis.Strong &&
-                                                  'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-                                          ]),
+                                    sizeClassesMap[size],
+                                    disabled ? disabledClasses : enabledClasses,
                                 ])}
                             >
-                                {state === CheckboxState.Checked && <IconCheckMark />}
-                                {state === CheckboxState.Mixed && <IconMinus />}
+                                {stateMap[state]}
                             </span>
                         </span>
                         <span className="tw-inline-flex tw-flex-col">
@@ -198,7 +191,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                     data-test-id="checkbox-label"
                                     className={merge([
                                         'tw-text-xs tw-select-none hover:tw-cursor-pointer hover:tw-text-black dark:hover:tw-text-white group-hover:tw-text-black dark:group-hover:tw-text-white',
-                                        isCheckedOrMixed(state) ? 'tw-font-medium' : '',
+                                        checkedOrMixed ? 'tw-font-medium' : '',
                                     ])}
                                 >
                                     {label}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -133,24 +133,26 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
 
     const disabledClasses = merge([
         'tw-bg-box-disabled tw-pointer-events-none',
-        !checkedOrMixed && 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
+        'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
         checkedOrMixed && 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
     ]);
 
-    const enabledClasses = merge([
-        !checkedOrMixed && 'tw-bg-base hover:tw-bg-box-neutral',
-        !checkedOrMixed && emphasis !== CheckboxEmphasis.Strong && 'tw-border tw-border-line-xx-strong',
-        !checkedOrMixed && emphasis === CheckboxEmphasis.Strong && 'tw-border-2 tw-border-box-selected-strong',
-        checkedOrMixed &&
-            emphasis === CheckboxEmphasis.Weak &&
-            'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
-        checkedOrMixed &&
-            emphasis === CheckboxEmphasis.Default &&
-            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-        checkedOrMixed &&
-            emphasis === CheckboxEmphasis.Strong &&
-            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-    ]);
+    const enabledClasses = merge(
+        checkedOrMixed
+            ? [
+                  emphasis === CheckboxEmphasis.Weak &&
+                      'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
+                  emphasis === CheckboxEmphasis.Default &&
+                      'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
+                  emphasis === CheckboxEmphasis.Strong &&
+                      'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
+              ]
+            : [
+                  'tw-bg-base hover:tw-bg-box-neutral',
+                  emphasis !== CheckboxEmphasis.Strong && 'tw-border tw-border-line-xx-strong',
+                  emphasis === CheckboxEmphasis.Strong && 'tw-border-2 tw-border-box-selected-strong',
+              ],
+    );
 
     return (
         <div className="tw-gap-1 tw-transition-colors" data-test-id="checkbox">

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -116,9 +116,12 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
     );
 
     const emphasisCheckedClassesMap: Record<CheckboxEmphasis, string> = {
-        [CheckboxEmphasis.Weak]: 'tw-h-4 tw-w-4',
-        [CheckboxEmphasis.Default]: 'tw-h-5 tw-w-5',
-        [CheckboxEmphasis.Strong]: 'tw-h-8 tw-w-8',
+        [CheckboxEmphasis.Weak]:
+            'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
+        [CheckboxEmphasis.Default]:
+            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
+        [CheckboxEmphasis.Strong]:
+            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
     };
 
     const sizeClassesMap: Record<CheckboxSize, string> = {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,17 +1,18 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useEffect, useState } from 'react';
 import { IconCheckMark, IconMinus } from '@foundation/Icon/Generated';
 import { InputLabel, InputLabelTooltipProps } from '@components/InputLabel/InputLabel';
-import { useMemoizedId } from '@hooks/useMemoizedId';
-import { useCheckbox } from '@react-aria/checkbox';
-import { useFocusRing } from '@react-aria/focus';
-import { mergeProps } from '@react-aria/utils';
-import { useToggleState } from '@react-stately/toggle';
+import React, { ForwardRefRenderFunction, HTMLAttributes, forwardRef } from 'react';
+import { useEffect, useState } from 'react';
+
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
+import { mergeProps } from '@react-aria/utils';
+import { useCheckbox } from '@react-aria/checkbox';
+import { useFocusRing } from '@react-aria/focus';
 import { useForwardedRef } from '@utilities/useForwardedRef';
-import React, { ForwardRefRenderFunction, HTMLAttributes, forwardRef } from 'react';
+import { useMemoizedId } from '@hooks/useMemoizedId';
+import { useToggleState } from '@react-stately/toggle';
 
 export enum CheckboxState {
     Checked = 'Checked',
@@ -22,11 +23,13 @@ export enum CheckboxState {
 export enum CheckboxEmphasis {
     Default = 'Default',
     Weak = 'Weak',
+    Strong = 'Strong',
 }
 
 export enum CheckboxSize {
     Default = 'Default',
     Large = 'Large',
+    XLarge = 'XLarge',
 }
 
 export type CheckboxProps = {
@@ -112,6 +115,21 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
         inputRef,
     );
 
+    const getCheckboxSize = () => {
+        switch (size) {
+            case CheckboxSize.Large: {
+                return 'tw-h-6 tw-w-6';
+            }
+            case CheckboxSize.XLarge: {
+                return 'tw-h-8 tw-w-8';
+            }
+            case CheckboxSize.Default:
+            default: {
+                return 'tw-h-4 tw-w-4';
+            }
+        }
+    };
+
     return (
         <div className="tw-gap-1 tw-transition-colors" data-test-id="checkbox">
             <div className={merge(['tw-inline-flex tw-flex-row tw-rounded', showFocus ? FOCUS_STYLE : ''])}>
@@ -140,8 +158,8 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                 data-test-id="checkbox-icon-box"
                                 aria-hidden="true"
                                 className={merge([
-                                    'tw-leading-3  tw-p-2 tw-relative tw-flex tw-items-center tw-justify-center tw-rounded tw-border tw-shrink-0 tw-flex-none',
-                                    size === 'Default' ? 'tw-h-4 tw-w-4' : 'tw-h-5 tw-w-5',
+                                    'tw-leading-3 tw-p-2 tw-relative tw-flex tw-items-center tw-justify-center tw-rounded tw-shrink-0 tw-flex-none',
+                                    getCheckboxSize(),
                                     disabled
                                         ? merge([
                                               'tw-bg-box-disabled tw-pointer-events-none',
@@ -151,13 +169,21 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                                   'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
                                           ])
                                         : merge([
+                                              !isCheckedOrMixed(state) && 'tw-bg-base hover:tw-bg-box-neutral',
                                               !isCheckedOrMixed(state) &&
-                                                  'tw-bg-base tw-border-line-xx-strong hover:tw-bg-box-neutral',
+                                                  emphasis !== CheckboxEmphasis.Strong &&
+                                                  'tw-border tw-border-line-xx-strong',
+                                              !isCheckedOrMixed(state) &&
+                                                  emphasis === CheckboxEmphasis.Strong &&
+                                                  'tw-border-2 tw-border-box-selected-strong',
                                               isCheckedOrMixed(state) &&
                                                   emphasis === CheckboxEmphasis.Weak &&
                                                   'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
                                               isCheckedOrMixed(state) &&
                                                   emphasis === CheckboxEmphasis.Default &&
+                                                  'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
+                                              isCheckedOrMixed(state) &&
+                                                  emphasis === CheckboxEmphasis.Strong &&
                                                   'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
                                           ]),
                                 ])}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -108,12 +108,18 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
             isDisabled: disabled,
             isRequired: required,
             isIndeterminate: state === CheckboxState.Mixed,
-            'aria-label': ariaLabel || label,
+            'aria-label': ariaLabel,
             value,
         },
         toggleState,
         inputRef,
     );
+
+    const emphasisCheckedClassesMap: Record<CheckboxEmphasis, string> = {
+        [CheckboxEmphasis.Weak]: 'tw-h-4 tw-w-4',
+        [CheckboxEmphasis.Default]: 'tw-h-5 tw-w-5',
+        [CheckboxEmphasis.Strong]: 'tw-h-8 tw-w-8',
+    };
 
     const sizeClassesMap: Record<CheckboxSize, string> = {
         [CheckboxSize.Default]: 'tw-h-4 tw-w-4',
@@ -132,27 +138,18 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
     const checkedOrMixed = isCheckedOrMixed(state);
 
     const disabledClasses = merge([
-        'tw-bg-box-disabled tw-pointer-events-none',
-        'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
-        checkedOrMixed && 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-border-line-strong',
+        'tw-bg-box-disabled tw-pointer-events-none tw-text-box-disabled-inverse tw-border-line-strong',
+        checkedOrMixed && 'tw-text-box-disabled-inverse tw-border-line-strong',
     ]);
 
-    const enabledClasses = merge(
-        checkedOrMixed
-            ? [
-                  emphasis === CheckboxEmphasis.Weak &&
-                      'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
-                  emphasis === CheckboxEmphasis.Default &&
-                      'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-                  emphasis === CheckboxEmphasis.Strong &&
-                      'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-              ]
-            : [
-                  'tw-bg-base hover:tw-bg-box-neutral',
-                  emphasis !== CheckboxEmphasis.Strong && 'tw-border tw-border-line-xx-strong',
-                  emphasis === CheckboxEmphasis.Strong && 'tw-border-2 tw-border-box-selected-strong',
-              ],
-    );
+    const enabledClasses = checkedOrMixed
+        ? emphasisCheckedClassesMap[emphasis]
+        : merge([
+              'tw-bg-base hover:tw-bg-box-neutral',
+              emphasis === CheckboxEmphasis.Strong
+                  ? 'tw-border-2 tw-border-box-selected-strong'
+                  : 'tw-border tw-border-line-xx-strong',
+          ]);
 
     return (
         <div className="tw-gap-1 tw-transition-colors" data-test-id="checkbox">
@@ -161,7 +158,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                     disabled={disabled}
                     clickable
                     htmlFor={id}
-                    tooltip={tooltip ?? undefined}
+                    tooltip={tooltip}
                     required={required}
                     bold={checkedOrMixed}
                 >
@@ -175,7 +172,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                 data-test-id="checkbox-input"
                                 aria-label={ariaLabel}
                                 role="checkbox"
-                                aria-checked={state === CheckboxState.Checked ? true : false}
+                                aria-checked={state === CheckboxState.Checked}
                                 required={required}
                             />
                             <span
@@ -196,7 +193,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                     data-test-id="checkbox-label"
                                     className={merge([
                                         'tw-text-xs tw-select-none hover:tw-cursor-pointer hover:tw-text-black dark:hover:tw-text-white group-hover:tw-text-black dark:group-hover:tw-text-white',
-                                        checkedOrMixed ? 'tw-font-medium' : '',
+                                        checkedOrMixed && 'tw-font-medium',
                                     ])}
                                 >
                                     {label}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -53,6 +53,22 @@ const isCheckedOrMixed = (checked: CheckboxState): boolean => {
     return checked === CheckboxState.Checked || checked === CheckboxState.Mixed;
 };
 
+const emphasisDefaultClasses =
+    'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover';
+
+const emphasisCheckedClassesMap: Record<CheckboxEmphasis, string> = {
+    [CheckboxEmphasis.Weak]:
+        'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
+    [CheckboxEmphasis.Default]: emphasisDefaultClasses,
+    [CheckboxEmphasis.Strong]: emphasisDefaultClasses,
+};
+
+const sizeClassesMap: Record<CheckboxSize, string> = {
+    [CheckboxSize.Default]: 'tw-h-4 tw-w-4',
+    [CheckboxSize.Large]: 'tw-h-5 tw-w-5',
+    [CheckboxSize.XLarge]: 'tw-h-8 tw-w-8',
+};
+
 const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProps> = (
     {
         id: propId,
@@ -114,21 +130,6 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
         toggleState,
         inputRef,
     );
-
-    const emphasisCheckedClassesMap: Record<CheckboxEmphasis, string> = {
-        [CheckboxEmphasis.Weak]:
-            'tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover',
-        [CheckboxEmphasis.Default]:
-            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-        [CheckboxEmphasis.Strong]:
-            'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover',
-    };
-
-    const sizeClassesMap: Record<CheckboxSize, string> = {
-        [CheckboxSize.Default]: 'tw-h-4 tw-w-4',
-        [CheckboxSize.Large]: 'tw-h-5 tw-w-5',
-        [CheckboxSize.XLarge]: 'tw-h-8 tw-w-8',
-    };
 
     const stateMap: Record<CheckboxState, ReactNode> = {
         [CheckboxState.Checked]: (

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -118,7 +118,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
     const getCheckboxSize = () => {
         switch (size) {
             case CheckboxSize.Large: {
-                return 'tw-h-6 tw-w-6';
+                return 'tw-h-5 tw-w-5';
             }
             case CheckboxSize.XLarge: {
                 return 'tw-h-8 tw-w-8';


### PR DESCRIPTION
https://www.figma.com/file/sNs31nygQIXSfM55RbvS8B/Bulk-Select-Assets?type=design&node-id=875-236497&t=fHKW9xCmM5Knat0Q-4

- Add a checkbox size to be able to have a checkbox of 32px width and height
- Add an emphasis to change the checkbox style (border width, border color) and remove the border when is checked.
