### PR TITLE
fix: updated raw parser [TASK-7579]

### DIFF
--- a/src/components/RichTextEditor/__tests__/Rendering.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/Rendering.cy.tsx
@@ -108,17 +108,10 @@ describe('RichTextEditor Rendering', () => {
 });
 
 describe('RichTextEditor Rendering - without proper parent Tag', () => {
-    it('it renders break BR', () => {
-        const text = '<br />';
-
-        cy.mount(<RichTextEditor value={text} />);
+    it('it renders breaks', () => {
+        cy.mount(<RichTextEditor value={'<br />'} />);
         cy.get(RICH_TEXT_EDITOR).should('contain.text', '\n\n');
-    });
-
-    it('it renders multiple BR', () => {
-        const text = '<br /><br /><br />';
-
-        cy.mount(<RichTextEditor value={text} />);
+        cy.mount(<RichTextEditor value={'<br /><br /><br />'} />);
         cy.get(RICH_TEXT_EDITOR).should('contain.text', '\n\n\n\n');
     });
 

--- a/src/components/RichTextEditor/__tests__/Rendering.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/Rendering.cy.tsx
@@ -1,0 +1,152 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { ELEMENT_PARAGRAPH } from '@udecode/plate';
+import React, { ReactElement, useState } from 'react';
+import { RichTextEditor } from '../RichTextEditor';
+import { RICH_TEXT_EDITOR } from './fixtures/selectors';
+
+const RichTextEditorWithValueSetOutside = ({ value }: { value: string }): ReactElement => {
+    const [initialValue, setInitialValue] = useState(value);
+
+    return <RichTextEditor onTextChange={(value) => setInitialValue(value)} value={initialValue} />;
+};
+
+describe('RichTextEditor Rendering', () => {
+    it('should render an empty rich text editor', () => {
+        cy.mount(<RichTextEditor />);
+
+        cy.get(RICH_TEXT_EDITOR).should('be.visible');
+    });
+
+    it('should render a raw content state', () => {
+        const text = 'This is some text that you can not edit';
+        cy.mount(<RichTextEditor value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text }] }])} />);
+
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', text);
+    });
+
+    it('should render a raw html content state', () => {
+        const text = '<p><b>this is bold</b> and <i>this italic</i></p>';
+        cy.mount(<RichTextEditor value={text} />);
+
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', 'this is bold and this italic');
+        cy.get('[contenteditable=true]').should('include.html', 'tw-font-bold');
+        cy.get('[contenteditable=true]').should('include.html', 'tw-italic');
+    });
+
+    it('should render a plain text string content state', () => {
+        const text = 'This is text';
+        cy.mount(<RichTextEditor value={text} />);
+
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', text);
+    });
+
+    it('should render the updated value when updateValueOnChange enabled', () => {
+        const initialText = 'This is the initial text';
+
+        cy.mount(
+            <RichTextEditor
+                updateValueOnChange
+                value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text: initialText }] }])}
+            />,
+        ).then(({ rerender }) => {
+            const updatedText = 'This is the updated text';
+            rerender(
+                <RichTextEditor
+                    updateValueOnChange
+                    value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text: updatedText }] }])}
+                />,
+            );
+            cy.get(RICH_TEXT_EDITOR).should('contain.text', updatedText);
+        });
+    });
+
+    it('should render the same value when updateValueOnChange disabled', () => {
+        const text = 'This is the initial text';
+
+        cy.mount(<RichTextEditor value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text }] }])} />).then(
+            ({ rerender }) => {
+                rerender(
+                    <RichTextEditor
+                        value={JSON.stringify([
+                            { type: ELEMENT_PARAGRAPH, children: [{ text: 'This is the updated text' }] },
+                        ])}
+                    />,
+                );
+                cy.get(RICH_TEXT_EDITOR).should('contain.text', text);
+            },
+        );
+    });
+
+    it('it should normalize the initial html value', () => {
+        const text = '<ul><li>foo</li><li>bar</li></ul>';
+        const onBlur = cy.spy();
+
+        const expectedResult = JSON.stringify([
+            {
+                type: 'ul',
+                children: [
+                    { type: 'li', children: [{ type: 'lic', children: [{ text: 'foo' }] }] },
+                    { type: 'li', children: [{ type: 'lic', children: [{ text: 'bar' }] }] },
+                ],
+            },
+        ]);
+
+        cy.mount(<RichTextEditor value={text} onBlur={onBlur} />);
+        cy.get('[contenteditable=true]')
+            .click()
+            .blur()
+            .then(() => expect(onBlur).to.be.calledWith(expectedResult));
+    });
+
+    it('renders normal text set outside', () => {
+        const text = 'This is new text';
+
+        cy.mount(<RichTextEditorWithValueSetOutside value={text} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', text);
+    });
+});
+
+describe('RichTextEditor Rendering - without proper parent Tag', () => {
+    it('it renders break BR', () => {
+        const text = '<br />';
+
+        cy.mount(<RichTextEditor value={text} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', '\n\n');
+    });
+
+    it('it renders multiple BR', () => {
+        const text = '<br /><br /><br />';
+
+        cy.mount(<RichTextEditor value={text} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', '\n\n\n\n');
+    });
+
+    it('it renders empty string on spaces', () => {
+        const text = '        ';
+
+        cy.mount(<RichTextEditor value={text} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', '');
+    });
+
+    it('it renders text with STRONG tag', () => {
+        const text = '<strong>This is new text</strong>';
+
+        cy.mount(<RichTextEditor value={text} />);
+        cy.get('[contenteditable=true]').should('include.html', 'tw-font-bold');
+    });
+
+    it('it renders text when DIV tag', () => {
+        const text = '<div>This is new text</div>';
+
+        cy.mount(<RichTextEditor value={text} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', 'This is new text');
+    });
+
+    it('it renders text when SPAN tag', () => {
+        const text = '<span>This is new text</span>';
+
+        cy.mount(<RichTextEditor value={text} />);
+        cy.get(RICH_TEXT_EDITOR).should('contain.text', 'This is new text');
+    });
+});

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { ELEMENT_PARAGRAPH } from '@udecode/plate';
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
 import { orderedListValue } from '../helpers/exampleValues';
 import {
     AlignRightPlugin,
@@ -27,7 +27,6 @@ import {
 } from './fixtures/RichTextEditor';
 import {
     CHECKBOX_INPUT,
-    RICH_TEXT_EDITOR,
     TEXTSTYLE_DROPDOWN_TRIGGER,
     TEXTSTYLE_OPTION,
     TOOLBAR_FLOATING,
@@ -59,92 +58,10 @@ const selectTextValue = (value: string) => {
     });
 };
 
-const RichTextEditorWithValueSetOutside = ({ value }: { value: string }): ReactElement => {
-    const [initialValue, setInitialValue] = useState(value);
-
-    return <RichTextEditor onTextChange={(value) => setInitialValue(value)} value={initialValue} />;
-};
-
 const activeButtonClassNames = '!tw-bg-box-selected tw-rounded !tw-text-box-selected-inverse';
 const disabledButtonClassNames = '!tw-cursor-not-allowed !tw-opacity-50';
 
 describe('RichTextEditor Component', () => {
-    describe('Rendering', () => {
-        it('should render an empty rich text editor', () => {
-            cy.mount(<RichTextEditor />);
-
-            cy.get(RICH_TEXT_EDITOR).should('be.visible');
-        });
-
-        it('should render a raw content state', () => {
-            const text = 'This is some text that you can not edit';
-            cy.mount(<RichTextEditor value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text }] }])} />);
-
-            cy.get(RICH_TEXT_EDITOR).should('contain.text', text);
-        });
-
-        it('should render a raw html content state', () => {
-            cy.mount(<RichTextEditor value={'<p><b>this is bold</b> and <i>this italic</i></p>'} />);
-
-            cy.get(RICH_TEXT_EDITOR).should('contain.text', 'this is bold and this italic');
-            cy.get('[contenteditable=true]').should('include.html', 'tw-font-bold');
-            cy.get('[contenteditable=true]').should('include.html', 'tw-italic');
-        });
-
-        it('should render a plain text string content state', () => {
-            const TEXT = 'This is text';
-            cy.mount(<RichTextEditor value={TEXT} />);
-
-            cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
-        });
-
-        it('wraps the Editor in the component ', () => {
-            const TEXT = 'This is new text';
-
-            cy.mount(<RichTextEditorWithValueSetOutside value={TEXT} />);
-            cy.get(RICH_TEXT_EDITOR).should('contain.text', TEXT);
-        });
-
-        it('should render the updated value when updateValueOnChange enabled', () => {
-            const INITIAL_TEXT = 'This is the initial text';
-
-            cy.mount(
-                <RichTextEditor
-                    updateValueOnChange
-                    value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text: INITIAL_TEXT }] }])}
-                />,
-            ).then(({ rerender }) => {
-                const UPDATED_TEXT = 'This is the updated text';
-                rerender(
-                    <RichTextEditor
-                        updateValueOnChange
-                        value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text: UPDATED_TEXT }] }])}
-                    />,
-                );
-                cy.get(RICH_TEXT_EDITOR).should('contain.text', UPDATED_TEXT);
-            });
-        });
-
-        it('should render the same value when updateValueOnChange disabled', () => {
-            const INITIAL_TEXT = 'This is the initial text';
-
-            cy.mount(
-                <RichTextEditor
-                    value={JSON.stringify([{ type: ELEMENT_PARAGRAPH, children: [{ text: INITIAL_TEXT }] }])}
-                />,
-            ).then(({ rerender }) => {
-                rerender(
-                    <RichTextEditor
-                        value={JSON.stringify([
-                            { type: ELEMENT_PARAGRAPH, children: [{ text: 'This is the updated text' }] },
-                        ])}
-                    />,
-                );
-                cy.get(RICH_TEXT_EDITOR).should('contain.text', INITIAL_TEXT);
-            });
-        });
-    });
-
     describe('Editable', () => {
         it('should be editable by default ', () => {
             cy.mount(<RichTextEditor />);
@@ -607,30 +524,6 @@ describe('RichTextEditor Component', () => {
                 />,
             );
             cy.get('[contenteditable=true] .tw-break-after-column').should('have.length', 1);
-        });
-    });
-
-    describe('initial value', () => {
-        it('it should normalize the initial html value', () => {
-            const onBlur = cy.spy();
-            cy.mount(<RichTextEditor value="<ul><li>foo</li><li>bar</li></ul>" onBlur={onBlur} />);
-
-            cy.get('[contenteditable=true]')
-                .click()
-                .blur()
-                .then(() => {
-                    expect(onBlur).to.be.calledWith(
-                        JSON.stringify([
-                            {
-                                type: 'ul',
-                                children: [
-                                    { type: 'li', children: [{ type: 'lic', children: [{ text: 'foo' }] }] },
-                                    { type: 'li', children: [{ type: 'lic', children: [{ text: 'bar' }] }] },
-                                ],
-                            },
-                        ]),
-                    );
-                });
         });
     });
 

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -7,12 +7,12 @@ import { InitPlateEditor } from './InitPlateEditor';
 const wrapChildrenWithoutTypeInParagraph = (children: Value): Value =>
     children[0].hasOwnProperty('type')
         ? children
-        : (children = [
+        : [
               {
                   type: 'p',
                   children,
               },
-          ]);
+          ];
 
 export const EMPTY_RICH_TEXT_VALUE: Value = [{ type: ELEMENT_PARAGRAPH, children: [{ text: '' }] }];
 

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -4,12 +4,15 @@ import { ELEMENT_PARAGRAPH, Value, deserializeHtml, normalizeEditor } from '@ude
 import { PluginComposer } from '../Plugins';
 import { InitPlateEditor } from './InitPlateEditor';
 
-const isHtmlString = (string: string): boolean => {
-    const fragment = new DOMParser().parseFromString(string, 'text/html');
-    return fragment.body.children.length > 0;
-};
-
-const wrapTextInHtml = (text: string) => (isHtmlString(text) ? text : `<p>${text}</p>`);
+const wrapChildrenWithoutTypeInParagraph = (children: Value): Value =>
+    children[0].hasOwnProperty('type')
+        ? children
+        : (children = [
+              {
+                  type: 'p',
+                  children,
+              },
+          ]);
 
 export const EMPTY_RICH_TEXT_VALUE: Value = [{ type: ELEMENT_PARAGRAPH, children: [{ text: '' }] }];
 
@@ -30,15 +33,11 @@ export const parseRawValue = ({ editorId = 'parseRawValue', raw, plugins }: Pars
     try {
         parsedValue = JSON.parse(raw);
     } catch {
-        const trimmed = raw.trim().replaceAll(/>\s+</g, '><');
-        const htmlDocumentString = wrapTextInHtml(trimmed);
+        const trimmedText = raw.trim().replaceAll(/>\s+</g, '><');
         const parsedHtml = deserializeHtml(editor, {
-            element: htmlDocumentString,
-            stripWhitespace: true,
+            element: trimmedText,
         }) as Value;
-        if (parsedHtml) {
-            parsedValue = parsedHtml;
-        }
+        parsedValue = wrapChildrenWithoutTypeInParagraph(parsedHtml);
     }
 
     editor.children = parsedValue;


### PR DESCRIPTION
The clickUp task: https://app.clickup.com/t/2523021/TASK-7579

What was braking? when passing text with html  <br /> the RTE was breaking because it creates Nodes without proper parent tag like Paragraph and looked liked this:
```
[{ "text": "\n" }]
```
This made RTE unresponsive and not capable of editing it anymore.

Solution: Wrapping such a text into paragraph parent which is then parsed in correct object for RTE.

Also refactored a bit of test and added new ones for this case.
