### PR TITLE
refactor: Tree item's backgound styling decoupled

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -268,19 +268,22 @@ export const TreeItem = memo(
             }
         }, [isActive, isExpanded, isParentActive, enrichedChildren, id]);
 
-        const liClassName = useMemo(
-            () =>
-                merge([
+        const { liClassName, backgroundClassName } = useMemo(() => {
+            return {
+                liClassName: merge([
                     FOCUS_VISIBLE_STYLE,
-                    'tw-cursor-default tw-transition-colors tw-outline-none tw-ring-inset tw-group tw-px-2.5 tw-no-underline tw-leading-5 tw-h-10',
-                    !isActive && !isSelected && 'active:tw-bg-box-neutral-pressed',
-                    !isActive && isSelected
-                        ? 'tw-font-medium tw-bg-box-neutral-strong tw-text-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-hover'
-                        : 'hover:tw-bg-box-neutral tw-text-text',
-                    transform?.y ? 'tw-bg-box-neutral-strong-inverse tw-text-text tw-font-normal' : '',
+                    'tw-relative tw-cursor-default tw-transition-colors tw-outline-none tw-ring-inset tw-group tw-px-2.5 tw-no-underline tw-leading-5 tw-h-10',
+                    !isActive && isSelected ? 'tw-font-medium tw-text-box-neutral-strong-inverse' : 'tw-text-text',
                 ]),
-            [isActive, isSelected, transform?.y],
-        );
+                backgroundClassName: merge([
+                    'tw-block tw-absolute tw-inset-0 tw-transition-colors -tw-z-10 -tw-mx-2.5',
+                    !isActive && !isSelected && 'group-active:tw-bg-box-neutral-pressed',
+                    !isActive && isSelected
+                        ? 'tw-bg-box-neutral-strong hover:tw-bg-box-neutral-strong-hover'
+                        : 'group-hover:tw-bg-box-neutral',
+                ]),
+            };
+        }, [isActive, isSelected]);
 
         const showContent = !isActive;
         const showChildren = isExpanded && !isActive;
@@ -317,6 +320,10 @@ export const TreeItem = memo(
             paddingLeft: depthPadding ?? levelPadding,
         };
 
+        const backgroundStyle = {
+            marginLeft: -1 * (depthPadding ?? levelPadding),
+        };
+
         const style = {
             transform: CSS.Transform.toString(transform),
             transition,
@@ -342,6 +349,7 @@ export const TreeItem = memo(
                 aria-owns={childrenIds.join(' ')}
             >
                 <div ref={setDraggableNodeRef} className={containerClassName} style={style}>
+                    <span className={backgroundClassName} style={backgroundStyle} aria-hidden={true} />
                     <DragHandle
                         {...listeners}
                         {...attributes}


### PR DESCRIPTION
decoupling the Tree Item background style allows to control different TreeItems UI states while dragging over.
Now the active item stays visually active even when another item is dragged above