### PR TITLE
fix: table header shouldn't overlay other content

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -162,7 +162,7 @@ export const Table = ({
                         </TableHeaderRow>
                     ))}
                 </thead>
-                <tbody>
+                <tbody className="tw-relative tw-z-[-1] sm:tw-z-auto">
                     {[...collection.body.childNodes].map((ariaRow) => {
                         const row = getRowFromId(rows, ariaRow.key);
 

--- a/src/components/Table/TableHeaderRow.tsx
+++ b/src/components/Table/TableHeaderRow.tsx
@@ -10,7 +10,7 @@ export const TableHeaderRow = ({ children }: TableHeaderRowProps) => {
     const ref = useRef<HTMLTableRowElement | null>(null);
 
     return (
-        <tr role="row" ref={ref} className="tw-py-4 tw-px-8 tw-sticky tw-top-0 tw-bg-base tw-z-10">
+        <tr role="row" ref={ref} className="tw-py-4 tw-px-8 tw-sticky tw-top-0 tw-bg-base">
             {children}
         </tr>
     );


### PR DESCRIPTION
Table header had z-index: 10 in order to avoid being overlaid by table content in mobile view (when the header is sticky). This high z-index value causes it to overlay other elements on the page, such as a sticky header.  The solution should be much less likely to conflict with other elements.
Before:
<img width="777" alt="Snímek obrazovky 2023-09-21 v 14 10 25" src="https://github.com/Frontify/fondue/assets/1754448/b4949e5b-6120-4d9c-9446-13e140373dce">

After:
<img width="780" alt="Snímek obrazovky 2023-09-21 v 14 06 52" src="https://github.com/Frontify/fondue/assets/1754448/8b9fc10b-3693-45f2-b9aa-de7095bfba0a">
