### PR TITLE
fix: Tree active drag handler visibility

### DIFF
--- a/src/components/Tree/TreeItem/DragHandle.tsx
+++ b/src/components/Tree/TreeItem/DragHandle.tsx
@@ -20,8 +20,8 @@ export const DragHandle = forwardRef(
                 ref={ref}
                 className={merge([
                     FOCUS_VISIBLE_STYLE,
-                    'tw-p-1 first:tw-ml-2 tw-text-text tw-opacity-0 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 tw-rounded-sm hover:tw-cursor-grab',
-                    active && 'tw-opacity-100 tw-text-white',
+                    'tw-p-1 first:tw-ml-2 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 tw-rounded-sm hover:tw-cursor-grab',
+                    active ? 'tw-opacity-100 tw-text-white' : 'tw-opacity-0 tw-text-text',
                     className,
                 ])}
                 data-test-id="fondue-tree-item-drag-handle"


### PR DESCRIPTION
fixes the Tree drag handler not visible for the active item.

cc: @imoutaharik 