### PR TITLE
fix(Tab): key navigation stop propagation

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -123,6 +123,8 @@ export const Tabs = ({
     };
 
     const handleKeyboardTabChange = (event: KeyboardEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+
         const overflownTabs = getOverflownTabs();
         const target = event.target as HTMLElement;
         const fromOverflow = target.id.includes('-m');


### PR DESCRIPTION
This change stops the propagation of key events to avoid unwanted event bubbling.