### PR TITLE
chore: editable data-test-id in Fondue components

### DIFF
--- a/src/components/AddBlockButton/AddBlockButton.tsx
+++ b/src/components/AddBlockButton/AddBlockButton.tsx
@@ -18,12 +18,14 @@ export type AddBlockButtonProps = {
     onClick: () => void;
     title?: string;
     orientation?: AddBlockButtonDirection;
+    'data-test-id'?: string;
 };
 
 export const AddBlockButton = ({
     onClick,
     title,
     orientation = AddBlockButtonDirection.Horizontal,
+    'data-test-id': dataTestId = 'add-block-button',
 }: AddBlockButtonProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
     const ref = useRef<HTMLButtonElement | null>(null);
@@ -33,7 +35,7 @@ export const AddBlockButton = ({
         <button
             {...mergeProps(buttonProps, focusProps)}
             title={title}
-            data-test-id="add-block-button"
+            data-test-id={dataTestId}
             className={merge([
                 'tw-group tw-leading-none tw-rounded-sm tw-outline-none',
                 isFocusVisible && FOCUS_STYLE,

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -19,6 +19,7 @@ export const Badge = ({
     disabled = false,
     onClick,
     onDismiss,
+    'data-test-id': dataTestId = 'badge',
 }: BadgeProps): Nullable<ReactElement> => {
     if (!children && !icon && !status) {
         return null;
@@ -50,7 +51,7 @@ export const Badge = ({
                     ? 'tw-bg-box-disabled tw-text-box-disabled-inverse'
                     : getStyleClasses(style, !!onClick, emphasis === BadgeEmphasis.Strong),
             ])}
-            data-test-id="badge"
+            data-test-id={dataTestId}
         >
             <Container
                 onClick={() => onClick && onClick()}
@@ -62,13 +63,13 @@ export const Badge = ({
                         : getSizeClasses(children, status, icon, size, !!onDismiss),
                     FOCUS_VISIBLE_STYLE,
                 ])}
-                data-test-id="badge-button"
+                data-test-id={`${dataTestId}-button`}
                 title={badgeTitle}
             >
-                {status && <BadgeStatusIcon status={status} disabled={disabled} />}
+                {status && <BadgeStatusIcon status={status} disabled={disabled} data-test-id={dataTestId} />}
                 {icon && (
                     <span
-                        data-test-id="badge-icon"
+                        data-test-id={`${dataTestId}-icon`}
                         className={merge([
                             'tw-flex-none tw-leading-none',
                             disabled && 'tw-opacity-30',
@@ -87,7 +88,7 @@ export const Badge = ({
             {onDismiss && (
                 <button
                     type="button"
-                    data-test-id="badge-dismiss"
+                    data-test-id={`${dataTestId}-dismiss`}
                     className={merge([
                         'tw-absolute tw-rounded tw-leading-4',
                         FOCUS_VISIBLE_STYLE,

--- a/src/components/Badge/BadgeStatusIcon.tsx
+++ b/src/components/Badge/BadgeStatusIcon.tsx
@@ -7,10 +7,10 @@ import { ColorFormat } from '../../types';
 import { badgeStatusClasses, isBadgeStatus } from './helpers';
 import { BadgeStatusIconProps } from './types';
 
-export const BadgeStatusIcon = ({ status, disabled }: BadgeStatusIconProps) => (
+export const BadgeStatusIcon = ({ status, disabled, 'data-test-id': dataTestId = 'badge' }: BadgeStatusIconProps) => (
     <div className="tw-px-0.5 tw-flex-none tw-inline-flex tw-justify-center tw-items-center tw-pr-1">
         <span
-            data-test-id="badge-status"
+            data-test-id={`${dataTestId}-status`}
             className={merge([
                 'tw-w-2 tw-h-2 tw-rounded-full tw-flex-none',
                 disabled && 'tw-opacity-30',

--- a/src/components/Badge/types.ts
+++ b/src/components/Badge/types.ts
@@ -16,9 +16,10 @@ export type BadgeProps = {
     emphasis?: BadgeEmphasis;
     size?: BadgeSize;
     children?: ReactNode;
+    'data-test-id'?: string;
 };
 
-export type BadgeStatusIconProps = { status: BadgeStatus | Color | string; disabled: boolean };
+export type BadgeStatusIconProps = { status: BadgeStatus | Color | string; disabled: boolean; 'data-test-id'?: string };
 
 export enum BadgeStatus {
     Positive = 'Positive',

--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -27,9 +27,16 @@ const Separator = () => (
 
 type BreadcrumbItemProps = Pick<Breadcrumb, 'label' | 'link' | 'onClick'> & {
     showSeparator: boolean;
+    'data-test-id'?: string;
 };
 
-export const BreadcrumbItem = ({ label, link, onClick, showSeparator }: BreadcrumbItemProps): ReactElement => {
+export const BreadcrumbItem = ({
+    label,
+    link,
+    onClick,
+    showSeparator,
+    'data-test-id': dataTestId = 'breadcrumb',
+}: BreadcrumbItemProps): ReactElement => {
     const ref = useRef(null);
 
     const Element = getItemElementType(link, onClick);
@@ -51,7 +58,7 @@ export const BreadcrumbItem = ({ label, link, onClick, showSeparator }: Breadcru
     return (
         <li
             className="tw-flex tw-items-center tw-text-text-weak hover:tw-text-text tw-text-xs tw-transition-colors"
-            data-test-id="breadcrumb-item"
+            data-test-id={`${dataTestId}-item`}
         >
             <Element ref={ref} {...props} className={merge(['tw-outline-none', isFocusVisible && FOCUS_STYLE])}>
                 {label}

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -22,18 +22,20 @@ export type Breadcrumb = {
     decorator?: ReactElement<IconProps>;
     bold?: boolean;
     badges?: BadgeProps[];
+    'data-test-id'?: string;
 };
 
 export type BreadcrumbsProps = {
     items: Breadcrumb[];
+    'data-test-id'?: string;
 };
 
-export const Breadcrumbs = ({ items }: BreadcrumbsProps): ReactElement => {
+export const Breadcrumbs = ({ items, 'data-test-id': dataTestId = 'breadcrumb' }: BreadcrumbsProps): ReactElement => {
     const props = mapBreadcrumbsToAriaProps(items);
     const { navProps } = useBreadcrumbs(props as AriaBreadcrumbsProps);
 
     return (
-        <nav {...navProps} className="tw-font-sans" aria-label="Breadcrumb">
+        <nav {...navProps} className="tw-font-sans" aria-label="Breadcrumb" data-test-id={dataTestId}>
             <ol className="tw-list-none tw-flex tw-flex-wrap tw-gap-y-1">
                 {items.map(({ label, badges, bold, decorator, link, onClick }, index) => {
                     const isCurrent = index === items.length - 1;
@@ -49,6 +51,7 @@ export const Breadcrumbs = ({ items }: BreadcrumbsProps): ReactElement => {
                                 decorator={decorator}
                                 link={link}
                                 onClick={onClick}
+                                data-test-id={dataTestId}
                             />
                         );
                     }
@@ -60,6 +63,7 @@ export const Breadcrumbs = ({ items }: BreadcrumbsProps): ReactElement => {
                             link={link}
                             onClick={onClick}
                             showSeparator={index < items.length - 2}
+                            data-test-id={dataTestId}
                         />
                     );
                 })}

--- a/src/components/Breadcrumbs/CurrentBreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/CurrentBreadcrumbItem.tsx
@@ -21,6 +21,7 @@ export const CurrentBreadcrumbItem = ({
     decorator,
     link,
     onClick,
+    'data-test-id': dataTestId = 'breadcrumb',
 }: CurrentBreadcrumbItemProps): ReactElement => {
     const ref = useRef(null);
     const Element = getItemElementType(link, onClick);
@@ -47,7 +48,7 @@ export const CurrentBreadcrumbItem = ({
     return (
         <li
             className="tw-w-full tw-inline-flex tw-align-middle tw-gap-x-1 tw-text-m tw-text-text tw-items-center"
-            data-test-id="breadcrumb-item"
+            data-test-id={`${dataTestId}-item`}
         >
             <Element ref={ref} {...props} className={classNames}>
                 {decorator}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -124,14 +124,17 @@ const ButtonComponent: ForwardRefRenderFunction<HTMLButtonElement | null, Button
         >
             {icon && (
                 <span
-                    data-test-id="button-icon"
+                    data-test-id={`${dataTestId}-icon`}
                     className={merge([children && !hideLabel ? IconSpacingClasses[size] : '', getStyles('icon')])}
                 >
                     {cloneElement(icon, { size: buttonIconSizeMap[size] })}
                 </span>
             )}
             {children && (
-                <span data-test-id="button-text" className={merge([getStyles('text'), hideLabel && 'tw-sr-only'])}>
+                <span
+                    data-test-id={`${dataTestId}-text`}
+                    className={merge([getStyles('text'), hideLabel && 'tw-sr-only'])}
+                >
                     {children}
                 </span>
             )}

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -4,7 +4,7 @@ import React, { Children, ReactElement, ReactNode, cloneElement, isValidElement 
 import { ButtonProps, ButtonSize } from '@components/Button';
 import { merge } from '@utilities/merge';
 
-export type ButtonGroupProps = { size: ButtonSize; children?: ReactNode };
+export type ButtonGroupProps = { size: ButtonSize; children?: ReactNode; 'data-test-id'?: string };
 
 const spacing: Record<ButtonSize, string> = {
     [ButtonSize.Small]: 'tw-gap-x-1',
@@ -12,9 +12,13 @@ const spacing: Record<ButtonSize, string> = {
     [ButtonSize.Large]: 'tw-gap-x-3',
 };
 
-export const ButtonGroup = ({ children, size }: ButtonGroupProps): ReactElement => {
+export const ButtonGroup = ({
+    children,
+    size,
+    'data-test-id': dataTestId = 'button-group',
+}: ButtonGroupProps): ReactElement => {
     return (
-        <div data-test-id="button-group" className={merge(['tw-display tw-inline-flex tw-flex-row', spacing[size]])}>
+        <div data-test-id={dataTestId} className={merge(['tw-display tw-inline-flex tw-flex-row', spacing[size]])}>
             {Children.map(children, (child) => {
                 if (!isValidElement(child)) {
                     return null;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -12,9 +12,15 @@ export type CardProps = {
     children: ReactNode | ReactNode[];
     hoverable?: boolean;
     onClick?: (event: PressEvent) => void;
+    'data-test-id'?: string;
 };
 
-export const Card = ({ hoverable = false, children, onClick }: CardProps): ReactElement => {
+export const Card = ({
+    hoverable = false,
+    children,
+    onClick,
+    'data-test-id': dataTestId = 'card',
+}: CardProps): ReactElement => {
     const ref = useRef<HTMLDivElement | null>(null);
     const { buttonProps } = useButton(
         { elementType: 'div', onPress: (event: PressEvent) => onClick && onClick(event) },
@@ -27,7 +33,7 @@ export const Card = ({ hoverable = false, children, onClick }: CardProps): React
     return (
         <div
             {...clickableProps}
-            data-test-id="card"
+            data-test-id={dataTestId}
             ref={ref}
             className={merge([
                 'tw-w-full tw-outline-none tw-bg-white tw-border tw-border-black-10 tw-rounded tw-overflow-hidden',

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -47,6 +47,7 @@ export type CheckboxProps = {
     helperText?: string;
     'aria-label'?: string;
     groupInputProps?: HTMLAttributes<HTMLElement>;
+    'data-test-id'?: string;
 };
 
 const isCheckedOrMixed = (checked: CheckboxState): boolean => {
@@ -85,6 +86,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
         groupInputProps,
         onChange,
         state = CheckboxState.Unchecked,
+        'data-test-id': dataTestId = 'checkbox',
     },
     ref,
 ) => {
@@ -156,7 +158,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
           ]);
 
     return (
-        <div className="tw-gap-1 tw-transition-colors" data-test-id="checkbox">
+        <div className="tw-gap-1 tw-transition-colors" data-test-id={dataTestId}>
             <div className={merge(['tw-inline-flex tw-flex-row tw-rounded', showFocus ? FOCUS_STYLE : ''])}>
                 <InputLabel
                     disabled={disabled}
@@ -173,14 +175,14 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                 id={id}
                                 ref={inputRef}
                                 className="tw-sr-only"
-                                data-test-id="checkbox-input"
+                                data-test-id={`${dataTestId}-input`}
                                 aria-label={ariaLabel}
                                 role="checkbox"
                                 aria-checked={state === CheckboxState.Checked}
                                 required={required}
                             />
                             <span
-                                data-test-id="checkbox-icon-box"
+                                data-test-id={`${dataTestId}-icon-box`}
                                 aria-hidden="true"
                                 className={merge([
                                     'tw-leading-3 tw-p-2 tw-relative tw-flex tw-items-center tw-justify-center tw-rounded tw-shrink-0 tw-flex-none',
@@ -194,7 +196,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                         <span className="tw-inline-flex tw-flex-col">
                             {label && !hideLabel && (
                                 <span
-                                    data-test-id="checkbox-label"
+                                    data-test-id={`${dataTestId}-label`}
                                     className={merge([
                                         'tw-text-xs tw-select-none hover:tw-cursor-pointer hover:tw-text-black dark:hover:tw-text-white group-hover:tw-text-black dark:group-hover:tw-text-white',
                                         checkedOrMixed && 'tw-font-medium',
@@ -205,7 +207,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                             )}
                             {helperText && !hideLabel && (
                                 <span
-                                    data-test-id="checkbox-helper-text"
+                                    data-test-id={`${dataTestId}-helper-text`}
                                     className={merge([
                                         'tw-font-sans tw-text-xs tw-font-normal',
                                         disabled ? 'text-disabled' : 'tw-text-text-weak',

--- a/src/components/Checklist/Checklist.tsx
+++ b/src/components/Checklist/Checklist.tsx
@@ -27,6 +27,7 @@ type ChecklistBase = {
     setActiveValues: (value: string[]) => void;
     activeValues?: string[];
     ariaLabel?: string;
+    'data-test-id'?: string;
 };
 
 type ChecklistVertical = ChecklistBase & {
@@ -85,6 +86,7 @@ export const Checklist = ({
     ariaLabel = 'Checklist',
     activeValues = [],
     direction = ChecklistDirection.Horizontal,
+    'data-test-id': dataTestId = 'checklist',
     ...props
 }: ChecklistProps) => {
     const listContainerRef = useRef<HTMLUListElement | null>(null);
@@ -104,7 +106,7 @@ export const Checklist = ({
     return (
         <ul
             {...groupProps}
-            data-test-id="checklist"
+            data-test-id={dataTestId}
             className={merge([
                 direction === ChecklistDirection.Horizontal
                     ? 'tw-flex tw-flex-row tw-gap-12'

--- a/src/components/CollapsibleWrap/CollapsibleWrap.tsx
+++ b/src/components/CollapsibleWrap/CollapsibleWrap.tsx
@@ -9,6 +9,7 @@ export const CollapsibleWrap = ({
     isOpen = false,
     preventInitialAnimation = false,
     animateOpacity = true,
+    'data-test-id': dataTestId = 'collapsible-wrap',
 }: CollapsibleWrapProps): ReactElement => (
     <AnimatePresence initial={preventInitialAnimation ? false : undefined}>
         {isOpen && children && (
@@ -21,7 +22,7 @@ export const CollapsibleWrap = ({
                     collapsed: { height: 0, overflow: 'hidden', opacity: animateOpacity ? 0 : 1 },
                 }}
                 transition={{ type: 'tween' }}
-                data-test-id="collapsible-wrap"
+                data-test-id={dataTestId}
             >
                 {children}
             </motion.div>

--- a/src/components/CollapsibleWrap/types.ts
+++ b/src/components/CollapsibleWrap/types.ts
@@ -7,4 +7,5 @@ export type CollapsibleWrapProps = {
     preventInitialAnimation?: boolean;
     animateOpacity?: boolean;
     children?: ReactNode;
+    'data-test-id'?: string;
 };

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -45,6 +45,7 @@ export type DatePickerProps = {
     onClose?: () => void;
     onBlur?: () => void;
     onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+    'data-test-id'?: string;
 } & (SingleDatePickerProps | RangeDatePickerProps);
 
 const getDayClasses = (variant: DatePickerProps['variant'], date: Date) => {
@@ -80,6 +81,7 @@ export const DatePicker = forwardRef<ReactDatePicker<never, boolean>, DatePicker
             preventOpenOnFocus = false,
             filterDate = () => true,
             variant = 'single',
+            'data-test-id': dataTestId = 'date-picker',
         },
         ref,
     ) => {
@@ -96,7 +98,7 @@ export const DatePicker = forwardRef<ReactDatePicker<never, boolean>, DatePicker
         };
 
         return (
-            <div data-test-id="date-picker">
+            <div data-test-id={dataTestId}>
                 <DatepickerComponent
                     calendarClassName="tw-rounded-sm tw-border tw-border-line-x-strong react-datepicker-wrap"
                     selected={value}

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -25,9 +25,16 @@ export type DropZoneProps<T> = {
     onDrop?: OnDropCallback<T>;
     accept: string | string[];
     children?: JSX.Element;
+    'data-test-id'?: string;
 };
 
-export const DropZone = <T extends object>({ data, onDrop, accept, children }: DropZoneProps<T>) => {
+export const DropZone = <T extends object>({
+    data,
+    onDrop,
+    accept,
+    children,
+    'data-test-id': dataTestId = 'drop-zone',
+}: DropZoneProps<T>) => {
     const [{ isOver, canDrop }, drop] = useDrop({
         accept: accept || '',
         drop: (item: OrderableListItem<T>) => {
@@ -56,7 +63,7 @@ export const DropZone = <T extends object>({ data, onDrop, accept, children }: D
         <div
             role="row"
             aria-hidden={!isActive}
-            data-test-id="drop-zone"
+            data-test-id={dataTestId}
             className={merge([
                 'tw-w-full tw-transition-height',
                 data.position !== 'within' ? outerDropZoneClassNames : 'tw-h-auto',

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -60,6 +60,7 @@ export type DropdownProps = {
     position?: DropdownPosition;
     emphasis?: TriggerEmphasis;
     flip?: boolean;
+    'data-test-id'?: string;
 };
 
 const getActiveItem = (blocks: MenuBlock[], activeId: string | number): MenuItemType | null => {
@@ -93,6 +94,7 @@ export const Dropdown = ({
     position = DropdownPosition.Bottom,
     emphasis = TriggerEmphasis.Default,
     flip = false,
+    'data-test-id': dataTestId = 'dropdown',
 }: DropdownProps): ReactElement => {
     const activeItem = !!activeItemId ? getActiveItem(menuBlocks, activeItemId) : null;
     const props = mapToAriaProps(ariaLabel, menuBlocks);
@@ -173,7 +175,7 @@ export const Dropdown = ({
     });
 
     return (
-        <div className="tw-relative tw-w-full tw-font-sans tw-text-s">
+        <div className="tw-relative tw-w-full tw-font-sans tw-text-s" data-test-id={dataTestId}>
             <Trigger
                 disabled={disabled}
                 buttonProps={buttonProps}
@@ -190,7 +192,7 @@ export const Dropdown = ({
                     {...mergeProps(buttonProps, focusProps)}
                     id={useMemoizedId(propId)}
                     ref={triggerRef}
-                    data-test-id="dropdown-trigger"
+                    data-test-id={`${dataTestId}-trigger`}
                     className={merge([
                         'tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none',
                         size === DropdownSize.Small
@@ -230,7 +232,7 @@ export const Dropdown = ({
                                 ref={overlayRef}
                                 style={autoResize ? { maxHeight } : {}}
                                 className="tw-flex tw-flex-col"
-                                data-test-id="dropdown-menu"
+                                data-test-id={`${dataTestId}-menu`}
                                 role="dialog"
                             >
                                 <DismissButton onDismiss={() => close()} />

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -58,6 +58,7 @@ export interface EditableTextProps {
     options?: EditableOptionProps;
     /** @deprecated Temporary solution for text with ellipisis in Tree Component */
     isOverflowing?: boolean;
+    'data-test-id'?: string;
 }
 
 /**
@@ -83,6 +84,7 @@ export const EditableText = ({
     children,
     options,
     isOverflowing = false,
+    'data-test-id': dataTestId = 'editable-node-container',
 }: EditableTextProps) => {
     // Read initial text strings from children
     const childrenLabel = EditableTextHelper.getLabel(children);
@@ -153,7 +155,7 @@ export const EditableText = ({
 
     return (
         <div
-            data-test-id="editable-node-container"
+            data-test-id={dataTestId}
             className={merge(['tw-relative tw-h-full', options?.removeBoxPadding === true ? '' : 'tw-p-2'])}
         >
             {editableState === EditableMode.INPUT ? (

--- a/src/components/FieldsetHeader/FieldsetHeader.tsx
+++ b/src/components/FieldsetHeader/FieldsetHeader.tsx
@@ -54,6 +54,7 @@ export type FieldsetHeaderProps = {
     onClick?: () => void;
     as?: keyof JSX.IntrinsicElements;
     tabIndex?: number;
+    'data-test-id'?: string;
 };
 
 export const renderFieldsetHeaderIconType = (
@@ -123,6 +124,7 @@ export const FieldsetHeader = ({
     onClick,
     as: Heading = 'label',
     tabIndex = -1,
+    'data-test-id': dataTestId = 'fieldset-header',
 }: FieldsetHeaderProps): ReactElement => {
     const id = useMemoizedId();
     const clickOnNotDisabled = () => !disabled && onClick && onClick();
@@ -136,7 +138,7 @@ export const FieldsetHeader = ({
 
     return (
         <header
-            data-test-id="fieldset-header"
+            data-test-id={dataTestId}
             role={onClick ? 'button' : undefined}
             onClick={clickOnNotDisabled}
             onKeyPress={clickOnNotDisabled}

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -113,9 +113,7 @@ export const FormControl = ({
                         direction === FormControlDirection.Vertical && 'tw-w-full',
                     ])}
                 >
-                    {label?.children && (
-                        <InputLabel {...label} disabled={disabled} clickable={clickable} data-test-id={dataTestId} />
-                    )}
+                    {label?.children && <InputLabel {...label} disabled={disabled} clickable={clickable} />}
                     {extra && (
                         <span
                             data-test-id={`${dataTestId}-extra`}

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -16,6 +16,7 @@ type HelperTextProps = {
     style: FormControlStyle;
     disabled?: boolean;
     fullWidth?: boolean;
+    'data-test-id'?: string;
 };
 
 const inputValidation: Record<FormControlStyle, Validation> = {
@@ -24,7 +25,13 @@ const inputValidation: Record<FormControlStyle, Validation> = {
     [FormControlStyle.Danger]: Validation.Error,
 };
 
-const HelperText = ({ text, disabled, style, fullWidth = false }: HelperTextProps): ReactElement => {
+const HelperText = ({
+    text,
+    disabled,
+    style,
+    fullWidth = false,
+    'data-test-id': dataTestId = 'form-control',
+}: HelperTextProps): ReactElement => {
     let textColorClass;
 
     switch (true) {
@@ -44,7 +51,7 @@ const HelperText = ({ text, disabled, style, fullWidth = false }: HelperTextProp
 
     return (
         <span
-            data-test-id="form-control-helper-text"
+            data-test-id={`${dataTestId}-helper-text`}
             className={`tw-text-s tw-font-sans ${fullWidth ? 'tw-w-full' : ''} ${textColorClass}`}
         >
             {text}
@@ -73,6 +80,7 @@ export type FormControlProps = {
     style?: FormControlStyle;
     name?: string;
     children?: ReactNode;
+    'data-test-id'?: string;
 };
 
 export const FormControl = ({
@@ -85,12 +93,13 @@ export const FormControl = ({
     clickable,
     direction = FormControlDirection.Vertical,
     style = FormControlStyle.Primary,
+    'data-test-id': dataTestId = 'form-control',
 }: FormControlProps): ReactElement => {
     const isHelperBefore = helper?.position === HelperPosition.Before;
 
     return (
         <div
-            data-test-id="form-control"
+            data-test-id={dataTestId}
             data-name={name}
             className={merge([
                 'tw-flex tw-items-center tw-gap-2',
@@ -104,10 +113,12 @@ export const FormControl = ({
                         direction === FormControlDirection.Vertical && 'tw-w-full',
                     ])}
                 >
-                    {label?.children && <InputLabel {...label} disabled={disabled} clickable={clickable} />}
+                    {label?.children && (
+                        <InputLabel {...label} disabled={disabled} clickable={clickable} data-test-id={dataTestId} />
+                    )}
                     {extra && (
                         <span
-                            data-test-id="form-control-extra"
+                            data-test-id={`${dataTestId}-extra`}
                             className="tw-pl-2 tw-text-black-80 tw-font-sans tw-text-s tw-whitespace-nowrap"
                         >
                             {extra}
@@ -121,6 +132,7 @@ export const FormControl = ({
                     fullWidth={direction === FormControlDirection.Vertical}
                     text={helper.text}
                     disabled={disabled}
+                    data-test-id={dataTestId}
                 />
             )}
             {children && (
@@ -144,6 +156,7 @@ export const FormControl = ({
                     text={helper.text}
                     disabled={disabled}
                     style={style}
+                    data-test-id={dataTestId}
                 />
             )}
         </div>

--- a/src/components/FrontifyPattern/FrontifyPattern.tsx
+++ b/src/components/FrontifyPattern/FrontifyPattern.tsx
@@ -17,6 +17,7 @@ export type FrontifyPatternProps = {
     scale?: PatternScale;
     scaleOrigin?: PatternScaleOrigin;
     foregroundColor?: PatternTheme;
+    'data-test-id'?: string;
 };
 
 export const FrontifyPattern = ({
@@ -24,10 +25,11 @@ export const FrontifyPattern = ({
     scale = PatternScale.SM,
     scaleOrigin = ['top', 'left'],
     foregroundColor = PatternTheme.Black,
+    'data-test-id': dataTestId = 'frontify-pattern',
 }: FrontifyPatternProps): ReactElement => {
     return (
         <div
-            data-test-id="frontify-pattern"
+            data-test-id={dataTestId}
             className={merge(['tw-w-[260px]', patternThemes[foregroundColor]])}
             style={{ transformOrigin: `${scaleOrigin.join(' ')}`, transform: `scale(${patternScales[scale]})` }}
         >

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -18,6 +18,7 @@ export type InputLabelProps = {
     tooltip?: InputLabelTooltipProps;
     bold?: boolean;
     children?: ReactNode;
+    'data-test-id'?: string;
 };
 
 export const InputLabel = ({
@@ -28,6 +29,7 @@ export const InputLabel = ({
     clickable = false,
     tooltip = [],
     bold,
+    'data-test-id': dataTestId = 'input-label',
 }: InputLabelProps): ReactElement => {
     const tooltips = Array.isArray(tooltip) ? tooltip : [tooltip];
 
@@ -42,7 +44,7 @@ export const InputLabel = ({
                 'tw-inline-flex tw-leading-4 tw-items-center tw-gap-1 tw-font-sans tw-text-s tw-max-w-full tw-min-w-0 tw-flex-initial',
                 disabled ? 'tw-text-text-disabled' : 'tw-text-text-weak',
             ])}
-            data-test-id="input-label-container"
+            data-test-id={`${dataTestId}-container`}
         >
             <div className="tw-flex-1 tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap">
                 <label
@@ -54,7 +56,7 @@ export const InputLabel = ({
                             ? 'hover:tw-cursor-not-allowed tw-pointer-events-none'
                             : 'hover:tw-cursor-pointer hover:tw-text-text group-hover:tw-text-text',
                     ])}
-                    data-test-id="input-label"
+                    data-test-id={dataTestId}
                     title={typeof children === 'string' ? children : ''}
                 >
                     {children}
@@ -62,7 +64,7 @@ export const InputLabel = ({
             </div>
 
             {required && (
-                <span data-test-id="input-label-required" className="tw-h-4 tw-text-m tw-text-text-negative">
+                <span data-test-id={`${dataTestId}-required`} className="tw-h-4 tw-text-m tw-text-text-negative">
                     *
                 </span>
             )}

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -62,6 +62,7 @@ export const LinkChooser = ({
     clearable,
     required,
     validation = Validation.Default,
+    'data-test-id': dataTestId = 'link-chooser',
 }: LinkChooserProps): ReactElement => {
     const [{ context, matches, value }, send, service] = useMachine(() =>
         linkChooserMachine.withContext({
@@ -247,17 +248,17 @@ export const LinkChooser = ({
     }, []);
 
     return (
-        <div data-test-id="link-chooser" ref={triggerRef} className="tw-w-full tw-font-sans tw-text-s">
+        <div data-test-id={dataTestId} ref={triggerRef} className="tw-w-full tw-font-sans tw-text-s">
             {!!label && (
                 <label
                     {...labelProps}
-                    data-test-id="link-chooser-label"
+                    data-test-id={`${dataTestId}-label`}
                     className="tw-text-black-80 tw-mb-1 tw-flex tw-align-items-center"
                 >
                     {label}
                     {required && (
                         <span
-                            data-test-id="link-chooser-label-required"
+                            data-test-id={`${dataTestId}-label-required`}
                             className="tw-h-4 tw-text-m tw-text-red-60 dark:tw-text-red-50 tw-ml-1"
                         >
                             *
@@ -290,7 +291,7 @@ export const LinkChooser = ({
                         animate={{ height: 'auto' }}
                         exit={{ height: 0 }}
                         transition={{ ease: [0.04, 0.62, 0.23, 0.98], duration: 0.5 }}
-                        data-test-id="link-chooser-dropdown"
+                        data-test-id={`${dataTestId}-dropdown`}
                     >
                         <DismissButton onDismiss={handleDropdownClose} />
                         <Popover
@@ -307,7 +308,7 @@ export const LinkChooser = ({
                                 border={false}
                                 machineService={service}
                             />
-                            <div data-test-id="link-chooser-action-menu" className="tw-border-t tw-border-black-10">
+                            <div data-test-id={`${dataTestId}-action-menu`} className="tw-border-t tw-border-black-10">
                                 <NavigationMenu machineService={service} state={state} />
                             </div>
                         </Popover>
@@ -315,7 +316,7 @@ export const LinkChooser = ({
                     </motion.div>
                 )}
             </AnimatePresence>
-            <div className="tw-my-2" data-test-id="link-chooser-new-tab">
+            <div className="tw-my-2" data-test-id={`${dataTestId}-new-tab`}>
                 <Checkbox
                     value="new-tab"
                     disabled={disabled}

--- a/src/components/LinkChooser/types.ts
+++ b/src/components/LinkChooser/types.ts
@@ -64,6 +64,7 @@ export type LinkChooserProps = {
     readonly clipboardOptions?: Clipboard;
     readonly getGlobalByQuery?: (query: string) => Promise<SearchResult[]>;
     readonly openPreview?: (value: string, target: string) => void;
+    'data-test-id'?: string;
 };
 
 export type SearchResult = Omit<MenuItemType, 'title'> & { icon: string; title: string; local?: boolean };

--- a/src/components/LoadingCircle/LoadingCircle.tsx
+++ b/src/components/LoadingCircle/LoadingCircle.tsx
@@ -19,6 +19,7 @@ export enum LoadingCircleSize {
 export type LoadingCircleProps = {
     style?: LoadingCircleStyle;
     size?: LoadingCircleSize;
+    'data-test-id'?: string;
 };
 
 export const statusClasses: Record<LoadingCircleStyle, string> = {
@@ -37,10 +38,11 @@ export const sizeClasses: Record<LoadingCircleSize, string> = {
 export const LoadingCircle = ({
     style = LoadingCircleStyle.Progress,
     size = LoadingCircleSize.Medium,
+    'data-test-id': dataTestId = 'loading-circle',
 }: LoadingCircleProps): ReactElement => {
     return (
         <div
-            data-test-id="loading-circle"
+            data-test-id={dataTestId}
             className={merge([
                 'tw-border-2 tw-border-solid tw-rounded-full tw-border-t-transparent tw-animate-spin',
                 statusClasses[style],

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -13,6 +13,7 @@ interface Props {
     children?: ReactNode | ReactNode[];
     onClose?: () => void;
     offset?: [number, number];
+    'data-test-id'?: string;
 }
 
 export type MenuProps = Props;
@@ -20,7 +21,14 @@ export type MenuProps = Props;
 const CONTAINER_BASE_CLASSES = 'tw-relative tw-bg-base tw-rounded tw-py-2 tw-shadow-mid tw-z-[120000]';
 const CONTAINER_CLASSES = merge([CONTAINER_BASE_CLASSES, INSET_BORDER]);
 
-export const Menu = ({ triggerRef, children, open = true, offset = [0, 8], onClose }: MenuProps) => {
+export const Menu = ({
+    triggerRef,
+    children,
+    open = true,
+    offset = [0, 8],
+    onClose,
+    'data-test-id': dataTestId = 'menu',
+}: MenuProps) => {
     const [isMenuOpen, setIsMenuOpen] = useState(open);
     const [menuContainerRef, setMenuContainerRef] = useState<HTMLElement | null>(null);
     const [menuOpenerRef, setMenuOpenerRef] = useState<HTMLElement | null>(null);
@@ -94,7 +102,7 @@ export const Menu = ({ triggerRef, children, open = true, offset = [0, 8], onClo
             ref={setMenuContainerRef}
             style={menuOpenerRef ? popperInstance.styles.popper : {}}
             {...(menuOpenerRef ? popperInstance.attributes.popper : {})}
-            data-test-id="menu"
+            data-test-id={dataTestId}
         >
             <ol className="tw-list-none" role="menu">
                 {children}

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -19,6 +19,7 @@ export type MenuItemProps = {
     link?: string;
     onClick?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
     children?: ReactNode;
+    'data-test-id'?: string;
 } & Omit<MenuItemContentProps, 'iconSize'>;
 
 export const menuItemSizeClassMap: Record<MenuItemContentSize, string> = {
@@ -77,13 +78,16 @@ export const MenuItem = ({
     children,
     link,
     onClick,
+    'data-test-id': dataTestId = 'menu-item',
 }: MenuItemProps) => {
     const currentIconSize = size === MenuItemContentSize.XSmall ? IconSize.Size16 : IconSize.Size20;
 
     const currentIcon = {
-        [SelectionIndicatorIcon.CaretRight]: <IconCaretRight data-test-id="menu-item-caret" size={currentIconSize} />,
+        [SelectionIndicatorIcon.CaretRight]: (
+            <IconCaretRight data-test-id={`${dataTestId}-caret`} size={currentIconSize} />
+        ),
         [SelectionIndicatorIcon.Check]: active && (
-            <IconCheckMark data-test-id="menu-item-active" size={currentIconSize} />
+            <IconCheckMark data-test-id={`${dataTestId}-active`} size={currentIconSize} />
         ),
         [SelectionIndicatorIcon.None]: null,
     }[selectionIndicator];
@@ -103,7 +107,7 @@ export const MenuItem = ({
         <>
             {children && (
                 <li
-                    data-test-id="menu-item"
+                    data-test-id={dataTestId}
                     role="menuitem"
                     className={merge([
                         'tw-text-sm tw-leading-4 tw-text-text-weak',

--- a/src/components/MultiInput/MultiInput.tsx
+++ b/src/components/MultiInput/MultiInput.tsx
@@ -11,15 +11,21 @@ export type MultiInputProps = {
     layout: MultiInputLayout;
     spanLastItem?: boolean;
     children: ReactNode;
+    'data-test-id'?: string;
 };
 
-export const MultiInput = ({ layout, spanLastItem, children }: MultiInputProps): ReactElement => {
+export const MultiInput = ({
+    layout,
+    spanLastItem,
+    children,
+    'data-test-id': dataTestId = 'multi-input',
+}: MultiInputProps): ReactElement => {
     const childrenArray = Children.toArray(children);
 
     return (
-        <div data-test-id="multi-input" className="tw-flex tw-gap-2 tw-w-full tw-flex-col">
+        <div data-test-id={dataTestId} className="tw-flex tw-gap-2 tw-w-full tw-flex-col">
             {layout === MultiInputLayout.Columns && (
-                <div data-test-id="multi-input-grid-columns" className="tw-grid tw-grid-cols-2 tw-gap-2">
+                <div data-test-id={`${dataTestId}-grid-columns`} className="tw-grid tw-grid-cols-2 tw-gap-2">
                     {childrenArray.map((child, index) => (
                         <div
                             className={spanLastItem && index === childrenArray.length - 1 ? 'tw-col-span-2' : ''}
@@ -31,7 +37,7 @@ export const MultiInput = ({ layout, spanLastItem, children }: MultiInputProps):
                 </div>
             )}
             {layout === MultiInputLayout.Spider && (
-                <div data-test-id="multi-input-grid-spider" className="tw-grid tw-grid-cols-4 tw-gap-2">
+                <div data-test-id={`${dataTestId}-grid-spider`} className="tw-grid tw-grid-cols-4 tw-gap-2">
                     {childrenArray[0] && <div className="tw-col-start-2 tw-col-span-2">{childrenArray[0]}</div>}
                     {childrenArray[1] && <div className="tw-col-start-1 tw-col-span-2">{childrenArray[1]}</div>}
                     {childrenArray[2] && <div className="tw-col-start-3 tw-col-span-2">{childrenArray[2]}</div>}

--- a/src/components/OrderableList/OrderableList.tsx
+++ b/src/components/OrderableList/OrderableList.tsx
@@ -30,6 +30,7 @@ export const OrderableList = <T extends object>({
     dragDisabled,
     items,
     renderContent,
+    'data-test-id': dataTestId = 'orderable-list',
 }: OrderableListProps<T>) => {
     const [itemsState, setItemsState] = useState(items);
     const listId = useId();
@@ -52,7 +53,7 @@ export const OrderableList = <T extends object>({
 
     return (
         <DndProvider backend={HTML5Backend}>
-            <div className="tw-outline-none" data-test-id="orderable-list">
+            <div className="tw-outline-none" data-test-id={dataTestId}>
                 {itemsState.map((item, index) => (
                     <React.Fragment key={`dropzone-orderable-list-key-${index}`}>
                         <DropZone

--- a/src/components/OrderableList/types.ts
+++ b/src/components/OrderableList/types.ts
@@ -26,6 +26,7 @@ export type OrderableListProps<T> = {
     dragDisabled: boolean;
     onMove: (modifiedItems: OrderableListItem<T>[]) => void;
     renderContent: RenderListItem<T>;
+    'data-test-id'?: string;
 };
 
 export enum ItemDragState {

--- a/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/src/components/OverflowMenu/OverflowMenu.tsx
@@ -17,14 +17,15 @@ export interface OverflowMenuItemProps {
 
 export interface OverflowMenuProps {
     items: OverflowMenuItemProps[];
+    'data-test-id'?: string;
 }
 
-export const OverflowMenu = ({ items }: OverflowMenuProps) => {
+export const OverflowMenu = ({ items, 'data-test-id': dataTestId = 'overflow-menu' }: OverflowMenuProps) => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const menuOpenerRef = useRef<HTMLButtonElement>(null);
 
     return (
-        <div data-test-id="overflow-menu" className="tw-relative tw-bottom-0 tw-top-0 tw-flex">
+        <div data-test-id={dataTestId} className="tw-relative tw-bottom-0 tw-top-0 tw-flex">
             <button
                 aria-haspopup="true"
                 aria-expanded={isMenuOpen}

--- a/src/components/RadioList/RadioList.tsx
+++ b/src/components/RadioList/RadioList.tsx
@@ -2,7 +2,7 @@
 
 import { Tooltip, TooltipAlignment, TooltipPosition } from '@components/Tooltip';
 import IconQuestionMarkCircle from '@foundation/Icon/Generated/IconQuestionMarkCircle';
-import { IconSize } from '@foundation/index';
+import { IconSize } from '@foundation/Icon';
 import { generateRandomId } from '@utilities/generateRandomId';
 import { merge } from '@utilities/merge';
 import React, { Children, ReactNode, isValidElement, useEffect, useRef, useState } from 'react';

--- a/src/components/RadioPill/RadioPill.tsx
+++ b/src/components/RadioPill/RadioPill.tsx
@@ -11,14 +11,21 @@ export type RadioPillProps = {
     active: boolean;
     onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
     icon?: React.ReactElement;
+    'data-test-id'?: string;
 };
 
-export const RadioPill = ({ label, active, icon, onClick }: RadioPillProps): ReactElement => {
+export const RadioPill = ({
+    label,
+    active,
+    icon,
+    onClick,
+    'data-test-id': dataTestId = 'radio-pill',
+}: RadioPillProps): ReactElement => {
     const { isFocusVisible, focusProps } = useFocusRing();
 
     return (
         <button
-            data-test-id="radio-pill"
+            data-test-id={dataTestId}
             type="button"
             className={merge([
                 'tw-inline-flex tw-items-center tw-rounded-full tw-text-xs tw-px-2 tw-py-1',

--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -14,6 +14,7 @@ const GRADIENTS = {
 export const ScrollWrapper = ({
     direction = ScrollWrapperDirection.Vertical,
     children,
+    'data-test-id': dataTestId = 'scroll-wrapper',
 }: ScrollWrapperProps): ReactElement => {
     const scrollingContainer = useRef<HTMLDivElement>(null);
 
@@ -27,10 +28,7 @@ export const ScrollWrapper = ({
     const gradientWidth = scrollingContainer.current ? scrollingContainer.current.clientWidth + 8 : '100%';
 
     return (
-        <div
-            data-test-id="scroll-wrapper"
-            className="tw-h-full tw-relative tw-flex-auto tw-flex tw-flex-col tw-min-h-0"
-        >
+        <div data-test-id={dataTestId} className="tw-h-full tw-relative tw-flex-auto tw-flex tw-flex-col tw-min-h-0">
             {directionVertical && showTopShadow && (
                 <div
                     className="tw-h-3 tw-w-full tw-absolute tw-z-10 tw-top-0 tw-left-0 tw-mix-blend-darken tw-border-t tw-border-line"

--- a/src/components/ScrollWrapper/types.ts
+++ b/src/components/ScrollWrapper/types.ts
@@ -17,4 +17,5 @@ export const scrollWrapperDirections: Record<ScrollWrapperDirection, string> = {
 export type ScrollWrapperProps = {
     direction?: ScrollWrapperDirection;
     children?: ReactElement | ReactElement[];
+    'data-test-id'?: string;
 };

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -31,6 +31,7 @@ type BaseSliderProps = {
     onChange: (value: SliderValue) => void;
     valueSuffix?: string;
     disabled?: boolean;
+    'data-test-id'?: string;
 };
 
 export type SliderValue = {
@@ -68,8 +69,9 @@ export const Slider = ({
     valueSuffix = '',
     onError,
     onChange,
-    ['aria-label']: ariaLabel = ARIA_LABEL_DEFAULT_VALUE,
+    'aria-label': ariaLabel = ARIA_LABEL_DEFAULT_VALUE,
     disabled = false,
+    'data-test-id': dataTestId = 'fondue-slider',
 }: SliderProps) => {
     const [value, setValue] = useState<number>();
     const [valueWithSuffix, setValueWithSuffix] = useState('');
@@ -293,11 +295,11 @@ export const Slider = ({
     }, [error, onError]);
 
     return (
-        <div className="tw-flex tw-flex-col" data-test-id="fondue-slider" id={id}>
+        <div className="tw-flex tw-flex-col" data-test-id={dataTestId} id={id}>
             <label
                 htmlFor={id}
                 className={merge([!label && 'tw-hidden', disabled && 'tw-text-text-disabled'])}
-                data-test-id="fondue-slider-label"
+                data-test-id={`${dataTestId}-label`}
             >
                 {label}
             </label>
@@ -311,7 +313,7 @@ export const Slider = ({
                     )}
                     <button
                         ref={setSliderRef}
-                        data-test-id="fondue-slider-interactive"
+                        data-test-id={`${dataTestId}-interactive`}
                         className="tw-flex-1 tw-relative tw-h-full tw-cursor-pointer disabled:tw-cursor-default tw-outline-none"
                         onMouseOver={onMouseOver}
                         onMouseOut={onMouseOut}
@@ -332,7 +334,7 @@ export const Slider = ({
                                 aria-valuemin={min}
                                 aria-valuemax={max}
                                 aria-label={ariaLabel}
-                                data-test-id="fondue-slider-track"
+                                data-test-id={`${dataTestId}-track`}
                                 className={merge([
                                     'tw-absolute tw-block tw-top-1/2 tw--translate-y-1/2 tw-origin-left tw-w-full tw-h-1  tw-rounded-sm tw-bg-box-neutral-strong tw-flex-1',
                                     disabled && 'tw-bg-box-neutral',

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -46,6 +46,7 @@ export type SwitchProps = {
     hug?: boolean;
     tooltip?: InputLabelTooltipProps;
     onChange?: (e: MouseEvent) => void;
+    'data-test-id'?: string;
 };
 
 export const Switch = ({
@@ -59,6 +60,7 @@ export const Switch = ({
     labelStyle = 'default',
     hug = false,
     tooltip,
+    'data-test-id': dataTestId = 'switch',
 }: SwitchProps): ReactElement => {
     const id = useMemoizedId(propId);
     const { isFocusVisible, focusProps } = useFocusRing();
@@ -133,18 +135,17 @@ export const Switch = ({
     }, [hug]);
 
     return (
-        <div className={containerClasses} data-test-id={SWITCH_ID}>
+        <div className={containerClasses} data-test-id={`${dataTestId}-container`}>
             {label && (
-                <InputLabel clickable={true} htmlFor={id} disabled={disabled} tooltip={tooltip}>
-                    {labelStyle === 'default' ? (
-                        <span data-test-id="switch-label-wrapper" className="tw-font-medium tw-text-text-weak">
-                            {label}
-                        </span>
-                    ) : (
-                        <span data-test-id="switch-label-wrapper" className="tw-font-bold tw-text-text">
-                            {label}
-                        </span>
-                    )}
+                <InputLabel clickable htmlFor={id} disabled={disabled} tooltip={tooltip}>
+                    <span
+                        data-test-id={`${dataTestId}-label-wrapper`}
+                        className={
+                            labelStyle === 'default' ? 'tw-font-medium tw-text-text-weak' : 'tw-font-bold tw-text-text'
+                        }
+                    >
+                        {label}
+                    </span>
                 </InputLabel>
             )}
             <button
@@ -152,7 +153,7 @@ export const Switch = ({
                 id={id}
                 disabled={disabled}
                 name={name}
-                data-test-id="switch"
+                data-test-id={dataTestId}
                 className={trackClasses}
                 value={mode}
                 onClick={onChange}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -32,7 +32,7 @@ export const tagStyles: Record<TagType, string> = {
         'tw-bg-white dark:tw-bg-black-100 hover:tw-bg-black-0 dark:hover:tw-bg-black-superdark tw-text-violet-60 dark:tw-text-violet-50 hover:tw-text-violet-70 dark:hover:tw-text-violet-60',
 };
 
-export type TagProps = TagPropsUnselected | TagPropsSelected;
+export type TagProps = { 'data-test-id'?: string } & (TagPropsUnselected | TagPropsSelected);
 
 type TagPropsSelected = {
     type: TagType.Selected | TagType.SelectedWithFocus;
@@ -48,7 +48,7 @@ type TagPropsUnselected = {
     size?: TagSize;
 };
 
-export const Tag = ({ type, label, onClick, size = TagSize.Medium }: TagProps) => {
+export const Tag = ({ type, label, onClick, size = TagSize.Medium, 'data-test-id': dataTestId = 'tag' }: TagProps) => {
     const ref = useRef<HTMLButtonElement | null>(null);
     const { isFocusVisible, focusProps } = useFocusRing();
     const isClickable = (type === TagType.Selected || type === TagType.SelectedWithFocus) && onClick;
@@ -61,7 +61,7 @@ export const Tag = ({ type, label, onClick, size = TagSize.Medium }: TagProps) =
 
     return (
         <button
-            data-test-id="tag"
+            data-test-id={dataTestId}
             className={merge([
                 'tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group  tw-break-word',
                 size === TagSize.Small ? 'tw-px-[6px] tw-py-[2px]' : 'tw-px-2.5 tw-py-1',
@@ -74,7 +74,7 @@ export const Tag = ({ type, label, onClick, size = TagSize.Medium }: TagProps) =
             {label}
             {isClickable && (
                 <span
-                    data-test-id="tag-reject-icon"
+                    data-test-id={`${dataTestId}-reject-icon`}
                     className="tw-opacity-80 group-hover:tw-opacity-100 tw-transition-opacity tw-ml-1"
                 >
                     <IconCross size={IconSize.Size12} />

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -18,6 +18,7 @@ export const Toast = ({
     icon,
     animationDirection = ToastAnimationDirection.BottomToTop,
     children,
+    'data-test-id': dataTestId = 'toast',
 }: ToastProps): ReactElement => (
     <AnimatePresence>
         {isOpen && (
@@ -29,7 +30,7 @@ export const Toast = ({
                 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: getToastStartPosition(animationDirection) }}
-                data-test-id="toast"
+                data-test-id={dataTestId}
                 aria-live="polite"
                 role="alert"
             >

--- a/src/components/Toast/types.tsx
+++ b/src/components/Toast/types.tsx
@@ -8,6 +8,7 @@ export type ToastProps = {
     icon: ReactNode;
     animationDirection?: ToastAnimationDirection;
     children?: ReactNode;
+    'data-test-id'?: string;
 };
 
 export enum ToastAnimationDirection {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -51,6 +51,7 @@ export type TooltipProps = {
     /** @deprecated use disabled since the tooltip is always present in the DOM now so hidden has no effect anymore */
     hidden?: boolean;
     enablePortal?: boolean;
+    'data-test-id'?: string;
 };
 
 const paddingsTop = {
@@ -158,6 +159,7 @@ export const Tooltip = ({
     disabled = false,
     enablePortal = false,
     hidden = false,
+    'data-test-id': dataTestId = 'tooltip',
 }: TooltipProps) => {
     const [triggerElementRef, setTriggerElementRef] = useState<HTMLElement | HTMLDivElement | HTMLButtonElement | null>(
         null,
@@ -313,7 +315,7 @@ export const Tooltip = ({
                         'tw-popper-container tw-inline-block tw-max-w-[200px] tw-dark tw-bg-base tw-rounded-md tw-shadow-mid tw-text-text tw-z-[120000]',
                         !isOpen && 'tw-opacity-0 tw-h-0 tw-w-0 tw-overflow-hidden',
                     ])}
-                    data-test-id="tooltip"
+                    data-test-id={dataTestId}
                     role="tooltip"
                     id={id}
                     style={popperInstance.styles.popper}
@@ -349,7 +351,7 @@ export const Tooltip = ({
                         {linkUrl && (
                             <a
                                 {...linkProps}
-                                data-test-id="tooltip-link"
+                                data-test-id={`${dataTestId}-link`}
                                 ref={linkRef}
                                 href={linkUrl}
                                 target="_blank"

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -13,6 +13,7 @@ export type TooltipIconProps = {
     iconSize?: IconSize;
     triggerIcon?: ReactElement<IconProps>;
     triggerStyle?: TooltipIconTriggerStyle;
+    'data-test-id'?: string;
 };
 
 export enum TooltipIconTriggerStyle {
@@ -38,9 +39,10 @@ export const TooltipIcon = ({
     iconSize = IconSize.Size16,
     triggerIcon = <IconQuestionMarkCircle />,
     triggerStyle = TooltipIconTriggerStyle.Primary,
+    'data-test-id': dataTestId = 'tooltip-icon',
 }: TooltipIconProps): ReactElement => {
     return (
-        <div data-test-id="tooltip-icon">
+        <div data-test-id={dataTestId}>
             {tooltip && (
                 <div>
                     <Tooltip
@@ -48,7 +50,7 @@ export const TooltipIcon = ({
                             <button
                                 type="button"
                                 aria-label="More info"
-                                data-test-id="tooltip-icon-trigger"
+                                data-test-id={`${dataTestId}-trigger`}
                                 className={merge([
                                     'tw-inline-flex tw-justify-center tw-items-center tw-cursor-default tw-outline-none tw-rounded-full',
                                     FOCUS_VISIBLE_STYLE,


### PR DESCRIPTION
1st wave of making 'data-test-id' editable.

Components yet to be done - postponed to a 2nd wave  :
- ActionMenu
- AssetInput
- ColorPicker
- Flyout
- LoadingBar
- Modal
- MultiSelect
- RadioList
- RTE
- SegmentedControls
- Table
- Tabs
- Textarea
- TextInput
- Trigger
