### PR TITLE
fix(Checkbox): size changing when unchecked in default size

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -224,7 +224,7 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
                                 data-test-id={`${dataTestId}-icon-box`}
                                 aria-hidden="true"
                                 className={merge([
-                                    'tw-leading-3 tw-p-2 tw-relative tw-flex tw-items-center tw-justify-center tw-rounded tw-shrink-0 tw-flex-none',
+                                    'tw-leading-3 tw-relative tw-flex tw-items-center tw-justify-center tw-rounded tw-shrink-0 tw-flex-none',
                                     sizeClassesMap[size],
                                     disabled ? disabledClasses : enabledClasses,
                                 ])}


### PR DESCRIPTION
When in `Default` size and `unchecked`, the padding added to the checkbox span was making the container to have `18px` instead of `16px` leading to a content "jump" when checking it.

It is possible to see the problem in https://beta-fondue-components.frontify.com/?path=/story/components-checkbox--checkbox

Just change the state from `Unchecked` to `Checked` or `Mixed`

cc: @imoutaharik 