### PR TITLE
fix: add `types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ],
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/index.es.js",
             "require": "./dist/index.umd.js"
         },


### PR DESCRIPTION
Allows TypeScript `moduleResolution` with `Bundler` or `NodeNext` to works