### PR TITLE
fix: (Tree) remove setOffset restricted update

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -67,7 +67,7 @@ import {
 } from './helpers';
 
 import { TreeContext, TreeContextProps } from './TreeContext';
-import { OFFSET_UPDATE_DELTA, ROOT_ID } from './helpers';
+import { ROOT_ID } from './helpers';
 
 const measuring: MeasuringConfiguration = {
     droppable: {
@@ -332,9 +332,7 @@ export const Tree = memo(
         };
 
         const handleDragMove = ({ delta }: DragMoveEvent) => {
-            if (delta.x % OFFSET_UPDATE_DELTA === 0) {
-                setOffset(delta.x);
-            }
+            setOffset(delta.x);
         };
 
         const handleDragCancel = () => {


### PR DESCRIPTION
This restriction added to prevent extra re-renders before, made Chrome buggy to get level 0 positioning.
Removing it, other previous updates fixed the extra re-renders