### PR TITLE
fix: TreeItem items with longer titles bug

### DIFF
--- a/src/components/Tree/TreeItem/TreeItem.tsx
+++ b/src/components/Tree/TreeItem/TreeItem.tsx
@@ -334,7 +334,7 @@ export const TreeItem = memo(
 
         const showContent = showContentWhileDragging ? true : !isActive;
         const wrapperContentClassName = merge([
-            'tw-max-w-full	tw-grow',
+            'tw-max-w-full tw-grow tw-overflow-hidden',
             isActive && showContentWhileDragging ? 'tw-opacity-75 tw-blur-sm tw-grayscale' : '',
         ]);
         const showChildren = isExpanded && !isActive;


### PR DESCRIPTION
Fixes the issue when titles are longer than space available https://app.clickup.com/t/2523021/TASK-8671

Before, the items expands more than parent container hiding elements on the right, like buttons:
<img width="396" alt="Screenshot 2023-09-20 at 11 10 38" src="https://github.com/Frontify/fondue/assets/357211/2fae9620-5e75-45fa-98bf-605037198926">

After, the ellipsis cuts the text at the right position:
<img width="386" alt="Screenshot 2023-09-20 at 11 11 52" src="https://github.com/Frontify/fondue/assets/357211/87d1e377-39b7-4065-a9f6-57aefb65164f">
