### PR TITLE
fix(RTE): serializer OL level calculation

### DIFF
--- a/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
+++ b/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
@@ -183,62 +183,27 @@ export const orderedListValue = {
     ],
 };
 
-export const multipleOrderedListsValue = {
-    type: ELEMENT_OL,
+const nestedListValue = {
+    type: ELEMENT_LI,
     children: [
+        createLicElement({ text: 'This comes first' }),
         {
-            type: ELEMENT_LI,
+            type: ELEMENT_OL,
             children: [
-                createLicElement({ text: 'First Item Ordered List' }),
                 {
-                    type: ELEMENT_OL,
-                    children: [
-                        {
-                            type: ELEMENT_LI,
-                            children: [createLicElement({ text: 'First First SubItem' })],
-                        },
-                        {
-                            type: ELEMENT_LI,
-                            children: [
-                                createLicElement({ text: 'First Second SubItem' }),
-                                {
-                                    type: ELEMENT_OL,
-                                    children: [
-                                        {
-                                            type: ELEMENT_LI,
-                                            children: [createLicElement({ text: 'First Second SubSubItem' })],
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    ],
+                    type: ELEMENT_LI,
+                    children: [createLicElement({ text: 'First Child Item' })],
                 },
-            ],
-        },
-        {
-            type: ELEMENT_LI,
-            children: [
-                createLicElement({ text: 'Second Item Ordered List' }),
                 {
-                    type: ELEMENT_OL,
+                    type: ELEMENT_LI,
                     children: [
+                        createLicElement({ text: 'Second Child Item' }),
                         {
-                            type: ELEMENT_LI,
-                            children: [createLicElement({ text: 'Second First SubItem' })],
-                        },
-                        {
-                            type: ELEMENT_LI,
+                            type: ELEMENT_OL,
                             children: [
-                                createLicElement({ text: 'Second Second SubItem' }),
                                 {
-                                    type: ELEMENT_OL,
-                                    children: [
-                                        {
-                                            type: ELEMENT_LI,
-                                            children: [createLicElement({ text: 'Second Second SubSubItem' })],
-                                        },
-                                    ],
+                                    type: ELEMENT_LI,
+                                    children: [createLicElement({ text: 'Nested Child Item number one' })],
                                 },
                             ],
                         },
@@ -247,6 +212,11 @@ export const multipleOrderedListsValue = {
             ],
         },
     ],
+};
+
+export const multipleOrderedListsValue = {
+    type: ELEMENT_OL,
+    children: [nestedListValue, nestedListValue],
 };
 
 export const defaultValue = [

--- a/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
+++ b/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
@@ -219,10 +219,7 @@ export const multipleOrderedListsValue = {
         {
             type: ELEMENT_LI,
             children: [
-                {
-                    type: 'lic',
-                    children: [createLicElement({ text: 'Second Item Ordered List' })],
-                },
+                createLicElement({ text: 'Second Item Ordered List' }),
                 {
                     type: ELEMENT_OL,
                     children: [

--- a/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
+++ b/src/components/RichTextEditor/helpers/exampleValues/exampleValues.ts
@@ -183,6 +183,75 @@ export const orderedListValue = {
     ],
 };
 
+export const multipleOrderedListsValue = {
+    type: ELEMENT_OL,
+    children: [
+        {
+            type: ELEMENT_LI,
+            children: [
+                createLicElement({ text: 'First Item Ordered List' }),
+                {
+                    type: ELEMENT_OL,
+                    children: [
+                        {
+                            type: ELEMENT_LI,
+                            children: [createLicElement({ text: 'First First SubItem' })],
+                        },
+                        {
+                            type: ELEMENT_LI,
+                            children: [
+                                createLicElement({ text: 'First Second SubItem' }),
+                                {
+                                    type: ELEMENT_OL,
+                                    children: [
+                                        {
+                                            type: ELEMENT_LI,
+                                            children: [createLicElement({ text: 'First Second SubSubItem' })],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            type: ELEMENT_LI,
+            children: [
+                {
+                    type: 'lic',
+                    children: [createLicElement({ text: 'Second Item Ordered List' })],
+                },
+                {
+                    type: ELEMENT_OL,
+                    children: [
+                        {
+                            type: ELEMENT_LI,
+                            children: [createLicElement({ text: 'Second First SubItem' })],
+                        },
+                        {
+                            type: ELEMENT_LI,
+                            children: [
+                                createLicElement({ text: 'Second Second SubItem' }),
+                                {
+                                    type: ELEMENT_OL,
+                                    children: [
+                                        {
+                                            type: ELEMENT_LI,
+                                            children: [createLicElement({ text: 'Second Second SubSubItem' })],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
 export const defaultValue = [
     createElement({ text: 'This text is bold.', mark: MARK_BOLD }),
     createElement({ text: 'This text is italic.', mark: MARK_ITALIC }),

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
@@ -120,7 +120,6 @@ describe('serializeNodeToHtmlRecursive()', () => {
         const parser = new DOMParser();
         const htmlDoc = parser.parseFromString(result, 'text/html');
         const orderedLists = htmlDoc.getElementsByTagName('ol');
-        console.log(orderedLists);
         expect(orderedLists[0]?.className).to.include('decimal');
         expect(orderedLists[1]?.className).to.include('alpha');
         expect(orderedLists[2]?.className).to.include('roman');

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.spec.ts
@@ -1,6 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { mentionable, orderedListValue, unorderedListValue } from '@components/RichTextEditor/helpers/exampleValues';
+import {
+    mentionable,
+    multipleOrderedListsValue,
+    orderedListValue,
+    unorderedListValue,
+} from '@components/RichTextEditor/helpers/exampleValues';
 import { ELEMENT_CHECK_ITEM, mapMentionable } from '@components/RichTextEditor/Plugins';
 import {
     ELEMENT_IMAGE,
@@ -104,6 +109,18 @@ describe('serializeNodeToHtmlRecursive()', () => {
         const parser = new DOMParser();
         const htmlDoc = parser.parseFromString(result, 'text/html');
         const orderedLists = htmlDoc.getElementsByTagName('ol');
+        expect(orderedLists[0]?.className).to.include('decimal');
+        expect(orderedLists[1]?.className).to.include('alpha');
+        expect(orderedLists[2]?.className).to.include('roman');
+    });
+
+    it('serializes multiple ordered lists with multiple levels to with correct list style types to html', () => {
+        const result = serializeNodeToHtmlRecursive(multipleOrderedListsValue, defaultStyles, {});
+
+        const parser = new DOMParser();
+        const htmlDoc = parser.parseFromString(result, 'text/html');
+        const orderedLists = htmlDoc.getElementsByTagName('ol');
+        console.log(orderedLists);
         expect(orderedLists[0]?.className).to.include('decimal');
         expect(orderedLists[1]?.className).to.include('alpha');
         expect(orderedLists[2]?.className).to.include('roman');

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
@@ -33,20 +33,19 @@ import { serializeLeafToHtml } from './serializeLeafToHtml';
 import { CSSPropertiesHover } from '../types';
 
 const getNestingLevels = (nodes: TDescendant[], type: string): number => {
-    if (!nodes || !Array.isArray(nodes)) {
-        return 0;
-    }
     let maxDepth = 0;
+
     for (const node of nodes) {
-        let currentDepth = node.type === type ? 1 : 0;
+        let currentDepth = 0;
+        if (node.type === type) {
+            currentDepth = 1;
+        }
         if (node.children) {
-            const childDepth = getNestingLevels(node.children as TDescendant[], type);
-            if (childDepth > 0) {
-                currentDepth += childDepth;
-            }
+            currentDepth += getNestingLevels(node.children as TDescendant[], type);
         }
         maxDepth = Math.max(maxDepth, currentDepth);
     }
+
     return maxDepth;
 };
 

--- a/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
+++ b/src/components/RichTextEditor/serializer/utils/serializeNodeToHtmlRecursive.ts
@@ -69,7 +69,6 @@ export const serializeNodeToHtmlRecursive = (
     }
 
     const rootNestingCount = nestingCount[node.type] || getNestingLevels([node], node.type);
-    console.log('rootNestingCount', rootNestingCount);
     let children = '';
     for (const element of node.children) {
         children += serializeNodeToHtmlRecursive(element, styles, {


### PR DESCRIPTION
[Task](https://app.clickup.com/t/8692pynn1)

Basically the problem was the nesting level was wrongly calculated as it counted all OLs and not just the ones in line. 

- OL
- - SUB OL
- - - SUB SUB OL
- - Another Sub OL
- - - SUB OL

They were all counted and the deepness was 5 but it should have been 3 as that's the deepest and so the wrong numbering was shown

Example of the bug:
![Screenshot 2023-09-22 at 10 57 42](https://github.com/Frontify/fondue/assets/9362990/45495c6a-d693-496a-a1a5-adc33088d05e)

How it should be:
![Screenshot 2023-09-22 at 10 59 07](https://github.com/Frontify/fondue/assets/9362990/dd86c018-c2f6-4b40-9949-9bdb082b44c7)

