### PR TITLE
fix(useToggleOverlay): export useToggleOverlay

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useClickOutside';
 export * from './useDebounce';
 export * from './useMemoizedId';
 export * from './useCopy';
+export * from './useToggleOverlay';


### PR DESCRIPTION
I think the useToggleOverlay is not yet exported from the hooks folder.