### PR TITLE
feat(segmentedControls): remove px in simple item

### DIFF
--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -95,7 +95,7 @@ const SegmentedControlsItem = forwardRef<HTMLDivElement, SegmentedControlsItemPr
                 onClick={handleMockLabelClick}
                 data-test-id={getSegmentedControlsItemTestId()}
                 className={merge([
-                    'tw-relative tw-w-full tw-px-4 tw-py-2 tw-inline-flex tw-justify-center tw-items-center tw-font-sans tw-font-normal tw-h-full tw-text-center',
+                    'tw-relative tw-w-full tw-py-2 tw-inline-flex tw-justify-center tw-items-center tw-font-sans tw-font-normal tw-h-full tw-text-center',
                     isActive && !disabled ? 'tw-text-text' : 'tw-text-text-weak',
                     !disabled
                         ? 'hover:tw-text-text hover:tw-cursor-pointer'

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -40,11 +40,12 @@ interface SegmentedControlsItemProps {
     id: string;
     item: TextOrNumberItem | IconItem;
     disabled: boolean;
+    hugWidth: boolean;
     radioGroupState: RadioGroupState;
 }
 
 const SegmentedControlsItem = forwardRef<HTMLDivElement, SegmentedControlsItemProps>((props, ref) => {
-    const { id, item, disabled, radioGroupState } = props;
+    const { id, item, disabled, radioGroupState, hugWidth } = props;
     const inputRef = useRef<HTMLInputElement | null>(null);
     const isActive = item.id === radioGroupState.selectedValue;
     const { inputProps } = useRadio(
@@ -100,6 +101,7 @@ const SegmentedControlsItem = forwardRef<HTMLDivElement, SegmentedControlsItemPr
                     !disabled
                         ? 'hover:tw-text-text hover:tw-cursor-pointer'
                         : 'tw-text-box-disabled-inverse hover:tw-cursor-not-allowed',
+                    hugWidth ? 'tw-px-4' : 'tw-px-2',
                 ])}
             >
                 <VisuallyHidden>
@@ -144,13 +146,14 @@ export const SegmentedControls = ({
             <SegmentedControlsItem
                 id={id}
                 item={item}
+                hugWidth={hugWidth}
                 disabled={disabled}
                 radioGroupState={radioGroupState}
                 ref={(el) => (itemsRef.current[index] = el)}
                 key={`fondue-segmented-controls-${id}-item-${item.id}`}
             />
         ));
-    }, [items, id, disabled, radioGroupState]);
+    }, [items, id, disabled, radioGroupState, hugWidth]);
     const selectedIndex = items.findIndex((item) => item.id === radioGroupState.selectedValue);
     const width = hugWidth ? '' : 'tw-w-full';
     const alignment = hugWidth ? 'tw-flex' : 'tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly';


### PR DESCRIPTION
px was added [here](https://github.com/Frontify/fondue/pull/1420/files#:~:text=w%2Dfull%20tw%2D-,px,-%2D4%20tw%2Dpy)

issue when the segment is small:
<img width="133" alt="image" src="https://github.com/Frontify/fondue/assets/42832501/045eeb47-80c9-4e75-b228-68e1d465bcdc">

now:
<img width="149" alt="image" src="https://github.com/Frontify/fondue/assets/42832501/a9828c6a-4f6d-4218-8542-bb58f471177a">
