### PR TITLE
fix: (TreeItem) z-index on item w/ active state

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -303,7 +303,7 @@ export const TreeItem = memo(
         }
 
         const containerClassName = merge([
-            'tw-transition-colors tw-flex tw-items-center tw-leading-5 tw-width-full',
+            'tw-relative tw-z-0 tw-transition-colors tw-flex tw-items-center tw-leading-5 tw-width-full',
             isActive ? 'tw-border-dashed tw-rounded-sm tw-border-2 tw-pr-0 tw-h-12' : 'tw-h-10',
             isActive &&
                 (canDrop


### PR DESCRIPTION
Tree item with active state is in fact invisible when used in a Flyout, due the background z-index.
This PR fixes the parent positioning and stack to fix the issue.