### PR TITLE
feat(RTE): add autoformat for fractions

### DIFF
--- a/src/components/RichTextEditor/Plugins/AutoformatPlugin/index.tsx
+++ b/src/components/RichTextEditor/Plugins/AutoformatPlugin/index.tsx
@@ -11,6 +11,7 @@ import {
     MARK_STRIKETHROUGH,
     MARK_UNDERLINE,
     autoformatArrow,
+    autoformatFraction,
     autoformatLegal,
     autoformatPunctuation,
     autoformatSubscriptNumbers,
@@ -43,6 +44,7 @@ export class AutoformatPlugin extends Plugin {
                         ...autoformatSubscriptSymbols,
                         ...autoformatSuperscriptNumbers,
                         ...autoformatSuperscriptSymbols,
+                        ...autoformatFraction,
                         {
                             mode: 'mark',
                             type: [MARK_UNDERLINE],

--- a/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -835,5 +835,15 @@ describe('RichTextEditor Component', () => {
             cy.get('[contenteditable=true]').click().type('(TM)');
             cy.get('[contenteditable=true]').should('include.html', '™');
         });
+
+        it('should autoformat 1/2 to ½', () => {
+            cy.get('[contenteditable=true]').click().type('1/2');
+            cy.get('[contenteditable=true]').should('include.html', '½');
+        });
+
+        it('should autoformat 2/3 to ⅔', () => {
+            cy.get('[contenteditable=true]').click().type('2/3');
+            cy.get('[contenteditable=true]').should('include.html', '⅔');
+        });
     });
 });


### PR DESCRIPTION
Adds the autoformat rule for fractions so 1/2 gets converted to ½