### PR TITLE
feat: added an option to disable the negative margin

### DIFF
--- a/src/components/ScrollWrapper/ScrollWrapper.cy.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.cy.tsx
@@ -92,4 +92,10 @@ describe('ScrollWrapper Component', () => {
             .should('have.class', 'tw-h-full')
             .should('have.class', 'tw-overflow-auto');
     });
+
+    it('should render without negative margin', () => {
+        cy.mount(<ScrollWrapperComponent disableNegativeMargin={true} />);
+
+        cy.get(SCROLL_WRAPPER_CONTENT_ID).should('not.have.class', 'tw-px-2').should('not.have.class', 'tw--mx-2');
+    });
 });

--- a/src/components/ScrollWrapper/ScrollWrapper.stories.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.stories.tsx
@@ -33,6 +33,7 @@ export default {
         tabindex: 0,
         'data-test-id': 'custom-data-test-id',
         scrollShadows: true,
+        disableNegativeMargin: false,
     },
 } as Meta<ScrollWrapperProps>;
 

--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -16,6 +16,7 @@ export const ScrollWrapper = ({
     direction = ScrollWrapperDirection.Vertical,
     children,
     scrollShadows = true,
+    disableNegativeMargin = false,
     'data-test-id': dataTestId = 'scroll-wrapper',
 }: ScrollWrapperProps): ReactElement => {
     const scrollingContainer = useRef<HTMLDivElement>(null);
@@ -50,8 +51,9 @@ export const ScrollWrapper = ({
                 aria-label="Scrollable dialogue content"
                 className={merge([
                     scrollWrapperDirections[direction],
-                    'tw-flex-auto tw-min-h-0 tw-outline-none tw-pt-px tw-pb-2 tw-px-2 tw--mx-2',
+                    'tw-flex-auto tw-min-h-0 tw-outline-none tw-pt-px tw-pb-2',
                     isFocusVisible && FOCUS_STYLE,
+                    !disableNegativeMargin && 'tw-px-2 tw--mx-2',
                 ])}
                 {...scrollDivProps}
                 {...focusProps}

--- a/src/components/ScrollWrapper/types.ts
+++ b/src/components/ScrollWrapper/types.ts
@@ -20,4 +20,5 @@ export type ScrollWrapperProps = {
     'data-test-id'?: string;
     tabindex?: number;
     scrollShadows?: boolean;
+    disableNegativeMargin?: boolean;
 };


### PR DESCRIPTION
Working with the new Dialog component I got into this issue where the negative margin + positive margin was causing unnecessary horizontal scrolling if ScrollWrapper was used inside DialogBody.