### PR TITLE
fix(Tree): ignore keydown if element is not a tree item

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -353,10 +353,9 @@ export const Tree = memo(
                 const activeElement = document.activeElement;
 
                 if (
-                    !activeElement ||
-                    !activeElement.parentElement ||
-                    !(activeElement instanceof HTMLLIElement) ||
-                    activeElement.getAttribute('role') !== 'treeitem'
+                    !activeElement?.parentElement ||
+                    activeElement.getAttribute('role') !== 'treeitem' ||
+                    !(activeElement instanceof HTMLLIElement)
                 ) {
                     return;
                 }

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -352,7 +352,12 @@ export const Tree = memo(
             (event: React.KeyboardEvent<HTMLUListElement>) => {
                 const activeElement = document.activeElement;
 
-                if (!activeElement || !activeElement.parentElement || !(activeElement instanceof HTMLLIElement)) {
+                if (
+                    !activeElement ||
+                    !activeElement.parentElement ||
+                    !(activeElement instanceof HTMLLIElement) ||
+                    activeElement.getAttribute('role') !== 'treeitem'
+                ) {
                     return;
                 }
 


### PR DESCRIPTION
The keydown callback was running for a `TreeItem` children when it is not supposed to, so we will return early if the active item role is not `treeitem`