### PR TITLE
fix: apply text disabled text color for the tab label

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -229,9 +229,8 @@ export const Tabs = ({
                                 id={`${tab.id}-btn`}
                                 className={merge([
                                     'tw-group tw-relative tw-mx-0 tw-py-4 tw-px-2 tw-w-max tw-cursor-pointer tw-flex tw-items-center tw-justify-center tw-whitespace-nowrap',
-                                    tab.disabled && 'tw-text-text-disabled',
-                                    !tab.disabled && 'hover:tw-text-text',
-                                    tab.id === activeItemId ? 'tw-font-medium tw-text-text' : 'tw-text-text-weak',
+                                    tab.id === activeItemId && 'tw-font-medium tw-text-text',
+                                    tab.disabled ? 'tw-text-text-disabled' : 'tw-text-text-weak hover:tw-text-text',
                                     size === TabSize.Small ? 'tw-text-sm' : 'tw-text-md',
                                 ])}
                                 key={tab.id}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -229,8 +229,8 @@ export const Tabs = ({
                                 id={`${tab.id}-btn`}
                                 className={merge([
                                     'tw-group tw-relative tw-mx-0 tw-py-4 tw-px-2 tw-w-max tw-cursor-pointer tw-flex tw-items-center tw-justify-center tw-whitespace-nowrap',
-                                    tab.id === activeItemId && 'tw-font-medium tw-text-text',
                                     tab.disabled ? 'tw-text-text-disabled' : 'tw-text-text-weak hover:tw-text-text',
+                                    tab.id === activeItemId && 'tw-font-medium tw-text-text',
                                     size === TabSize.Small ? 'tw-text-sm' : 'tw-text-md',
                                 ])}
                                 key={tab.id}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -53,6 +53,18 @@ const paddingMap: Record<TabsPaddingX, string> = {
     [TabsPaddingX.Large]: 'tw-pl-l',
 };
 
+const getTabButtonTextStyle = (tab: TabItemProps, activeItemId: string) => {
+    if (tab.disabled) {
+        return 'tw-text-text-disabled';
+    }
+
+    if (tab.id === activeItemId) {
+        return 'tw-font-medium tw-text-text';
+    }
+
+    return 'tw-text-text-weak hover:tw-text-text';
+};
+
 export const Tabs = ({
     paddingX,
     size,
@@ -229,9 +241,7 @@ export const Tabs = ({
                                 id={`${tab.id}-btn`}
                                 className={merge([
                                     'tw-group tw-relative tw-mx-0 tw-py-4 tw-px-2 tw-w-max tw-cursor-pointer tw-flex tw-items-center tw-justify-center tw-whitespace-nowrap',
-                                    tab.disabled ? 'tw-text-text-disabled' : 'tw-text-text-weak hover:tw-text-text',
-                                    tab.id === activeItemId && 'tw-font-medium tw-text-text',
-                                    size === TabSize.Small ? 'tw-text-sm' : 'tw-text-md',
+                                    getTabButtonTextStyle(tab, activeItemId),
                                 ])}
                                 key={tab.id}
                                 onClick={() => {


### PR DESCRIPTION
TabItem disabled state
- `text-weak` is overriding the `text-disabled` and we can't see the right color

<img width="479" alt="Screenshot 2023-09-21 at 10 24 39" src="https://github.com/Frontify/fondue/assets/35492/b64f5bfe-907e-4662-a6a2-75617c9508f4">

https://www.figma.com/file/MmTUiRZXSDXtewPb7JYoOg/Metadata-(Permissions-%26-Dependencies)?type=design&node-id=5307-48196&mode=design&t=3c0p2euhnY4rKNTf-0
