### PR TITLE
refactor: (Tree) Add levelConstraint to TreeItem

### DIFF
--- a/src/components/Tree/Tree.cy.tsx
+++ b/src/components/Tree/Tree.cy.tsx
@@ -74,7 +74,7 @@ describe('Tree and TreeItem components', () => {
         cy.mount(<TreeComponent />);
 
         cy.get(TREE_ID).should('be.visible');
-        cy.get(TREE_ITEM_ID).should('be.visible').should('have.length', 3);
+        cy.get(TREE_ITEM_ID).should('be.visible').should('have.length', 4);
         cy.get(TREE_ITEM_TOGGLE_ID).first().should('be.visible');
         cy.get(TREE_ITEM_ID).first().should('have.attr', 'aria-selected', 'false');
     });
@@ -121,10 +121,10 @@ describe('Tree and TreeItem components', () => {
         cy.mount(<TreeComponent />);
 
         cy.get(TREE_ITEM_TOGGLE_ID).first().click();
-        cy.get(TREE_ITEM_ID).should('have.length', 8);
+        cy.get(TREE_ITEM_ID).should('have.length', 9);
 
         cy.get(TREE_ITEM_TOGGLE_ID).first().click();
-        cy.get(TREE_ITEM_ID).should('have.length', 3);
+        cy.get(TREE_ITEM_ID).should('have.length', 4);
     });
 
     it('should trigger onExpand as a controlled component', () => {
@@ -168,9 +168,9 @@ describe('Tree and TreeItem components', () => {
         cy.mount(<TreeComponent draggable />);
 
         cy.get(TREE_ITEM_TOGGLE_ID).first().click();
-        cy.get(TREE_ITEM_ID).should('have.length', 8);
+        cy.get(TREE_ITEM_ID).should('have.length', 9);
         cy.get(TREE_ITEM_DRAG_HANDLE_ID).first().realMouseDown();
-        cy.get(TREE_ITEM_ID).should('have.length', 3);
+        cy.get(TREE_ITEM_ID).should('have.length', 4);
         cy.get(TREE_ITEM_DRAG_HANDLE_ID).first().realMouseUp();
     });
 
@@ -237,7 +237,7 @@ describe('Tree and TreeItem components', () => {
             .realPress('ArrowDown')
             .realPress('ArrowRight')
             .realPress('ArrowUp');
-        cy.get(TREE_ITEM_ID).should('have.length', 14);
+        cy.get(TREE_ITEM_ID).should('have.length', 15);
         cy.get(TREE_ITEM_ID).eq(4).should('have.focus');
     });
 
@@ -245,10 +245,20 @@ describe('Tree and TreeItem components', () => {
         cy.mount(<TreeComponent draggable />);
 
         cy.get(TREE_ITEM_TOGGLE_ID).first().click();
-        cy.get(TREE_ITEM_ID).should('have.length', 8);
+        cy.get(TREE_ITEM_ID).should('have.length', 9);
         cy.get(TREE_ITEM_DRAG_HANDLE_ID).eq(4).realMouseDown().realMouseMove(0, -80).realMouseMove(40, 0);
         cy.wait(300);
-        cy.get(TREE_ITEM_ID).should('have.length', 11);
+        cy.get(TREE_ITEM_ID).should('have.length', 12);
+    });
+
+    it('should not allow to go deeper with levelConstraint 0', () => {
+        cy.mount(<TreeComponent draggable />);
+
+        cy.get(TREE_ITEM_DRAG_HANDLE_ID).eq(3).realMouseDown().realMouseMove(40, 0);
+        cy.get(TREE_ITEM_OVERLAY_ID)
+            .should('be.visible')
+            .should('have.attr', 'style')
+            .and('include', 'margin-left: 0px');
     });
 });
 

--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -32,6 +32,7 @@ const animateLayoutChanges: AnimateLayoutChanges = ({ isSorting, wasDragging }) 
 /** @private */
 type TreeItemPrivateProps = {
     level?: number;
+    levelConstraint?: Nullable<number>;
     parentId?: string;
     isSelected?: boolean;
     isExpanded?: boolean;

--- a/src/components/Tree/helpers/projection.ts
+++ b/src/components/Tree/helpers/projection.ts
@@ -33,6 +33,10 @@ const getDragDepth = (offset: number) => {
     return Math.round(offset / INDENTATION_WIDTH);
 };
 
+const getNodeDepthConstraint = (node: ReactElement) => {
+    return (node?.props.levelConstraint ?? null) !== null ? node.props.levelConstraint : false;
+};
+
 const calculateMaxDepth = (previousNode: ReactElement, nextNode: ReactElement) => {
     const previousNodeDepth = getNodeDepth(previousNode);
 
@@ -64,11 +68,14 @@ export const getProjection = ({ nodes, activeId, overId, dragOffset }: Projectio
     const previousNode = newNodes[overNodeIndex - 1];
     const nextNode = newNodes[overNodeIndex + 1];
 
+    const activeNodeDepthConstraint = getNodeDepthConstraint(activeNode);
     const dragDepth = getDragDepth(dragOffset);
     const projectedDepth = (activeNode?.props?.level ?? 0) + dragDepth;
 
-    const maxDepth = calculateMaxDepth(previousNode, nextNode);
-    const minDepth = calculateMinDepth(previousNode, nextNode);
+    const maxDepth =
+        activeNodeDepthConstraint !== false ? activeNodeDepthConstraint : calculateMaxDepth(previousNode, nextNode);
+    const minDepth =
+        activeNodeDepthConstraint !== false ? activeNodeDepthConstraint : calculateMinDepth(previousNode, nextNode);
 
     let depth = projectedDepth || getNodeDepth(nextNode);
     if (projectedDepth >= maxDepth) {

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -58,6 +58,7 @@ type TreeItemBaseProps = {
     showCaret?: boolean;
     ignoreItemDoubleClick?: boolean;
     expandOnSelect?: boolean;
+    levelConstraint?: Nullable<number>;
 };
 
 export type TreeItemWithLabelProps = {

--- a/src/components/Tree/utils/mocks.ts
+++ b/src/components/Tree/utils/mocks.ts
@@ -120,6 +120,13 @@ export const treeItemsMock: TreeItemMock[] = [
         accepts: 'document',
         draggable: false,
     },
+    {
+        id: '4',
+        label: 'Design System Testing - level 0 constraint',
+        type: 'document',
+        accepts: 'document',
+        levelConstraint: 0,
+    },
 ];
 
 const reducer = (nodes: TreeItemMock[], expandedIds: string[] = []): TreeItemMock[] => {


### PR DESCRIPTION
Adds `levelConstraint` to the TreeItem, so projection can restrict the depth level allowed for the items to move.
Allows to restrict some elements to be only moved at level 0, for example. 