### PR TITLE
feat(icons): add unique clip path id to all icons

### DIFF
--- a/scripts/generateReactIcons.ts
+++ b/scripts/generateReactIcons.ts
@@ -61,6 +61,10 @@ const generateSvgComponent = async (svgPath: Entry) => {
             template: IconTemplate,
             dimensions: true,
             typescript: true,
+            replaceAttrValues: {
+                prefix__a: svgFileName,
+                'url(#prefix__a)': `url(#${svgFileName})`,
+            },
             svgProps: {
                 className: '{customClassName}',
                 name: `${ICON_COMPONENT_PREFIX}${svgFileName}`,

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -13,7 +13,7 @@ const TABBABLE_ELEMENTS = [
     'embed',
     'audio[controls]',
     'video[controls]',
-    '[contenteditable]',
+    '[contenteditable="true"]',
     '[tabindex]',
 ].join(':not([hidden]):not([tabindex="-1"]):not([disabled]),');
 

--- a/src/components/RichTextEditor/helpers/forceToFocusElement.ts
+++ b/src/components/RichTextEditor/helpers/forceToFocusElement.ts
@@ -13,7 +13,7 @@ const TABBABLE_ELEMENTS = [
     'embed',
     'audio[controls]',
     'video[controls]',
-    '[contenteditable="true"]',
+    '[contenteditable]',
     '[tabindex]',
 ].join(':not([hidden]):not([tabindex="-1"]):not([disabled]),');
 

--- a/src/foundation/Icon/Generated/IconArrowAlignHorizontalCentre12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowAlignHorizontalCentre12.tsx
@@ -12,7 +12,7 @@ function IconArrowAlignHorizontalCentre12(props: GeneratedIconProps): React.Reac
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowAlignHorizontalCentre12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowAlignHorizontalCentre12(props: GeneratedIconProps): React.Reac
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowAlignHorizontalCentre12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowAlignVerticalCentre12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowAlignVerticalCentre12.tsx
@@ -12,7 +12,7 @@ function IconArrowAlignVerticalCentre12(props: GeneratedIconProps): React.ReactE
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowAlignVerticalCentre12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowAlignVerticalCentre12(props: GeneratedIconProps): React.ReactE
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowAlignVerticalCentre12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowCircleDown12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowCircleDown12.tsx
@@ -12,7 +12,7 @@ function IconArrowCircleDown12(props: GeneratedIconProps): React.ReactElement<Ge
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowCircleDown12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowCircleDown12(props: GeneratedIconProps): React.ReactElement<Ge
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowCircleDown12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowCircleUp12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowCircleUp12.tsx
@@ -12,7 +12,7 @@ function IconArrowCircleUp12(props: GeneratedIconProps): React.ReactElement<Gene
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowCircleUp12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowCircleUp12(props: GeneratedIconProps): React.ReactElement<Gene
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowCircleUp12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowMinimize12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowMinimize12.tsx
@@ -12,7 +12,7 @@ function IconArrowMinimize12(props: GeneratedIconProps): React.ReactElement<Gene
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowMinimize12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowMinimize12(props: GeneratedIconProps): React.ReactElement<Gene
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowMinimize12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowMove12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowMove12.tsx
@@ -12,7 +12,7 @@ function IconArrowMove12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowMove12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowMove12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowMove12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowMove20.tsx
+++ b/src/foundation/Icon/Generated/IconArrowMove20.tsx
@@ -12,7 +12,7 @@ function IconArrowMove20(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowMove20)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowMove20(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowMove20">
                         <path fill="#fff" d="M0 0h20v20H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowScaleHorizontal12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowScaleHorizontal12.tsx
@@ -12,7 +12,7 @@ function IconArrowScaleHorizontal12(props: GeneratedIconProps): React.ReactEleme
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowScaleHorizontal12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowScaleHorizontal12(props: GeneratedIconProps): React.ReactEleme
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowScaleHorizontal12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconArrowScaleVertical12.tsx
+++ b/src/foundation/Icon/Generated/IconArrowScaleVertical12.tsx
@@ -12,7 +12,7 @@ function IconArrowScaleVertical12(props: GeneratedIconProps): React.ReactElement
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ArrowScaleVertical12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconArrowScaleVertical12(props: GeneratedIconProps): React.ReactElement
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ArrowScaleVertical12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconBasketball12.tsx
+++ b/src/foundation/Icon/Generated/IconBasketball12.tsx
@@ -12,7 +12,7 @@ function IconBasketball12(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Basketball12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconBasketball12(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Basketball12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconBox12.tsx
+++ b/src/foundation/Icon/Generated/IconBox12.tsx
@@ -12,7 +12,7 @@ function IconBox12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Box12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconBox12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Box12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconBracketsCurly12.tsx
+++ b/src/foundation/Icon/Generated/IconBracketsCurly12.tsx
@@ -12,7 +12,7 @@ function IconBracketsCurly12(props: GeneratedIconProps): React.ReactElement<Gene
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#BracketsCurly12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconBracketsCurly12(props: GeneratedIconProps): React.ReactElement<Gene
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="BracketsCurly12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconChartPie12.tsx
+++ b/src/foundation/Icon/Generated/IconChartPie12.tsx
@@ -12,7 +12,7 @@ function IconChartPie12(props: GeneratedIconProps): React.ReactElement<Generated
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ChartPie12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconChartPie12(props: GeneratedIconProps): React.ReactElement<Generated
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ChartPie12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCheckMarkCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconCheckMarkCircle12.tsx
@@ -12,7 +12,7 @@ function IconCheckMarkCircle12(props: GeneratedIconProps): React.ReactElement<Ge
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#CheckMarkCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCheckMarkCircle12(props: GeneratedIconProps): React.ReactElement<Ge
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="CheckMarkCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCheckMarkCircle12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconCheckMarkCircle12Filled.tsx
@@ -12,7 +12,7 @@ function IconCheckMarkCircle12Filled(props: GeneratedIconProps): React.ReactElem
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#CheckMarkCircle12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCheckMarkCircle12Filled(props: GeneratedIconProps): React.ReactElem
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="CheckMarkCircle12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconCircle12.tsx
@@ -12,7 +12,7 @@ function IconCircle12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Circle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCircle12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Circle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconClock12.tsx
+++ b/src/foundation/Icon/Generated/IconClock12.tsx
@@ -12,7 +12,7 @@ function IconClock12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Clock12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconClock12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Clock12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconClockAlternative12.tsx
+++ b/src/foundation/Icon/Generated/IconClockAlternative12.tsx
@@ -12,7 +12,7 @@ function IconClockAlternative12(props: GeneratedIconProps): React.ReactElement<G
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ClockAlternative12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconClockAlternative12(props: GeneratedIconProps): React.ReactElement<G
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ClockAlternative12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconClockList12.tsx
+++ b/src/foundation/Icon/Generated/IconClockList12.tsx
@@ -12,7 +12,7 @@ function IconClockList12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ClockList12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconClockList12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ClockList12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCode12.tsx
+++ b/src/foundation/Icon/Generated/IconCode12.tsx
@@ -12,7 +12,7 @@ function IconCode12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Code12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCode12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Code12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCog12.tsx
+++ b/src/foundation/Icon/Generated/IconCog12.tsx
@@ -12,7 +12,7 @@ function IconCog12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Cog12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCog12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Cog12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCountry12.tsx
+++ b/src/foundation/Icon/Generated/IconCountry12.tsx
@@ -12,7 +12,7 @@ function IconCountry12(props: GeneratedIconProps): React.ReactElement<GeneratedI
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Country12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCountry12(props: GeneratedIconProps): React.ReactElement<GeneratedI
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Country12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCrossCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconCrossCircle12.tsx
@@ -12,7 +12,7 @@ function IconCrossCircle12(props: GeneratedIconProps): React.ReactElement<Genera
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#CrossCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCrossCircle12(props: GeneratedIconProps): React.ReactElement<Genera
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="CrossCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconCrossCircle12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconCrossCircle12Filled.tsx
@@ -12,7 +12,7 @@ function IconCrossCircle12Filled(props: GeneratedIconProps): React.ReactElement<
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#CrossCircle12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconCrossCircle12Filled(props: GeneratedIconProps): React.ReactElement<
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="CrossCircle12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconDoAndDont20.tsx
+++ b/src/foundation/Icon/Generated/IconDoAndDont20.tsx
@@ -12,7 +12,7 @@ function IconDoAndDont20(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#DoAndDont20)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconDoAndDont20(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="DoAndDont20">
                         <path fill="#fff" d="M0 0h20v20H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconDoAndDontBox12.tsx
+++ b/src/foundation/Icon/Generated/IconDoAndDontBox12.tsx
@@ -12,7 +12,7 @@ function IconDoAndDontBox12(props: GeneratedIconProps): React.ReactElement<Gener
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#DoAndDontBox12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconDoAndDontBox12(props: GeneratedIconProps): React.ReactElement<Gener
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="DoAndDontBox12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconEraser12.tsx
+++ b/src/foundation/Icon/Generated/IconEraser12.tsx
@@ -12,7 +12,7 @@ function IconEraser12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Eraser12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconEraser12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Eraser12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconExclamationMarkCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconExclamationMarkCircle12.tsx
@@ -12,7 +12,7 @@ function IconExclamationMarkCircle12(props: GeneratedIconProps): React.ReactElem
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ExclamationMarkCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconExclamationMarkCircle12(props: GeneratedIconProps): React.ReactElem
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ExclamationMarkCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconExclamationMarkCircle12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconExclamationMarkCircle12Filled.tsx
@@ -12,7 +12,7 @@ function IconExclamationMarkCircle12Filled(props: GeneratedIconProps): React.Rea
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ExclamationMarkCircle12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconExclamationMarkCircle12Filled(props: GeneratedIconProps): React.Rea
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ExclamationMarkCircle12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconExclamationMarkTriangle12.tsx
+++ b/src/foundation/Icon/Generated/IconExclamationMarkTriangle12.tsx
@@ -12,7 +12,7 @@ function IconExclamationMarkTriangle12(props: GeneratedIconProps): React.ReactEl
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ExclamationMarkTriangle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconExclamationMarkTriangle12(props: GeneratedIconProps): React.ReactEl
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ExclamationMarkTriangle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconEye12.tsx
+++ b/src/foundation/Icon/Generated/IconEye12.tsx
@@ -12,7 +12,7 @@ function IconEye12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Eye12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconEye12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Eye12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconEyeOff12.tsx
+++ b/src/foundation/Icon/Generated/IconEyeOff12.tsx
@@ -12,7 +12,7 @@ function IconEyeOff12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#EyeOff12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconEyeOff12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="EyeOff12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceExtraHappy12.tsx
+++ b/src/foundation/Icon/Generated/IconFaceExtraHappy12.tsx
@@ -12,7 +12,7 @@ function IconFaceExtraHappy12(props: GeneratedIconProps): React.ReactElement<Gen
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceExtraHappy12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceExtraHappy12(props: GeneratedIconProps): React.ReactElement<Gen
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceExtraHappy12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceHappy12.tsx
+++ b/src/foundation/Icon/Generated/IconFaceHappy12.tsx
@@ -12,7 +12,7 @@ function IconFaceHappy12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceHappy12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceHappy12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceHappy12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceHappy12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconFaceHappy12Filled.tsx
@@ -12,7 +12,7 @@ function IconFaceHappy12Filled(props: GeneratedIconProps): React.ReactElement<Ge
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceHappy12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceHappy12Filled(props: GeneratedIconProps): React.ReactElement<Ge
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceHappy12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceNeutral12.tsx
+++ b/src/foundation/Icon/Generated/IconFaceNeutral12.tsx
@@ -12,7 +12,7 @@ function IconFaceNeutral12(props: GeneratedIconProps): React.ReactElement<Genera
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceNeutral12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceNeutral12(props: GeneratedIconProps): React.ReactElement<Genera
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceNeutral12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceNeutral12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconFaceNeutral12Filled.tsx
@@ -12,7 +12,7 @@ function IconFaceNeutral12Filled(props: GeneratedIconProps): React.ReactElement<
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceNeutral12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceNeutral12Filled(props: GeneratedIconProps): React.ReactElement<
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceNeutral12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceSad12.tsx
+++ b/src/foundation/Icon/Generated/IconFaceSad12.tsx
@@ -12,7 +12,7 @@ function IconFaceSad12(props: GeneratedIconProps): React.ReactElement<GeneratedI
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceSad12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceSad12(props: GeneratedIconProps): React.ReactElement<GeneratedI
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceSad12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFaceSad12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconFaceSad12Filled.tsx
@@ -12,7 +12,7 @@ function IconFaceSad12Filled(props: GeneratedIconProps): React.ReactElement<Gene
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FaceSad12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFaceSad12Filled(props: GeneratedIconProps): React.ReactElement<Gene
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FaceSad12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconFocalPoint12.tsx
+++ b/src/foundation/Icon/Generated/IconFocalPoint12.tsx
@@ -12,7 +12,7 @@ function IconFocalPoint12(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#FocalPoint12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconFocalPoint12(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="FocalPoint12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconHeartCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconHeartCircle12.tsx
@@ -12,7 +12,7 @@ function IconHeartCircle12(props: GeneratedIconProps): React.ReactElement<Genera
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#HeartCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconHeartCircle12(props: GeneratedIconProps): React.ReactElement<Genera
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="HeartCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconHeartCircleStack12.tsx
+++ b/src/foundation/Icon/Generated/IconHeartCircleStack12.tsx
@@ -12,7 +12,7 @@ function IconHeartCircleStack12(props: GeneratedIconProps): React.ReactElement<G
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#HeartCircleStack12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconHeartCircleStack12(props: GeneratedIconProps): React.ReactElement<G
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="HeartCircleStack12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconHome12.tsx
+++ b/src/foundation/Icon/Generated/IconHome12.tsx
@@ -12,7 +12,7 @@ function IconHome12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Home12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconHome12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Home12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconImage12.tsx
+++ b/src/foundation/Icon/Generated/IconImage12.tsx
@@ -12,7 +12,7 @@ function IconImage12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Image12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconImage12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Image12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconImageWithText12.tsx
+++ b/src/foundation/Icon/Generated/IconImageWithText12.tsx
@@ -12,7 +12,7 @@ function IconImageWithText12(props: GeneratedIconProps): React.ReactElement<Gene
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ImageWithText12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconImageWithText12(props: GeneratedIconProps): React.ReactElement<Gene
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ImageWithText12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconJohanna12.tsx
+++ b/src/foundation/Icon/Generated/IconJohanna12.tsx
@@ -12,7 +12,7 @@ function IconJohanna12(props: GeneratedIconProps): React.ReactElement<GeneratedI
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Johanna12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconJohanna12(props: GeneratedIconProps): React.ReactElement<GeneratedI
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Johanna12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLabel12.tsx
+++ b/src/foundation/Icon/Generated/IconLabel12.tsx
@@ -12,7 +12,7 @@ function IconLabel12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Label12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLabel12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Label12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLeaf12.tsx
+++ b/src/foundation/Icon/Generated/IconLeaf12.tsx
@@ -12,7 +12,7 @@ function IconLeaf12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Leaf12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLeaf12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Leaf12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLeaf16.tsx
+++ b/src/foundation/Icon/Generated/IconLeaf16.tsx
@@ -12,7 +12,7 @@ function IconLeaf16(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Leaf16)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLeaf16(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Leaf16">
                         <path fill="#fff" d="M0 0h16v16H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLeaf20.tsx
+++ b/src/foundation/Icon/Generated/IconLeaf20.tsx
@@ -12,7 +12,7 @@ function IconLeaf20(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Leaf20)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLeaf20(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Leaf20">
                         <path fill="#fff" d="M0 0h20v20H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLeaf24.tsx
+++ b/src/foundation/Icon/Generated/IconLeaf24.tsx
@@ -12,7 +12,7 @@ function IconLeaf24(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Leaf24)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLeaf24(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Leaf24">
                         <path fill="#fff" d="M0 0h24v24H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLightbulb12.tsx
+++ b/src/foundation/Icon/Generated/IconLightbulb12.tsx
@@ -12,7 +12,7 @@ function IconLightbulb12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Lightbulb12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLightbulb12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Lightbulb12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLightning12.tsx
+++ b/src/foundation/Icon/Generated/IconLightning12.tsx
@@ -12,7 +12,7 @@ function IconLightning12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Lightning12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLightning12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Lightning12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconListCheck12.tsx
+++ b/src/foundation/Icon/Generated/IconListCheck12.tsx
@@ -12,7 +12,7 @@ function IconListCheck12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ListCheck12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconListCheck12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ListCheck12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconListNumbers12.tsx
+++ b/src/foundation/Icon/Generated/IconListNumbers12.tsx
@@ -12,7 +12,7 @@ function IconListNumbers12(props: GeneratedIconProps): React.ReactElement<Genera
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#ListNumbers12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconListNumbers12(props: GeneratedIconProps): React.ReactElement<Genera
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="ListNumbers12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLockOpen12.tsx
+++ b/src/foundation/Icon/Generated/IconLockOpen12.tsx
@@ -12,7 +12,7 @@ function IconLockOpen12(props: GeneratedIconProps): React.ReactElement<Generated
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#LockOpen12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLockOpen12(props: GeneratedIconProps): React.ReactElement<Generated
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="LockOpen12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconLockOpen12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconLockOpen12Filled.tsx
@@ -12,7 +12,7 @@ function IconLockOpen12Filled(props: GeneratedIconProps): React.ReactElement<Gen
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#LockOpen12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconLockOpen12Filled(props: GeneratedIconProps): React.ReactElement<Gen
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="LockOpen12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconMagnifier12.tsx
+++ b/src/foundation/Icon/Generated/IconMagnifier12.tsx
@@ -12,7 +12,7 @@ function IconMagnifier12(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Magnifier12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconMagnifier12(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Magnifier12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconMagnifierPlus12.tsx
+++ b/src/foundation/Icon/Generated/IconMagnifierPlus12.tsx
@@ -12,7 +12,7 @@ function IconMagnifierPlus12(props: GeneratedIconProps): React.ReactElement<Gene
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#MagnifierPlus12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconMagnifierPlus12(props: GeneratedIconProps): React.ReactElement<Gene
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="MagnifierPlus12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconMediaObjectRatio2To112.tsx
+++ b/src/foundation/Icon/Generated/IconMediaObjectRatio2To112.tsx
@@ -12,7 +12,7 @@ function IconMediaObjectRatio2To112(props: GeneratedIconProps): React.ReactEleme
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#MediaObjectRatio2To112)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconMediaObjectRatio2To112(props: GeneratedIconProps): React.ReactEleme
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="MediaObjectRatio2To112">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconMinusCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconMinusCircle12.tsx
@@ -12,7 +12,7 @@ function IconMinusCircle12(props: GeneratedIconProps): React.ReactElement<Genera
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#MinusCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconMinusCircle12(props: GeneratedIconProps): React.ReactElement<Genera
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="MinusCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconMoney12.tsx
+++ b/src/foundation/Icon/Generated/IconMoney12.tsx
@@ -12,7 +12,7 @@ function IconMoney12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Money12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconMoney12(props: GeneratedIconProps): React.ReactElement<GeneratedIco
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Money12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconMoneyCircle12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconMoneyCircle12Filled.tsx
@@ -12,7 +12,7 @@ function IconMoneyCircle12Filled(props: GeneratedIconProps): React.ReactElement<
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#MoneyCircle12Filled)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconMoneyCircle12Filled(props: GeneratedIconProps): React.ReactElement<
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="MoneyCircle12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconNook12.tsx
+++ b/src/foundation/Icon/Generated/IconNook12.tsx
@@ -12,7 +12,7 @@ function IconNook12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Nook12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconNook12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Nook12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconOrientationBoxes12.tsx
+++ b/src/foundation/Icon/Generated/IconOrientationBoxes12.tsx
@@ -12,7 +12,7 @@ function IconOrientationBoxes12(props: GeneratedIconProps): React.ReactElement<G
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#OrientationBoxes12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconOrientationBoxes12(props: GeneratedIconProps): React.ReactElement<G
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="OrientationBoxes12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPaintbrush12.tsx
+++ b/src/foundation/Icon/Generated/IconPaintbrush12.tsx
@@ -12,7 +12,7 @@ function IconPaintbrush12(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Paintbrush12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPaintbrush12(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Paintbrush12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPaintbrush16.tsx
+++ b/src/foundation/Icon/Generated/IconPaintbrush16.tsx
@@ -12,7 +12,7 @@ function IconPaintbrush16(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Paintbrush16)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPaintbrush16(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Paintbrush16">
                         <path fill="#fff" d="M0 0h16v16H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPaintbrush20.tsx
+++ b/src/foundation/Icon/Generated/IconPaintbrush20.tsx
@@ -12,7 +12,7 @@ function IconPaintbrush20(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Paintbrush20)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPaintbrush20(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Paintbrush20">
                         <path fill="#fff" d="M0 0h20v20H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPaintbrush24.tsx
+++ b/src/foundation/Icon/Generated/IconPaintbrush24.tsx
@@ -12,7 +12,7 @@ function IconPaintbrush24(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Paintbrush24)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPaintbrush24(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Paintbrush24">
                         <path fill="#fff" d="M0 0h24v24H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPaintbrush32.tsx
+++ b/src/foundation/Icon/Generated/IconPaintbrush32.tsx
@@ -12,7 +12,7 @@ function IconPaintbrush32(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Paintbrush32)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPaintbrush32(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Paintbrush32">
                         <path fill="#fff" d="M0 0h32v32H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPen12.tsx
+++ b/src/foundation/Icon/Generated/IconPen12.tsx
@@ -12,7 +12,7 @@ function IconPen12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Pen12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPen12(props: GeneratedIconProps): React.ReactElement<GeneratedIconP
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Pen12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPlayCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconPlayCircle12.tsx
@@ -12,7 +12,7 @@ function IconPlayCircle12(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#PlayCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPlayCircle12(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="PlayCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPlusBoxStack12.tsx
+++ b/src/foundation/Icon/Generated/IconPlusBoxStack12.tsx
@@ -12,7 +12,7 @@ function IconPlusBoxStack12(props: GeneratedIconProps): React.ReactElement<Gener
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#PlusBoxStack12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPlusBoxStack12(props: GeneratedIconProps): React.ReactElement<Gener
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="PlusBoxStack12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPlusCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconPlusCircle12.tsx
@@ -12,7 +12,7 @@ function IconPlusCircle12(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#PlusCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPlusCircle12(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="PlusCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPolygon12.tsx
+++ b/src/foundation/Icon/Generated/IconPolygon12.tsx
@@ -12,7 +12,7 @@ function IconPolygon12(props: GeneratedIconProps): React.ReactElement<GeneratedI
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Polygon12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPolygon12(props: GeneratedIconProps): React.ReactElement<GeneratedI
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Polygon12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconPuzzle12.tsx
+++ b/src/foundation/Icon/Generated/IconPuzzle12.tsx
@@ -12,7 +12,7 @@ function IconPuzzle12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Puzzle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconPuzzle12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Puzzle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconQuestionMarkCircle12.tsx
+++ b/src/foundation/Icon/Generated/IconQuestionMarkCircle12.tsx
@@ -12,7 +12,7 @@ function IconQuestionMarkCircle12(props: GeneratedIconProps): React.ReactElement
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#QuestionMarkCircle12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconQuestionMarkCircle12(props: GeneratedIconProps): React.ReactElement
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="QuestionMarkCircle12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconRocket12.tsx
+++ b/src/foundation/Icon/Generated/IconRocket12.tsx
@@ -12,7 +12,7 @@ function IconRocket12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Rocket12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconRocket12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Rocket12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconScissors12.tsx
+++ b/src/foundation/Icon/Generated/IconScissors12.tsx
@@ -12,7 +12,7 @@ function IconScissors12(props: GeneratedIconProps): React.ReactElement<Generated
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Scissors12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconScissors12(props: GeneratedIconProps): React.ReactElement<Generated
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Scissors12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconSkip5SecondsBackward12.tsx
+++ b/src/foundation/Icon/Generated/IconSkip5SecondsBackward12.tsx
@@ -12,7 +12,7 @@ function IconSkip5SecondsBackward12(props: GeneratedIconProps): React.ReactEleme
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Skip5SecondsBackward12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconSkip5SecondsBackward12(props: GeneratedIconProps): React.ReactEleme
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Skip5SecondsBackward12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconSpeaker12.tsx
+++ b/src/foundation/Icon/Generated/IconSpeaker12.tsx
@@ -12,7 +12,7 @@ function IconSpeaker12(props: GeneratedIconProps): React.ReactElement<GeneratedI
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Speaker12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconSpeaker12(props: GeneratedIconProps): React.ReactElement<GeneratedI
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Speaker12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconSpeakerOff12.tsx
+++ b/src/foundation/Icon/Generated/IconSpeakerOff12.tsx
@@ -12,7 +12,7 @@ function IconSpeakerOff12(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#SpeakerOff12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconSpeakerOff12(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="SpeakerOff12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconSpeechBubbleStack12.tsx
+++ b/src/foundation/Icon/Generated/IconSpeechBubbleStack12.tsx
@@ -12,7 +12,7 @@ function IconSpeechBubbleStack12(props: GeneratedIconProps): React.ReactElement<
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#SpeechBubbleStack12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconSpeechBubbleStack12(props: GeneratedIconProps): React.ReactElement<
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="SpeechBubbleStack12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconStar12.tsx
+++ b/src/foundation/Icon/Generated/IconStar12.tsx
@@ -12,7 +12,7 @@ function IconStar12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Star12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconStar12(props: GeneratedIconProps): React.ReactElement<GeneratedIcon
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Star12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconStar12Filled.tsx
+++ b/src/foundation/Icon/Generated/IconStar12Filled.tsx
@@ -12,7 +12,7 @@ function IconStar12Filled(props: GeneratedIconProps): React.ReactElement<Generat
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Star12Filled)">
                     <path
                         fill="currentColor"
                         stroke="currentColor"
@@ -20,7 +20,7 @@ function IconStar12Filled(props: GeneratedIconProps): React.ReactElement<Generat
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Star12Filled">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconStrikethroughBox12.tsx
+++ b/src/foundation/Icon/Generated/IconStrikethroughBox12.tsx
@@ -12,7 +12,7 @@ function IconStrikethroughBox12(props: GeneratedIconProps): React.ReactElement<G
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#StrikethroughBox12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconStrikethroughBox12(props: GeneratedIconProps): React.ReactElement<G
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="StrikethroughBox12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconSubscript24.tsx
+++ b/src/foundation/Icon/Generated/IconSubscript24.tsx
@@ -12,7 +12,7 @@ function IconSubscript24(props: GeneratedIconProps): React.ReactElement<Generate
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Subscript24)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -27,7 +27,7 @@ function IconSubscript24(props: GeneratedIconProps): React.ReactElement<Generate
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Subscript24">
                         <path fill="#fff" d="M0 0h24v24H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconTarget12.tsx
+++ b/src/foundation/Icon/Generated/IconTarget12.tsx
@@ -12,7 +12,7 @@ function IconTarget12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#Target12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconTarget12(props: GeneratedIconProps): React.ReactElement<GeneratedIc
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="Target12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>

--- a/src/foundation/Icon/Generated/IconTextBoxStack12.tsx
+++ b/src/foundation/Icon/Generated/IconTextBoxStack12.tsx
@@ -12,7 +12,7 @@ function IconTextBoxStack12(props: GeneratedIconProps): React.ReactElement<Gener
             {...props}
         >
             <g fill="none">
-                <g clipPath="url(#prefix__a)">
+                <g clipPath="url(#TextBoxStack12)">
                     <path
                         fill="currentColor"
                         fillRule="evenodd"
@@ -21,7 +21,7 @@ function IconTextBoxStack12(props: GeneratedIconProps): React.ReactElement<Gener
                     />
                 </g>
                 <defs>
-                    <clipPath id="prefix__a">
+                    <clipPath id="TextBoxStack12">
                         <path fill="#fff" d="M0 0h12v12H0z" />
                     </clipPath>
                 </defs>


### PR DESCRIPTION
Some icons have clipPath builtin e.g. `IconChartPie12` or `IconDoAndDont20` . Respectively they both have a clip path that clips a 12x12 and a 20x20 area. However the IDs of these clip paths are the same prefix__a  which results in conflicting.


Bonus: Fix RTE focus issue.