### PR TITLE
fix(RTE): disable toolbar in readonly mode

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -107,7 +107,7 @@ export const RichTextEditor = ({
                 plugins={config.create()}
                 initialValue={memoizedValue}
             >
-                {config.toolbar(toolbarWidth)}
+                {!editableProps.readOnly && config.toolbar(toolbarWidth)}
                 {config.inline()}
                 {updateValueOnChange && <ContentReplacement value={parseRawValue({ editorId, raw: value, plugins })} />}
             </Plate>


### PR DESCRIPTION
Toolbar should not show up when selecting text in `readonly` mode.

<img width="634" alt="Bildschirmfoto 2023-06-16 um 09 39 36" src="https://github.com/Frontify/fondue/assets/11270687/b5ff428e-dce3-449f-a42b-73198d6dd4e1">
