### PR TITLE
fix: disable tooltip listeners when closed

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -106,7 +106,7 @@ export default {
 
 export const TooltipComponent: StoryFn<TooltipProps> = (args: TooltipProps) => {
     return (
-        <div className="tw-w-screen tw-h-screen tw-flex tw-justify-center tw-items-center">
+        <div className="tw-w-screen tw-h-[1000px] tw-flex tw-justify-center tw-items-center">
             <Tooltip
                 {...args}
                 triggerElement={

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -162,6 +162,7 @@ export const Tooltip = ({
     const [triggerElementRef, setTriggerElementRef] = useState<HTMLElement | HTMLDivElement | HTMLButtonElement | null>(
         null,
     );
+    const [isOpen, setIsOpen] = useState(false);
     const linkRef = useRef<HTMLAnchorElement | null>(null);
 
     const shouldPreventTooltipOpening = hidden || disabled;
@@ -189,6 +190,10 @@ export const Tooltip = ({
                 },
             },
             {
+                name: 'eventListeners',
+                options: { scroll: isOpen, resize: isOpen },
+            },
+            {
                 name: 'offset',
                 options: {
                     offset: [0, tooltipOffset],
@@ -203,7 +208,6 @@ export const Tooltip = ({
 
     const currentPlacement = popperInstance.state?.placement ?? position;
     const arrowStyling = getArrowClasses(currentPlacement, brightHeader, alignment);
-    const [isOpen, setIsOpen] = useState(false);
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const handleHideTooltipOnHover = useCallback(() => {


### PR DESCRIPTION
This pr disables the tooltip position update listeners when the tooltip is not currently visible, since it was causing thousands of re-renders when a guideline was scrolled