### PR TITLE
feat(BrandColorPicker): fix visibility of icons by adding size to segmentControl

### DIFF
--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -63,6 +63,7 @@ export const BrandColorPicker = ({ palettes: defaultPalettes = [], currentColor,
                 </div>
                 <div className="tw-w-[72px]">
                     <SegmentedControls
+                        size="small"
                         items={views}
                         activeItemId={view}
                         onChange={(colorView) => setView(colorView as BrandColorView)}


### PR DESCRIPTION
[Before](https://beta-fondue-components.frontify.com/?path=/story/components-color-picker--with-brand-colors):
<img width="392" alt="image" src="https://github.com/Frontify/fondue/assets/42832501/1352ac79-6339-4001-9c01-dd2bec71c9ad">

Now:
<img width="378" alt="image" src="https://github.com/Frontify/fondue/assets/42832501/02d47bd7-b964-4f76-ab34-c3cabe5268f3">
