### PR TITLE
refactor(Tree): change indentation width to 20

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -65,9 +65,7 @@ import {
 } from './helpers';
 
 import { TreeContext, TreeContextProps } from './TreeContext';
-
-export const ROOT_ID = '__ROOT__';
-export const INDENTATION_WIDTH = 32;
+import { ROOT_ID } from './helpers';
 
 const measuring: MeasuringConfiguration = {
     droppable: {

--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -17,8 +17,7 @@ import type {
     TreeItemProps,
 } from '@components/Tree/types';
 
-import { Projection } from '../helpers';
-import { INDENTATION_WIDTH } from '../Tree';
+import { INDENTATION_WIDTH, Projection } from '../helpers';
 import { removeFragmentsAndEnrichChildren, useDeepCompareEffect } from '../utils';
 
 import { DragHandle } from './DragHandle';

--- a/src/components/Tree/TreeItem/TreeItemOverlay.tsx
+++ b/src/components/Tree/TreeItem/TreeItemOverlay.tsx
@@ -5,7 +5,7 @@ import React, { Children, ReactNode } from 'react';
 import { merge } from '@utilities/merge';
 import { IconGrabHandle12 } from '@foundation/Icon';
 
-import { INDENTATION_WIDTH } from '../Tree';
+import { INDENTATION_WIDTH } from '../helpers';
 
 export type Overlay = {
     id: string;

--- a/src/components/Tree/helpers/constants.ts
+++ b/src/components/Tree/helpers/constants.ts
@@ -1,0 +1,4 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export const ROOT_ID = '__ROOT__';
+export const INDENTATION_WIDTH = 20;

--- a/src/components/Tree/helpers/index.ts
+++ b/src/components/Tree/helpers/index.ts
@@ -4,3 +4,4 @@ export * from './getMovementAnnouncements';
 export * from './nodes';
 export * from './projection';
 export * from './reducer';
+export * from './constants';

--- a/src/components/Tree/helpers/projection.ts
+++ b/src/components/Tree/helpers/projection.ts
@@ -3,7 +3,7 @@
 import { ReactElement } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 
-import { INDENTATION_WIDTH, ROOT_ID } from '../Tree';
+import { INDENTATION_WIDTH, ROOT_ID } from '../helpers';
 import type { InternalTreeItemProps } from '../TreeItem';
 
 export type ProjectionArgs = {

--- a/src/components/Tree/utils/keyboardCoordinates.ts
+++ b/src/components/Tree/utils/keyboardCoordinates.ts
@@ -8,8 +8,7 @@ import {
     getFirstCollision,
 } from '@dnd-kit/core';
 
-import { getProjection } from '../helpers';
-import { INDENTATION_WIDTH } from '../Tree';
+import { INDENTATION_WIDTH, getProjection } from '../helpers';
 import type { SensorContext } from '../types';
 
 const directions: string[] = [KeyboardCode.Down, KeyboardCode.Right, KeyboardCode.Up, KeyboardCode.Left];


### PR DESCRIPTION
This PR changes the `Tree` component `INDENTATION_WIDTH` constant value from `32` to `20`.
Also, the constants exported on the file `Tree.tsx` were extracted to a `constants.ts` helper file in order to avoid circular dependencies.