### PR TITLE
feat: Tree only expand on hover for allowed items

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -95,11 +95,17 @@ export const TreeItem = memo(
         const cleanCurrentType = currentType?.replace(/-\d+$/, '') || '';
 
         const isWithin =
-            activeProjection?.previousNode?.depth !== undefined &&
-            activeProjection?.depth > activeProjection?.previousNode?.depth;
+            projection?.previousNode?.depth !== undefined && projection?.depth > projection?.previousNode?.depth;
+
+        const canDropWithinAndDeeper =
+            isWithin &&
+            projection?.previousNode?.accepts !== undefined &&
+            (projection?.previousNode?.accepts.includes(`${cleanCurrentType}-deeper`) ||
+                projection?.previousNode?.accepts.includes(`${cleanCurrentType}-within`));
 
         const canDropWithin =
-            (isWithin &&
+            (isActive &&
+                isWithin &&
                 activeProjection?.previousNode?.accepts !== undefined &&
                 activeProjection?.previousNode?.accepts.includes(`${cleanCurrentType}-within`)) ||
             (activeProjection?.isWithinParent && parentAccepts.includes(`${cleanCurrentType}-within`));
@@ -120,7 +126,7 @@ export const TreeItem = memo(
 
             if (
                 isActive &&
-                isWithin &&
+                canDropWithinAndDeeper &&
                 activeProjection?.parentId &&
                 activeProjection.previousNode &&
                 activeProjection.parentId === activeProjection.previousNode.id &&
@@ -134,6 +140,7 @@ export const TreeItem = memo(
             activeProjection?.previousNode,
             expandProjectionParent,
             isActive,
+            canDropWithinAndDeeper,
             isWithin,
         ]);
 
@@ -284,6 +291,7 @@ export const TreeItem = memo(
             !isActive &&
             !isExpanded &&
             showExpandButton &&
+            canDropWithinAndDeeper &&
             projection?.previousNode?.id === id &&
             projection?.depth > projection?.previousNode?.depth
         ) {

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -48,8 +48,9 @@ type TreeItemBaseProps = {
     type?: string;
     /**
      * The kinds of dragItems this dropTarget accepts
-     *  @example 'itemA, itemA-within'
+     *  @example 'itemA, itemA-within, itemA-deeper'
      * if suffix '-within' is appended, then it will allow dropping item inside it
+     * if suffix '-deeper' is appended, then it will allow expand because it will allow dropping in levels deeper
      */
     accepts?: string;
     children?: ReactNode;


### PR DESCRIPTION
`-deeper` suffix on `accepts property indicates that the item can be dropped in deeper levels (grandchildren, grand-grandchildren) so the container item can be expanded.