### PR TITLE
chore: rename OrderableList to LegacyOrderableList

### DIFF
--- a/src/components/DropZone/DropZone.stories.tsx
+++ b/src/components/DropZone/DropZone.stories.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { chain } from '@react-aria/utils';
 import { Meta, StoryFn } from '@storybook/react';
 
-import { OrderableList as DropZoneComponent, OrderableListProps } from '@components/OrderableList';
-import { StoryListItem, renderContent, storyItems } from '@components/OrderableList/utils';
-import type { OrderableListItem } from '@components/OrderableList/types';
+import { LegacyOrderableList as DropZoneComponent, LegacyOrderableListProps } from '@components/LegacyOrderableList';
+import { StoryListItem, renderContent, storyItems } from '@components/LegacyOrderableList/utils';
+import type { LegacyOrderableListItem } from '@components/LegacyOrderableList/types';
 
 export default {
     title: 'Components/Drop Zone',
@@ -18,12 +18,15 @@ export default {
     argTypes: {
         onMove: { action: 'onMove' },
     },
-} as Meta<OrderableListProps<StoryListItem>>;
+} as Meta<LegacyOrderableListProps<StoryListItem>>;
 
-export const DropZoneWithOrderableList: StoryFn<OrderableListProps<StoryListItem>> = ({ onMove, dragDisabled }) => {
+export const DropZoneWithOrderableList: StoryFn<LegacyOrderableListProps<StoryListItem>> = ({
+    onMove,
+    dragDisabled,
+}) => {
     const [items, setItems] = useState(storyItems);
 
-    const handleMove = (modifiedItems: OrderableListItem<StoryListItem>[]) => {
+    const handleMove = (modifiedItems: LegacyOrderableListItem<StoryListItem>[]) => {
         const modifiedArray = items.map((item) => {
             const matchingModifiedItem = modifiedItems.find((modifiedItem) => modifiedItem.id === item.id);
             if (matchingModifiedItem) {

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -2,7 +2,7 @@
 
 import { useDrop } from 'react-dnd';
 import { merge } from '@utilities/merge';
-import { OrderableListItem } from '@components/OrderableList/types';
+import { LegacyOrderableListItem } from '@components/LegacyOrderableList/types';
 import { DraggableItem } from '@utilities/dnd';
 
 import { CollisionPosition } from '..';
@@ -36,10 +36,10 @@ export const DropZone = <T extends object>({
 }: DropZoneProps<T>) => {
     const [{ isOver, canDrop }, drop] = useDrop({
         accept: accept || '',
-        drop: (item: OrderableListItem<T>) => {
+        drop: (item: LegacyOrderableListItem<T>) => {
             onDrop?.(data.targetItem, item, data.position);
         },
-        canDrop: (item: OrderableListItem<T>) => {
+        canDrop: (item: LegacyOrderableListItem<T>) => {
             // can't drop an item on itself
             if (item.id === data.targetItem.id) {
                 return false;

--- a/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
+++ b/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
@@ -4,7 +4,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { useId } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
-import { ItemDragState, LegacyCollectionItemProps } from './types';
+import { LegacyCollectionItemProps, LegacyItemDragState } from './types';
 import { useDrag } from 'react-dnd';
 
 export const LegacyCollectionItem = <T extends object>({
@@ -17,7 +17,7 @@ export const LegacyCollectionItem = <T extends object>({
     const [{ componentDragState }, drag] = useDrag({
         item: { ...item },
         collect: (monitor) => ({
-            componentDragState: monitor.isDragging() ? ItemDragState.Dragging : ItemDragState.Idle,
+            componentDragState: monitor.isDragging() ? LegacyItemDragState.Dragging : LegacyItemDragState.Idle,
         }),
         type: listId,
         canDrag: !dragDisabled,

--- a/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
+++ b/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
@@ -1,0 +1,41 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { useFocusRing } from '@react-aria/focus';
+import { useId } from '@react-aria/utils';
+import { FOCUS_STYLE } from '@utilities/focusStyle';
+import { merge } from '@utilities/merge';
+import { ItemDragState, LegacyCollectionItemProps } from './types';
+import { useDrag } from 'react-dnd';
+
+export const LegacyCollectionItem = <T extends object>({
+    item,
+    renderContent,
+    dragDisabled,
+    listId,
+}: LegacyCollectionItemProps<T>) => {
+    const { isFocusVisible } = useFocusRing();
+    const [{ componentDragState }, drag] = useDrag({
+        item: { ...item },
+        collect: (monitor) => ({
+            componentDragState: monitor.isDragging() ? ItemDragState.Dragging : ItemDragState.Idle,
+        }),
+        type: listId,
+        canDrag: !dragDisabled,
+    });
+    const id = useId();
+
+    return (
+        <div
+            ref={drag}
+            className={merge(['tw-relative tw-outline-none', isFocusVisible ? 'tw-z-30' : 'tw-z-0'])}
+            aria-labelledby={id}
+            data-test-id="draggable-item"
+            aria-disabled={dragDisabled}
+        >
+            <div className={merge(['tw-outline-none', isFocusVisible && FOCUS_STYLE])}>
+                {renderContent(item, { componentDragState, isFocusVisible })}
+            </div>
+        </div>
+    );
+};
+LegacyCollectionItem.displayName = 'FondueLegacyCollectionItem';

--- a/src/components/LegacyOrderableList/LegacyOrderableList.cy.tsx
+++ b/src/components/LegacyOrderableList/LegacyOrderableList.cy.tsx
@@ -122,7 +122,7 @@ describe('OrderableList Component', () => {
         cy.get(DRAGGABLE_ITEM).each(($el) => {
             const dataTransfer = new DataTransfer();
             cy.wrap($el)
-                .should('have.text', LegacyLegacyItemDragState.Idle)
+                .should('have.text', LegacyItemDragState.Idle)
                 .trigger('dragstart', { dataTransfer })
                 .trigger('drag');
             cy.wrap($el).should('have.text', LegacyItemDragState.Dragging);

--- a/src/components/LegacyOrderableList/LegacyOrderableList.cy.tsx
+++ b/src/components/LegacyOrderableList/LegacyOrderableList.cy.tsx
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import {
-    ItemDragState,
     LegacyDragProperties,
+    LegacyItemDragState,
     LegacyOrderableList,
     LegacyOrderableListItem,
     LegacyOrderableListProps,
@@ -121,13 +121,16 @@ describe('OrderableList Component', () => {
 
         cy.get(DRAGGABLE_ITEM).each(($el) => {
             const dataTransfer = new DataTransfer();
-            cy.wrap($el).should('have.text', ItemDragState.Idle).trigger('dragstart', { dataTransfer }).trigger('drag');
-            cy.wrap($el).should('have.text', ItemDragState.Dragging);
+            cy.wrap($el)
+                .should('have.text', LegacyLegacyItemDragState.Idle)
+                .trigger('dragstart', { dataTransfer })
+                .trigger('drag');
+            cy.wrap($el).should('have.text', LegacyItemDragState.Dragging);
             cy.get(LIST_ID).trigger('dragenter', { dataTransfer }).trigger('dragover', { dataTransfer });
             cy.get(DROP_ZONE).should('exist').and('have.length', 7);
             cy.get(LIST_ID).trigger('drop', { dataTransfer, force: true });
             cy.wrap($el).trigger('dragend', { dataTransfer, force: true });
-            cy.wrap($el).should('have.text', ItemDragState.Idle);
+            cy.wrap($el).should('have.text', LegacyItemDragState.Idle);
         });
     });
 

--- a/src/components/LegacyOrderableList/LegacyOrderableList.cy.tsx
+++ b/src/components/LegacyOrderableList/LegacyOrderableList.cy.tsx
@@ -1,0 +1,164 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import {
+    ItemDragState,
+    LegacyDragProperties,
+    LegacyOrderableList,
+    LegacyOrderableListItem,
+    LegacyOrderableListProps,
+} from '.';
+
+const LIST_ID = '[data-test-id=orderable-list]';
+const DRAGGABLE_ITEM = '[data-test-id=draggable-item]';
+const DROP_ZONE = '[data-test-id=drop-zone]';
+
+const ITEM_HEIGHT = 20;
+
+type TestItem = {
+    text: string;
+};
+
+const testItems: LegacyOrderableListItem<TestItem>[] = [
+    { id: '1', alt: '1', text: 'Item 1', sort: 1 },
+    { id: '2', alt: '2', text: 'Item 2', sort: 2 },
+    { id: '3', alt: '3', text: 'Item 3', sort: 3 },
+    { id: '4', alt: '4', text: 'Item 4', sort: 4 },
+    { id: '5', alt: '5', text: 'Item 5', sort: 5 },
+    { id: '6', alt: '6', text: 'Item 6', sort: 6 },
+];
+
+const renderDefaultTestItems = ({ text }: LegacyOrderableListItem<TestItem>) => (
+    <div style={{ height: `${ITEM_HEIGHT}px` }}>{text}</div>
+);
+
+const renderWithFocusableItems = (
+    _item: LegacyOrderableListItem<TestItem>,
+    { isFocusVisible }: LegacyDragProperties,
+) => (
+    <div
+        style={{ height: `${ITEM_HEIGHT}px` }}
+        className="tw-flex tw-justify-around"
+        data-focus-visible={isFocusVisible}
+    >
+        <button data-test-id="focusable-item">Button</button>
+        <input data-test-id="focusable-item" value="Input"></input>
+        <textarea data-test-id="focusable-item">Textarea</textarea>
+    </div>
+);
+
+const OrderableListWithDefaultProps = ({
+    renderContent = renderDefaultTestItems,
+    items = testItems,
+    dragDisabled = false,
+    onMove = cy.stub(),
+}: Partial<LegacyOrderableListProps<TestItem>>) => (
+    <LegacyOrderableList renderContent={renderContent} dragDisabled={dragDisabled} items={items} onMove={onMove} />
+);
+
+describe('OrderableList Component', () => {
+    it('renders correct number of list items', () => {
+        cy.mount(<OrderableListWithDefaultProps />);
+        cy.get(LIST_ID)
+            .find(DRAGGABLE_ITEM)
+            .should('have.length', testItems.length)
+            .each(($el, index) => {
+                cy.wrap($el).should('have.text', testItems[index].text);
+            });
+    });
+
+    it('Does not crash if item list is empty', () => {
+        cy.mount(<OrderableListWithDefaultProps items={[]} />);
+        cy.get(LIST_ID).should('exist');
+    });
+
+    it('Fires a move event when item is dropped over an insertion indicator', () => {
+        const stubbedOnMove = cy.stub().as('onMove');
+        const dataTransfer = new DataTransfer();
+        const targetDropZone = 4;
+        const dragAnimationDelay = 50;
+
+        cy.mount(<OrderableListWithDefaultProps onMove={stubbedOnMove} />);
+
+        cy.get(DRAGGABLE_ITEM).first().trigger('dragstart', { dataTransfer }).trigger('drag');
+        cy.get(DROP_ZONE).eq(targetDropZone).as('fourthDropZone');
+        cy.get('@fourthDropZone')
+            .trigger('dragenter', { dataTransfer, force: true })
+            .trigger('dragover', { dataTransfer, force: true })
+            .wait(dragAnimationDelay);
+        cy.get(DROP_ZONE).each(($el, i) => {
+            if (i === targetDropZone) {
+                expect($el).to.have.class('tw-border-violet-60');
+            } else {
+                expect($el).not.to.have.class('tw-border-violet-60');
+            }
+        });
+        cy.get('@fourthDropZone').trigger('drop', { dataTransfer, force: true });
+        cy.get('@onMove').should('have.been.called');
+    });
+
+    it('Hides insertion indicator if position change is original index', () => {
+        cy.mount(<OrderableListWithDefaultProps />);
+
+        cy.get(DRAGGABLE_ITEM).each(($el, index) => {
+            const dataTransfer = new DataTransfer();
+            cy.wrap($el).trigger('dragstart', { dataTransfer }).trigger('drag');
+            cy.get(DROP_ZONE)
+                .eq(index)
+                .as('targetDropZone')
+                .trigger('dragenter', { dataTransfer })
+                .trigger('dragover', { dataTransfer });
+            cy.get('@targetDropZone').should('not.have.class', 'tw-border-violet-60');
+            cy.get('@targetDropZone').should('have.attr', 'aria-hidden').and('equal', 'true');
+        });
+    });
+
+    it('Passes on correct drag state to each item', () => {
+        const renderWithDragState = (_item: TestItem, { componentDragState }: LegacyDragProperties) => (
+            <div style={{ height: `${ITEM_HEIGHT}px` }}>{componentDragState}</div>
+        );
+
+        cy.mount(<OrderableListWithDefaultProps renderContent={renderWithDragState} />);
+
+        cy.get(DRAGGABLE_ITEM).each(($el) => {
+            const dataTransfer = new DataTransfer();
+            cy.wrap($el).should('have.text', ItemDragState.Idle).trigger('dragstart', { dataTransfer }).trigger('drag');
+            cy.wrap($el).should('have.text', ItemDragState.Dragging);
+            cy.get(LIST_ID).trigger('dragenter', { dataTransfer }).trigger('dragover', { dataTransfer });
+            cy.get(DROP_ZONE).should('exist').and('have.length', 7);
+            cy.get(LIST_ID).trigger('drop', { dataTransfer, force: true });
+            cy.wrap($el).trigger('dragend', { dataTransfer, force: true });
+            cy.wrap($el).should('have.text', ItemDragState.Idle);
+        });
+    });
+
+    it('Should disable drag events if dragDisabled prop is true, but maintain focus for navigation', () => {
+        cy.mount(<OrderableListWithDefaultProps dragDisabled={true} renderContent={renderWithFocusableItems} />);
+        cy.get(DRAGGABLE_ITEM).each(($el) => {
+            const disabled = $el.attr('aria-disabled');
+            expect(disabled).to.equal('true');
+        });
+    });
+
+    it('Should not allow drag into other orderable list', () => {
+        const dataTransfer = new DataTransfer();
+
+        cy.mount(
+            <>
+                <OrderableListWithDefaultProps />
+                <OrderableListWithDefaultProps />
+            </>,
+        );
+
+        cy.get(LIST_ID).should('have.length', 2);
+        cy.get(LIST_ID).eq(1).find(DRAGGABLE_ITEM).first().trigger('dragstart', { dataTransfer }).trigger('drag');
+        cy.get(LIST_ID)
+            .first()
+            .get(DROP_ZONE)
+            .as('targetDropZone')
+            .first()
+            .trigger('dragenter', { dataTransfer })
+            .trigger('dragover', { dataTransfer });
+        cy.get('@targetDropZone').should('not.have.class', 'tw-border-violet-60');
+        cy.get('@targetDropZone').should('have.attr', 'aria-hidden').and('equal', 'true');
+    });
+});

--- a/src/components/LegacyOrderableList/LegacyOrderableList.stories.tsx
+++ b/src/components/LegacyOrderableList/LegacyOrderableList.stories.tsx
@@ -9,7 +9,7 @@ import { chain } from '@react-aria/utils';
 import { renderContent, storyItems } from '@components/LegacyOrderableList/utils';
 
 export default {
-    title: 'Components/Legacy Orderable List',
+    title: 'Deprecated/Legacy Orderable List',
     component: OrderableListComponent,
     tags: ['autodocs'],
     args: {

--- a/src/components/LegacyOrderableList/LegacyOrderableList.stories.tsx
+++ b/src/components/LegacyOrderableList/LegacyOrderableList.stories.tsx
@@ -1,0 +1,63 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+import { LegacyOrderableList as OrderableListComponent } from './LegacyOrderableList';
+import { LegacyOrderableListItem } from './types';
+import { LegacyOrderableListProps } from '.';
+import { chain } from '@react-aria/utils';
+import { renderContent, storyItems } from '@components/LegacyOrderableList/utils';
+
+export default {
+    title: 'Components/Legacy Orderable List',
+    component: OrderableListComponent,
+    tags: ['autodocs'],
+    args: {
+        dragDisabled: false,
+    },
+    argTypes: {
+        onMove: { action: 'onMove' },
+    },
+} as Meta<LegacyOrderableListProps<StoryListItem>>;
+
+type StoryListItem = {
+    textContent: JSX.Element;
+};
+
+export const LegacyOrderableList: StoryFn<LegacyOrderableListProps<StoryListItem>> = ({ onMove, dragDisabled }) => {
+    const [items, setItems] = useState(storyItems);
+
+    const handleMove = (modifiedItems: LegacyOrderableListItem<StoryListItem>[]) => {
+        const modifiedArray = items.map((item) => {
+            const matchingModifiedItem = modifiedItems.find((modifiedItem) => modifiedItem.id === item.id);
+            if (matchingModifiedItem) {
+                return { ...matchingModifiedItem };
+            }
+
+            return { ...item };
+        });
+
+        setItems(modifiedArray);
+    };
+
+    return (
+        <>
+            <div className="tw-m-auto tw-w-[600px] tw-pb-6">
+                <OrderableListComponent
+                    items={items}
+                    onMove={chain(handleMove, onMove)}
+                    dragDisabled={dragDisabled}
+                    renderContent={(...args) => renderContent(...args)}
+                />
+            </div>
+            <div className="tw-m-auto tw-w-[600px]">
+                <OrderableListComponent
+                    items={items}
+                    onMove={chain(handleMove, onMove)}
+                    dragDisabled={dragDisabled}
+                    renderContent={(...args) => renderContent(...args)}
+                />
+            </div>
+        </>
+    );
+};

--- a/src/components/LegacyOrderableList/LegacyOrderableList.tsx
+++ b/src/components/LegacyOrderableList/LegacyOrderableList.tsx
@@ -1,0 +1,95 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Fragment, useEffect, useState } from 'react';
+
+import { LegacyCollectionItem } from './LegacyCollectionItem';
+import { LegacyOrderableListItem, LegacyOrderableListProps } from './types';
+import { DropZone } from '@components/DropZone';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { DndProvider } from 'react-dnd';
+import { moveItems } from '@utilities/dnd';
+import { useId } from '@react-aria/utils';
+import { CollisionPosition } from '..';
+
+const listItemsCompareFn = <T extends object>(
+    itemA: LegacyOrderableListItem<T>,
+    itemB: LegacyOrderableListItem<T>,
+): number => {
+    if (itemA.sort === null && itemB.sort === null) {
+        return 1;
+    }
+    if (itemA.sort === null) {
+        return 1;
+    }
+    if (itemB.sort === null) {
+        return -1;
+    }
+
+    return itemA.sort - itemB.sort;
+};
+
+export const LegacyOrderableList = <T extends object>({
+    onMove,
+    dragDisabled,
+    items,
+    renderContent,
+    'data-test-id': dataTestId = 'orderable-list',
+}: LegacyOrderableListProps<T>) => {
+    const [itemsState, setItemsState] = useState(items);
+    const listId = useId();
+
+    useEffect(() => {
+        // sort the incoming items
+        const itemsClone = [...items];
+        itemsClone.sort(listItemsCompareFn);
+        setItemsState(itemsClone);
+    }, [items]);
+
+    const handleDrop = (
+        targetItem: LegacyOrderableListItem<T>,
+        sourceItem: LegacyOrderableListItem<T>,
+        position: CollisionPosition,
+    ) => {
+        const modifiedItems = moveItems(targetItem, sourceItem, position, itemsState);
+        onMove(modifiedItems);
+    };
+
+    return (
+        <DndProvider backend={HTML5Backend}>
+            <div className="tw-outline-none" data-test-id={dataTestId}>
+                {itemsState.map((item, index) => (
+                    <Fragment key={`dropzone-orderable-list-key-${index}`}>
+                        <DropZone
+                            key={`orderable-list-item-${index}-before`}
+                            data={{
+                                targetItem: item,
+                                position: 'before' as const,
+                            }}
+                            onDrop={handleDrop}
+                            accept={listId}
+                        />
+                        <LegacyCollectionItem
+                            key={item.id}
+                            dragDisabled={dragDisabled}
+                            item={item}
+                            renderContent={renderContent}
+                            listId={listId}
+                        />
+                        {index === items.length - 1 && (
+                            <DropZone
+                                key={`orderable-list-item-${index}-after`}
+                                data={{
+                                    targetItem: item,
+                                    position: 'after' as const,
+                                }}
+                                onDrop={handleDrop}
+                                accept={listId}
+                            />
+                        )}
+                    </Fragment>
+                ))}
+            </div>
+        </DndProvider>
+    );
+};
+LegacyOrderableList.displayName = 'FondueLegacyOrderableList';

--- a/src/components/LegacyOrderableList/index.ts
+++ b/src/components/LegacyOrderableList/index.ts
@@ -1,0 +1,4 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './LegacyOrderableList';
+export * from './types';

--- a/src/components/LegacyOrderableList/types.ts
+++ b/src/components/LegacyOrderableList/types.ts
@@ -20,7 +20,7 @@ export type LegacyOrderableListItem<T = Record<string, unknown>> = DraggableItem
 };
 
 export type LegacyDragProperties = {
-    componentDragState: ItemDragState;
+    componentDragState: LegacyItemDragState;
     isFocusVisible: boolean;
 };
 
@@ -32,7 +32,7 @@ export type LegacyOrderableListProps<T> = {
     'data-test-id'?: string;
 };
 
-export enum ItemDragState {
+export enum LegacyItemDragState {
     Dragging = 'Dragging',
     Idle = 'Idle',
     Preview = 'Preview',

--- a/src/components/LegacyOrderableList/types.ts
+++ b/src/components/LegacyOrderableList/types.ts
@@ -5,7 +5,7 @@ import { DraggableItem } from '@utilities/dnd';
 
 export type LegacyRenderListItem<T> = (
     items: LegacyOrderableListItem<T>,
-    dragProps?: LegacyDragProperties,
+    dragProps: LegacyDragProperties,
 ) => ReactElement;
 
 export type LegacyCollectionItemProps<T> = {

--- a/src/components/LegacyOrderableList/types.ts
+++ b/src/components/LegacyOrderableList/types.ts
@@ -1,0 +1,39 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { ReactElement } from 'react';
+import { DraggableItem } from '@utilities/dnd';
+
+export type LegacyRenderListItem<T> = (
+    items: LegacyOrderableListItem<T>,
+    dragProps?: LegacyDragProperties,
+) => ReactElement;
+
+export type LegacyCollectionItemProps<T> = {
+    item: LegacyOrderableListItem<T>;
+    dragDisabled: boolean;
+    renderContent: LegacyRenderListItem<T>;
+    listId: string;
+};
+
+export type LegacyOrderableListItem<T = Record<string, unknown>> = DraggableItem<T> & {
+    alt: string;
+};
+
+export type LegacyDragProperties = {
+    componentDragState: ItemDragState;
+    isFocusVisible: boolean;
+};
+
+export type LegacyOrderableListProps<T> = {
+    items: LegacyOrderableListItem<T>[];
+    dragDisabled: boolean;
+    onMove: (modifiedItems: LegacyOrderableListItem<T>[]) => void;
+    renderContent: LegacyRenderListItem<T>;
+    'data-test-id'?: string;
+};
+
+export enum ItemDragState {
+    Dragging = 'Dragging',
+    Idle = 'Idle',
+    Preview = 'Preview',
+}

--- a/src/components/LegacyOrderableList/utils/index.ts
+++ b/src/components/LegacyOrderableList/utils/index.ts
@@ -1,0 +1,5 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './mocks';
+export * from './renderContent';
+export * from './types';

--- a/src/components/LegacyOrderableList/utils/mocks.tsx
+++ b/src/components/LegacyOrderableList/utils/mocks.tsx
@@ -1,0 +1,61 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { LegacyOrderableListItem } from '@components/LegacyOrderableList';
+import { HighlightColor, HighlightProps, StoryListItem } from '@components/LegacyOrderableList/utils/types';
+import { ReactElement } from 'react';
+import { merge } from '@utilities/merge';
+
+const HighlightClasses: Record<HighlightColor, string> = {
+    [HighlightColor.Violet]: 'tw-text-violet-60',
+    [HighlightColor.Green]: 'tw-text-green-60',
+    [HighlightColor.Red]: 'tw-text-red-60',
+};
+
+const Highlight = ({ color, children }: HighlightProps): ReactElement => (
+    <span className={merge(['tw-font-medium', HighlightClasses[color]])}>{children}</span>
+);
+
+export const storyItems: LegacyOrderableListItem<StoryListItem>[] = [
+    {
+        id: '1',
+        textContent: (
+            <p>
+                The list rendering is completely customizable through the &nbsp;
+                <Highlight color={HighlightColor.Green}>renderContent</Highlight> callback prop.
+            </p>
+        ),
+        alt: 'one',
+        sort: 1,
+    },
+    {
+        id: '3',
+        textContent: (
+            <p>
+                Use the <Highlight color={HighlightColor.Green}>sort</Highlight> property in the &nbsp;
+                <Highlight color={HighlightColor.Green}>OrderableListItem</Highlight> to determine the position of items
+                items in the list.
+            </p>
+        ),
+        alt: 'three',
+        sort: 2,
+    },
+    {
+        id: '4',
+        textContent: <p>Items can contain multiple focusable elements.</p>,
+        alt: 'four',
+        sort: null,
+    },
+    {
+        id: '7',
+        textContent: (
+            <p>
+                The drag-preview is created as a new element, using the
+                <Highlight color={HighlightColor.Green}>renderContent</Highlight> callback with the dragged item key to
+                render its content. The state of any interactive items must be managed outside of the list to achieve
+                consistent rendering in the drag preview.
+            </p>
+        ),
+        alt: 'seven',
+        sort: 3,
+    },
+];

--- a/src/components/LegacyOrderableList/utils/renderContent.tsx
+++ b/src/components/LegacyOrderableList/utils/renderContent.tsx
@@ -1,13 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ItemDragState, LegacyDragProperties, LegacyOrderableListItem } from '@components/LegacyOrderableList';
+import { LegacyDragProperties, LegacyItemDragState, LegacyOrderableListItem } from '@components/LegacyOrderableList';
 import { merge } from '@utilities/merge';
 import { StoryListItem } from '@components/LegacyOrderableList/utils/types';
 
-const dragStoryStyles: Record<ItemDragState, string> = {
-    [ItemDragState.Dragging]: 'tw-bg-black-10 tw-border-black-20 tw-opacity-75',
-    [ItemDragState.Idle]: 'tw-border-black-20',
-    [ItemDragState.Preview]: 'tw-bg-white tw-border-violet-70 tw-border-2',
+const dragStoryStyles: Record<LegacyItemDragState, string> = {
+    [LegacyItemDragState.Dragging]: 'tw-bg-black-10 tw-border-black-20 tw-opacity-75',
+    [LegacyItemDragState.Idle]: 'tw-border-black-20',
+    [LegacyItemDragState.Preview]: 'tw-bg-white tw-border-violet-70 tw-border-2',
 };
 
 export const renderContent = (

--- a/src/components/LegacyOrderableList/utils/renderContent.tsx
+++ b/src/components/LegacyOrderableList/utils/renderContent.tsx
@@ -1,0 +1,35 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { ItemDragState, LegacyDragProperties, LegacyOrderableListItem } from '@components/LegacyOrderableList';
+import { merge } from '@utilities/merge';
+import { StoryListItem } from '@components/LegacyOrderableList/utils/types';
+
+const dragStoryStyles: Record<ItemDragState, string> = {
+    [ItemDragState.Dragging]: 'tw-bg-black-10 tw-border-black-20 tw-opacity-75',
+    [ItemDragState.Idle]: 'tw-border-black-20',
+    [ItemDragState.Preview]: 'tw-bg-white tw-border-violet-70 tw-border-2',
+};
+
+export const renderContent = (
+    { textContent }: LegacyOrderableListItem<StoryListItem>,
+    { componentDragState, isFocusVisible }: LegacyDragProperties,
+) => {
+    return (
+        <div
+            className={merge([
+                'tw-break-word tw-border tw-border-black-40 tw-border-solid tw-p-3',
+                dragStoryStyles[componentDragState],
+                isFocusVisible && 'tw-bg-violet-20',
+            ])}
+        >
+            <div className="tw-text-xs tw-text-black-60">Position: Foo</div>
+            <hr className="tw-mt-2 tw-mb-2 tw-border-black-20 tw-bg-black-20" />
+            <div>{textContent}</div>
+            <hr className="tw-mt-3 tw-mb-2 tw-border-black-20 tw-bg-black-20" />
+            <div className="tw-flex tw-justify-between tw-text-s">
+                {isFocusVisible && <span className="tw-font-medium">Im in keyboard focus</span>}
+                <span>Drag State: {componentDragState}</span>
+            </div>
+        </div>
+    );
+};

--- a/src/components/LegacyOrderableList/utils/types.ts
+++ b/src/components/LegacyOrderableList/utils/types.ts
@@ -1,0 +1,18 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { ReactChild } from 'react';
+
+export type StoryListItem = {
+    textContent: JSX.Element;
+};
+
+export enum HighlightColor {
+    Violet = 'Violet',
+    Green = 'Green',
+    Red = 'Red',
+}
+
+export type HighlightProps = {
+    color: HighlightColor;
+    children: ReactChild;
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ export * from './FrontifyPattern';
 export * from './Grid';
 export * from './InlineDialog';
 export * from './InputLabel';
+export * from './LegacyOrderableList';
 export * from './LinkChooser';
 export * from './LoadingBar';
 export * from './LoadingCircle';


### PR DESCRIPTION
In order to replace `react-dnd` we need to replace OrderableList, the only component using it.
First step use LegacyOrderableList, this should work the same way as OrderableList