### PR TITLE
feat(RTE): add more autoformat options

### DIFF
--- a/src/components/RichTextEditor/Plugins/AutoformatPlugin/index.tsx
+++ b/src/components/RichTextEditor/Plugins/AutoformatPlugin/index.tsx
@@ -1,6 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { createAutoformatPlugin } from '@udecode/plate';
 import { Plugin, PluginProps } from '../Plugin';
 import { AUTOFORMAT_PLUGIN } from './id';
 import {
@@ -11,6 +10,14 @@ import {
     MARK_ITALIC,
     MARK_STRIKETHROUGH,
     MARK_UNDERLINE,
+    autoformatArrow,
+    autoformatLegal,
+    autoformatPunctuation,
+    autoformatSubscriptNumbers,
+    autoformatSubscriptSymbols,
+    autoformatSuperscriptNumbers,
+    autoformatSuperscriptSymbols,
+    createAutoformatPlugin,
     toggleList,
     unwrapList,
 } from '@udecode/plate';
@@ -29,6 +36,13 @@ export class AutoformatPlugin extends Plugin {
             createAutoformatPlugin({
                 options: {
                     rules: [
+                        ...autoformatPunctuation,
+                        ...autoformatArrow,
+                        ...autoformatLegal,
+                        ...autoformatSubscriptNumbers,
+                        ...autoformatSubscriptSymbols,
+                        ...autoformatSuperscriptNumbers,
+                        ...autoformatSuperscriptSymbols,
                         {
                             mode: 'mark',
                             type: [MARK_UNDERLINE],
@@ -89,7 +103,7 @@ export class AutoformatPlugin extends Plugin {
                         {
                             mode: 'block',
                             type: ELEMENT_OL,
-                            match: ['1. '],
+                            match: ['1. ', '1) '],
                             preFormat: unwrapList,
                             format: (editor) => toggleList(editor, { type: ELEMENT_OL }),
                         },

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -692,8 +692,28 @@ describe('RichTextEditor Component', () => {
             cy.get('[contenteditable=true]').should('include.html', STRIKETHROUGH_CLASSES);
         });
 
-        it('should autoformat - to code block', () => {
-            cy.get('[contenteditable=true]').click().type('`hello`');
+        it('should autoformat ~1 to ₁', () => {
+            cy.get('[contenteditable=true]').click().type('~1');
+            cy.get('[contenteditable=true]').should('include.html', '₁');
+        });
+
+        it('should autoformat ~+ to ₊', () => {
+            cy.get('[contenteditable=true]').click().type('~+');
+            cy.get('[contenteditable=true]').should('include.html', '₊');
+        });
+
+        it('should autoformat ^1 to ¹', () => {
+            cy.get('[contenteditable=true]').click().type('^1');
+            cy.get('[contenteditable=true]').should('include.html', '¹');
+        });
+
+        it('should autoformat ^+ to ⁺', () => {
+            cy.get('[contenteditable=true]').click().type('^+');
+            cy.get('[contenteditable=true]').should('include.html', '⁺');
+        });
+
+        it('should autoformat `code` to code block', () => {
+            cy.get('[contenteditable=true]').click().type('`code`');
             cy.get('[contenteditable=true]').should('include.html', CODE_CLASSES);
         });
 
@@ -731,12 +751,89 @@ describe('RichTextEditor Component', () => {
             cy.get('[contenteditable=true]').get('ol').should('have.class', getOrderedListClasses(0));
         });
 
+        it('should autoformat 1) to ordered list', () => {
+            cy.get('[contenteditable=true]').click().type('1. hello');
+            cy.get('[contenteditable=true]').should('include.html', '<ol');
+            cy.get('[contenteditable=true]').should('include.html', '<li');
+            cy.get('[contenteditable=true]').get('ol').should('have.class', getOrderedListClasses(0));
+        });
+
         it('should autoformat [] to checkbox list', () => {
             cy.get('[contenteditable=true]').click().type('[] hello');
             cy.get('[contenteditable=true]').should('include.html', '<div');
             cy.get('[contenteditable=true]').get('div').should('have.class', CHECKBOX_DIV_CLASSES);
             cy.get('[contenteditable=true]').should('include.html', '<input');
             cy.get('[contenteditable=true]').get('span').should('have.class', CHECKBOX_SPAN_CLASSES);
+        });
+
+        it('should autoformat -- to —', () => {
+            cy.get('[contenteditable=true]').click().type('--');
+            cy.get('[contenteditable=true]').should('include.html', '—');
+        });
+
+        it('should autoformat ... to …', () => {
+            cy.get('[contenteditable=true]').click().type('...');
+            cy.get('[contenteditable=true]').should('include.html', '…');
+        });
+
+        it('should autoformat >> to »', () => {
+            cy.get('[contenteditable=true]').click().type('>>');
+            cy.get('[contenteditable=true]').should('include.html', '»');
+        });
+
+        it('should autoformat << to «', () => {
+            cy.get('[contenteditable=true]').click().type('<<');
+            cy.get('[contenteditable=true]').should('include.html', '«');
+        });
+
+        it('should autoformat -> to →', () => {
+            cy.get('[contenteditable=true]').click().type('->');
+            cy.get('[contenteditable=true]').should('include.html', '→');
+        });
+
+        it('should autoformat <- to ←', () => {
+            cy.get('[contenteditable=true]').click().type('<-');
+            cy.get('[contenteditable=true]').should('include.html', '←');
+        });
+
+        it('should autoformat => to ⇒', () => {
+            cy.get('[contenteditable=true]').click().type('=>');
+            cy.get('[contenteditable=true]').should('include.html', '⇒');
+        });
+
+        it('should autoformat <= to ⇐', () => {
+            cy.get('[contenteditable=true]').click().type('<=');
+            cy.get('[contenteditable=true]').should('include.html', '⇐');
+        });
+
+        it('should autoformat (c) to ©', () => {
+            cy.get('[contenteditable=true]').click().type('(c)');
+            cy.get('[contenteditable=true]').should('include.html', '©');
+        });
+
+        it('should autoformat (C) to ©', () => {
+            cy.get('[contenteditable=true]').click().type('(C)');
+            cy.get('[contenteditable=true]').should('include.html', '©');
+        });
+
+        it('should autoformat (r) to ®', () => {
+            cy.get('[contenteditable=true]').click().type('(r)');
+            cy.get('[contenteditable=true]').should('include.html', '®');
+        });
+
+        it('should autoformat (R) to ®', () => {
+            cy.get('[contenteditable=true]').click().type('(R)');
+            cy.get('[contenteditable=true]').should('include.html', '®');
+        });
+
+        it('should autoformat (tm) to ™', () => {
+            cy.get('[contenteditable=true]').click().type('(tm)');
+            cy.get('[contenteditable=true]').should('include.html', '™');
+        });
+
+        it('should autoformat (TM) to ™', () => {
+            cy.get('[contenteditable=true]').click().type('(TM)');
+            cy.get('[contenteditable=true]').should('include.html', '™');
         });
     });
 });


### PR DESCRIPTION
added autoformat for legal signs, punctuation, arrows and subscript symbols and numbers, also added autoformat for `1)` 