### PR TITLE
feat(RTE): allow tabbing to next or prev element

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -7,7 +7,7 @@ import { RenderPlaceholderProps } from 'slate-react';
 import { ContentReplacement } from './ContentReplacement';
 import { RichTextEditorProvider } from './context/RichTextEditorContext';
 import { Position } from './EditorPositioningWrapper';
-import { forceToBlurActiveElement } from './helpers';
+import { forceToFocusNextElement } from './helpers';
 import { useEditorState } from './hooks';
 import { GAP_DEFAULT, KEY_ELEMENT_BREAK_AFTER_COLUMN, PluginComposer, defaultPlugins } from './Plugins';
 import { PaddingSizes, TreeOfNodes } from './types';
@@ -83,8 +83,7 @@ export const RichTextEditor = ({
         },
         onKeyDown: (event) => {
             if (event.code === 'Tab') {
-                // Forcing a blur event because of accessibility
-                forceToBlurActiveElement();
+                forceToFocusNextElement(event, !event.shiftKey);
             }
         },
         scrollSelectionIntoView: () => {

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -679,4 +679,22 @@ describe('RichTextEditor Component', () => {
             cy.get('[contenteditable=true]').should('include.html', 'sub');
         });
     });
+
+    describe('Accessbility', () => {
+        it('should be able to tab between multiple rich text editors.', () => {
+            cy.mount(
+                <>
+                    <RichTextEditor value="<p>Mock</p>" />
+                    <RichTextEditor value="<p>Mock2</p>" />
+                </>,
+            );
+
+            cy.get('[contenteditable=true]').eq(0).click();
+            cy.get('[contenteditable=true]').eq(0).should('be.focused');
+            cy.realPress('Tab');
+            cy.get('[contenteditable=true]').eq(1).should('be.focused');
+            cy.realPress(['Shift', 'Tab']);
+            cy.get('[contenteditable=true]').eq(0).should('be.focused');
+        });
+    });
 });

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -1,13 +1,28 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const TABBABLE_ELEMENTS = [
+    'input:not([disabled]):not([type=hidden])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    'a[href]',
+    'area[href]',
+    'summary',
+    'iframe',
+    'object',
+    'embed',
+    'audio[controls]',
+    'video[controls]',
+    '[contenteditable]',
+    '[tabindex]:not([tabindex="-1"]):not([disabled])',
+].join(':not([hidden]):not([tabindex="-1"]),');
+
 export const forceToFocusNextElement = (event: React.KeyboardEvent, forwards: boolean) => {
     if (!document.activeElement) {
         return;
     }
     event.preventDefault();
-    const focusableElementSelectors =
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable], iframe, object, embed, [tabindex]:not([tabindex="-1"])';
-    const focusableElements = Array.from(document.querySelectorAll(focusableElementSelectors));
+    const focusableElements = Array.from(document.querySelectorAll(TABBABLE_ELEMENTS));
     const currentIndex = focusableElements.indexOf(document.activeElement);
     const indexOfNextFocus =
         (forwards ? currentIndex + 1 : currentIndex - 1 + focusableElements.length) % focusableElements.length;

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -6,7 +6,7 @@ export const forceToFocusNextElement = (event: React.KeyboardEvent, forwards: bo
     }
     event.preventDefault();
     const focusableElementSelectors =
-        'button, [href], input, select, textarea, [role="textbox"], [tabindex]:not([tabindex="-1"]';
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable], iframe, object, embed, [tabindex]:not([tabindex="-1"])';
     const focusableElements = Array.from(document.querySelectorAll(focusableElementSelectors));
     const currentIndex = focusableElements.indexOf(document.activeElement);
     const indexOfNextFocus =

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -1,0 +1,18 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export const forceToFocusNextElement = (event: React.KeyboardEvent, forwards: boolean) => {
+    if (!document.activeElement) {
+        return;
+    }
+    event.preventDefault();
+    const focusableElementSelectors =
+        'button, [href], input, select, textarea, [role="textbox"], [tabindex]:not([tabindex="-1"]';
+    const focusableElements = Array.from(document.querySelectorAll(focusableElementSelectors));
+    const currentIndex = focusableElements.indexOf(document.activeElement);
+    const indexOfNextFocus =
+        (forwards ? currentIndex + 1 : currentIndex - 1 + focusableElements.length) % focusableElements.length;
+    const nextFocusable = focusableElements[indexOfNextFocus] as HTMLElement;
+    if (nextFocusable) {
+        nextFocusable.focus();
+    }
+};

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 const TABBABLE_ELEMENTS = [
-    'input:not([disabled]):not([type=hidden])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    'button:not([disabled])',
+    'input',
+    'select',
+    'textarea',
+    'button',
     'a[href]',
     'area[href]',
     'summary',
@@ -14,8 +14,8 @@ const TABBABLE_ELEMENTS = [
     'audio[controls]',
     'video[controls]',
     '[contenteditable]',
-    '[tabindex]:not([tabindex="-1"]):not([disabled])',
-].join(':not([hidden]):not([tabindex="-1"]),');
+    '[tabindex]',
+].join(':not([hidden]):not([tabindex="-1"]):not([disabled]),');
 
 export const forceToFocusNextElement = (event: React.KeyboardEvent, forwards: boolean) => {
     if (!document.activeElement) {

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -22,7 +22,9 @@ export const forceToFocusNextElement = (event: React.KeyboardEvent, forwards: bo
         return;
     }
     event.preventDefault();
-    const focusableElements = Array.from(document.querySelectorAll(TABBABLE_ELEMENTS));
+    const focusableElements = Array.from(document.querySelectorAll(TABBABLE_ELEMENTS)).filter((focusableElement) =>
+        isElementVisible(focusableElement as HTMLElement),
+    );
     const currentIndex = focusableElements.indexOf(document.activeElement);
     const indexOfNextFocus =
         (forwards ? currentIndex + 1 : currentIndex - 1 + focusableElements.length) % focusableElements.length;
@@ -30,4 +32,16 @@ export const forceToFocusNextElement = (event: React.KeyboardEvent, forwards: bo
     if (nextFocusable) {
         nextFocusable.focus();
     }
+};
+
+const isElementVisible = (element: HTMLElement) => {
+    let currentElement: HTMLElement | null = element;
+    while (currentElement) {
+        const style = window.getComputedStyle(currentElement);
+        if (style.display === 'none' || style.visibility === 'hidden') {
+            return false;
+        }
+        currentElement = currentElement.parentElement;
+    }
+    return true;
 };

--- a/src/components/RichTextEditor/helpers/index.ts
+++ b/src/components/RichTextEditor/helpers/index.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export * from './forceToFocusElement';
 export * from './forceToBlurActiveElement';
 export * from './getHotkeyByPlatform';
 export * from './getTooltip';


### PR DESCRIPTION
Previously on TAB the RTE blurred and removed focus. However TAB should also focus the next element in the focus tree, so in this PR I am implementing that.