### PR TITLE
fix: Tree flickering

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -11,6 +11,7 @@ import React, {
     useReducer,
     useRef,
     useState,
+    useTransition,
 } from 'react';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { restrictToWindowEdges } from '@dnd-kit/modifiers';
@@ -182,6 +183,7 @@ const reducer = produce((draft: TreeState, action: TreeStateAction) => {
             draft.expandedIds = action.payload.expandedIds;
             draft.selectionMode = action.payload.selectionMode;
             break;
+
         default:
             console.warn(`Updated tree with action "${action.type}" but it has not effect.`);
     }
@@ -216,6 +218,8 @@ export const Tree = memo(
         );
 
         const [treeState, updateTreeState] = useReducer(reducer, initialState);
+        const [, startTransition] = useTransition();
+
         const [offset, setOffset] = useState(0);
         const [overId, setOverId] = useState<Nullable<string>>(null);
         const [activeId, setActiveId] = useState<Nullable<string>>(null);
@@ -582,10 +586,12 @@ export const Tree = memo(
                 }
             }
 
-            updateTreeState({
-                type: 'REGISTER_NODES',
-                payload: nodesToRender.map((n) => n.node),
-            });
+            startTransition(() =>
+                updateTreeState({
+                    type: 'REGISTER_NODES',
+                    payload: nodesToRender.map((n) => n.node),
+                }),
+            );
         }, [treeState.rootNodes, treeState.expandedIds]);
 
         useEffect(() => {
@@ -626,36 +632,37 @@ export const Tree = memo(
             });
         }, [activeId, offset, overId, treeState.nodes]);
 
-        const nodes = useMemo(() => {
-            const newNodes = treeState.nodes.map((node) => {
-                return cloneElement(node, {
-                    projection: node.props.id === activeId ? treeState.projection : null,
-                    treeDraggable: draggable,
-                    isSelected: treeState.selectedIds.has(node.props.id),
-                    isExpanded: treeState.expandedIds.has(node.props.id),
-                    registerOverlay,
-                    onExpand: handleExpand,
-                    onShrink: handleShrink,
-                    onSelect: handleSelect,
-                    registerNodeChildren,
-                    unregisterNodeChildren,
-                });
-            });
-            return newNodes;
-        }, [
-            draggable,
-            handleExpand,
-            handleShrink,
-            handleSelect,
-            activeId,
-            registerOverlay,
-            treeState.expandedIds,
-            treeState.nodes,
-            treeState.projection,
-            treeState.selectedIds,
-            registerNodeChildren,
-            unregisterNodeChildren,
-        ]);
+        const nodes = useMemo(
+            () =>
+                treeState.nodes.map((node) => {
+                    return cloneElement(node, {
+                        projection: node.props.id === activeId ? treeState.projection : null,
+                        treeDraggable: draggable,
+                        isSelected: treeState.selectedIds.has(node.props.id),
+                        isExpanded: treeState.expandedIds.has(node.props.id),
+                        registerOverlay,
+                        onExpand: handleExpand,
+                        onShrink: handleShrink,
+                        onSelect: handleSelect,
+                        registerNodeChildren,
+                        unregisterNodeChildren,
+                    });
+                }),
+            [
+                draggable,
+                handleExpand,
+                handleShrink,
+                handleSelect,
+                activeId,
+                registerOverlay,
+                treeState.expandedIds,
+                treeState.nodes,
+                treeState.projection,
+                treeState.selectedIds,
+                registerNodeChildren,
+                unregisterNodeChildren,
+            ],
+        );
 
         const contextValue: TreeContextProps = useMemo(
             () => ({

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -39,11 +39,8 @@ export type TreeProps = {
 
 type TreeItemBaseProps = {
     id: string;
-
     'data-test-id'?: string;
-
     onDrop?: OnTreeDropCallback;
-
     /**
      * The type of item being dragged.
      */
@@ -54,15 +51,10 @@ type TreeItemBaseProps = {
      * if suffix '-within' is appended, then it will allow dropping item inside it
      */
     accepts?: string;
-
     children?: ReactNode;
-
     draggable?: boolean;
-
     showCaret?: boolean;
-
     ignoreItemDoubleClick?: boolean;
-
     expandOnSelect?: boolean;
 };
 


### PR DESCRIPTION
Fixes tree flickering due reloading of the tree when some upper level property gets updated.

`useTransition` on final nodes update seems to hold the re-render until the whole children tree is loaded. Even tested with a 2G throttled network connection.
 
Without, there is a  re-render when every level gets loaded, leaving the flickering effect.