### PR TITLE
chore(datepicker): reset the css for children container

### DIFF
--- a/src/components/DatePicker/DatePicker.css
+++ b/src/components/DatePicker/DatePicker.css
@@ -148,3 +148,10 @@
     background-color: transparent;
     color: var(--text-color-disabled);
 }
+
+/* reset styles injected by the library */ 
+.react-datepicker__children-container {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+}


### PR DESCRIPTION
Updating the datepicker package led to introducing breaking styles in the datepicker children container