### PR TITLE
feat: added focusOnMount and onEnterPressed props to textarea

### DIFF
--- a/src/components/Textarea/Textarea.cy.tsx
+++ b/src/components/Textarea/Textarea.cy.tsx
@@ -58,6 +58,11 @@ describe('Textarea component', () => {
         cy.get('[data-test-id="decorator"]').should('be.visible').contains(DECORATOR_TEXT);
     });
 
+    it('focuses on mount', () => {
+        cy.mount(<Textarea focusOnMount />);
+        cy.get(TEXTAREA_ID).should('have.focus');
+    });
+
     it('calls the onInput event', () => {
         const onInputStub = cy.stub().as('onInputStub');
         cy.mount(<Textarea onInput={onInputStub}></Textarea>);
@@ -70,6 +75,13 @@ describe('Textarea component', () => {
         cy.mount(<Textarea onBlur={onBlurStub}></Textarea>);
         cy.get(TEXTAREA_ID).type(INPUT_TEXT).blur();
         cy.get('@onBlurStub').should('be.calledOnce');
+    });
+
+    it('calls the onEnterPressed event', () => {
+        const onEnterPressedStub = cy.stub().as('onEnterPressedStub');
+        cy.mount(<Textarea onEnterPressed={onEnterPressedStub}></Textarea>);
+        cy.get(TEXTAREA_ID).type('{enter}');
+        cy.get('@onEnterPressedStub').should('to.have.always.been.callCount', 1);
     });
 
     it('starts with the minimum number of rows', () => {

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -16,6 +16,7 @@ export default {
         resizeable: true,
         selectable: false,
         validation: Validation.Default,
+        focusOnMount: false,
     },
     argTypes: {
         value: { type: 'string' },
@@ -31,6 +32,8 @@ export default {
         },
         minRows: { type: 'number' },
         maxRows: { type: 'number' },
+        onEnterPressed: { action: 'onEnterPressed' },
+        focusOnMount: { type: 'boolean' },
     },
 } as Meta<TextareaProps>;
 

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -32,7 +32,7 @@ export default {
         },
         minRows: { type: 'number' },
         maxRows: { type: 'number' },
-        onEnterPressed: { action: 'onEnterPressed' },
+        onEnterPressed: { action: 'onEnterPressed', table: { disable: true } },
         focusOnMount: { type: 'boolean' },
     },
 } as Meta<TextareaProps>;
@@ -42,4 +42,13 @@ export const Textarea: StoryFn<TextareaProps> = (args: TextareaProps) => {
     useEffect(() => setInput(`${args.value || ''}`), [args.value]);
 
     return <TextareaComponent {...args} value={input} onInput={setInput} />;
+};
+export const OnEnterPressed = Textarea.bind({});
+OnEnterPressed.args = {
+    onEnterPressed: () => console.log('Enter pressed'),
+};
+
+export const FocusOnMount = Textarea.bind({});
+FocusOnMount.args = {
+    focusOnMount: true,
 };

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -43,10 +43,6 @@ export const Textarea: StoryFn<TextareaProps> = (args: TextareaProps) => {
 
     return <TextareaComponent {...args} value={input} onInput={setInput} />;
 };
-export const OnEnterPressed = Textarea.bind({});
-OnEnterPressed.args = {
-    onEnterPressed: () => console.log('Enter pressed'),
-};
 
 export const FocusOnMount = Textarea.bind({});
 FocusOnMount.args = {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -64,7 +64,7 @@ export const Textarea = ({
 
     const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
         if (event.key === 'Enter') {
-            onEnterPressed && onEnterPressed(event);
+            onEnterPressed?.(event);
         }
     };
 

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -57,9 +57,7 @@ export const Textarea = ({
     const textareaElement = useRef<HTMLTextAreaElement | null>(null);
 
     useEffect(() => {
-        setTimeout(() => {
-            focusOnMount && textareaElement.current?.focus();
-        }, 0);
+        focusOnMount && textareaElement.current?.focus();
     }, [focusOnMount]);
 
     const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -7,7 +7,7 @@ import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Validation, validationClassMap } from '@utilities/validation';
 import { LoadingCircle, LoadingCircleSize } from '@components/LoadingCircle';
-import { FocusEvent, FormEvent, ReactElement, ReactNode } from 'react';
+import { FocusEvent, FormEvent, KeyboardEvent, ReactElement, ReactNode, useEffect, useRef } from 'react';
 import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize';
 import { IconExclamationMarkTriangle } from '@foundation/Icon/Generated';
 
@@ -29,6 +29,8 @@ export type TextareaProps = {
     autosize?: boolean;
     resizeable?: boolean;
     selectable?: boolean;
+    focusOnMount?: boolean;
+    onEnterPressed?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
 };
 
 export const Textarea = ({
@@ -47,8 +49,24 @@ export const Textarea = ({
     resizeable = true,
     onFocus,
     selectable = false,
+    focusOnMount,
+    onEnterPressed,
 }: TextareaProps): ReactElement => {
     const Component = autosize ? TextareaAutosize : 'textarea';
+
+    const textareaElement = useRef<HTMLTextAreaElement | null>(null);
+
+    useEffect(() => {
+        setTimeout(() => {
+            focusOnMount && textareaElement.current?.focus();
+        }, 0);
+    }, [focusOnMount]);
+
+    const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+        if (event.key === 'Enter') {
+            onEnterPressed && onEnterPressed(event);
+        }
+    };
 
     const { isFocusVisible, focusProps } = useFocusRing({ isTextInput: true });
 
@@ -72,6 +90,7 @@ export const Textarea = ({
                 }) as TextareaAutosizeProps)}
                 {...(autosize ? autosizeProps : { rows: minRows })}
                 id={useMemoizedId(propId)}
+                ref={textareaElement}
                 value={value}
                 placeholder={placeholder}
                 required={required}
@@ -95,6 +114,7 @@ export const Textarea = ({
                         onFocus(e);
                     }
                 }}
+                onKeyDown={onKeyDown}
                 data-test-id="textarea"
             />
             {validation === Validation.Loading && (


### PR DESCRIPTION
I added the following props:
- focusOnMount
- onEnterPressed

They behave the same way as in the input component.

I was requiring those props to integrate the textarea into an ongoing feature.