### PR TITLE
fix(RTE): floating link is empty in some cases

### DIFF
--- a/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/FloatingLink.tsx
+++ b/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/FloatingLink.tsx
@@ -39,7 +39,8 @@ const FloatingLinkEditRoot = createComponentAs<FloatingLinkProps>((props) => {
     return createElementAs('div', htmlProps);
 });
 
-PlateFloatingLink.EditRoot = FloatingLinkEditRoot;
-PlateFloatingLink.InsertRoot = FloatingLinkInsertRoot;
-
-export const FloatingLink = PlateFloatingLink;
+export const FloatingLink = {
+    ...PlateFloatingLink,
+    EditRoot: FloatingLinkEditRoot,
+    InsertRoot: FloatingLinkInsertRoot,
+};


### PR DESCRIPTION
Overriding the instance of the package can cause unintentional consequences.