### PR TITLE
fix: prevent focus on press in legacy flyout

### DIFF
--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -106,7 +106,8 @@ export const Flyout = ({
     });
 
     const { buttonProps, isPressed } = useButton(
-        { onPress: () => toggle(), elementType: 'div', isDisabled: isTriggerDisabled },
+        // @ts-expect-error preventFocusOnPress is an undocumented property in react-aria
+        { onPress: () => toggle(), elementType: 'div', isDisabled: isTriggerDisabled, preventFocusOnPress: true },
         triggerRef,
     );
 


### PR DESCRIPTION
FocusOnPress causes a lot of issues when using custom components as the trigger element. Preventing focus does nothing to harm accessibility as the button fill be focused natively by the browser.

Everything should still open and close correctly. To see the issue replace the Button component with a standard <button> in the WithButtonFlyoutTemplate and see the focus ring appear when the button is pressed