### PR TITLE
fix: Tree clean empty items to prevent phantom items

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -209,6 +209,7 @@ export const TreeItem = memo(
 
         useDeepCompareEffect(() => {
             if (Children.count(enrichedChildren) === 0) {
+                unregisterNodeChildren?.(id);
                 return;
             }
 


### PR DESCRIPTION
When removing all children from a parent, the last child is kept in the UI (as a phantom item). Ensure we unregister them correctly