### PR TITLE
feat: Tree hide item selected state when dnd

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -272,7 +272,7 @@ export const TreeItem = memo(
                     FOCUS_VISIBLE_STYLE,
                     'tw-cursor-default tw-transition-colors tw-outline-none tw-ring-inset tw-group tw-px-2.5 tw-no-underline tw-leading-5 tw-h-10',
                     !isActive && !isSelected && 'active:tw-bg-box-neutral-pressed',
-                    isSelected && !transform?.y
+                    !isActive && isSelected
                         ? 'tw-font-medium tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover'
                         : 'hover:tw-bg-box-neutral tw-text-text',
                     transform?.y ? 'tw-bg-box-neutral-strong-inverse tw-text-text tw-font-normal' : '',


### PR DESCRIPTION
When dragging a selected item hide the selected state to prevent the flashes on/off when you drag past it.
