### PR TITLE
fix: Input focus state style hierarchy

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -180,8 +180,8 @@ export const TextInput = ({
     }, [obfuscated]);
 
     const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === 'Enter') {
-            onEnterPressed && onEnterPressed(event);
+        if (event.key === 'Enter' && onEnterPressed) {
+            onEnterPressed(event);
         }
     };
 
@@ -194,6 +194,18 @@ export const TextInput = ({
 
     const spellcheckProp = typeof spellcheck === 'boolean' ? { spellCheck: spellcheck } : null;
 
+    const setStylePrecedence = () => {
+        if (
+            isFocusVisible &&
+            !clearButtonIsFocusVisible &&
+            !passwordButtonIsFocusVisible &&
+            !copyButtonIsFocusVisible
+        ) {
+            return FOCUS_STYLE;
+        }
+        return 'hover:tw-border-line-x-strong';
+    };
+
     return (
         <div
             {...focusProps}
@@ -203,15 +215,7 @@ export const TextInput = ({
                 dotted ? 'tw-border-dashed' : 'tw-border-solid',
                 disabled || readonly
                     ? 'tw-border-black-5 tw-bg-black-5 dark:tw-bg-black-90 dark:tw-border-black-90'
-                    : merge([
-                          'focus-within:tw-border-black-90 hover:tw-border-line-x-strong',
-                          validationClassMap[validation],
-                          isFocusVisible &&
-                              !clearButtonIsFocusVisible &&
-                              !passwordButtonIsFocusVisible &&
-                              !copyButtonIsFocusVisible &&
-                              FOCUS_STYLE,
-                      ]),
+                    : merge(['focus-within:tw-border-black-90', validationClassMap[validation], setStylePrecedence()]),
             ])}
             data-test-id="fondue-text-input-component"
         >

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -194,18 +194,6 @@ export const TextInput = ({
 
     const spellcheckProp = typeof spellcheck === 'boolean' ? { spellCheck: spellcheck } : null;
 
-    const setStylePrecedence = () => {
-        if (
-            isFocusVisible &&
-            !clearButtonIsFocusVisible &&
-            !passwordButtonIsFocusVisible &&
-            !copyButtonIsFocusVisible
-        ) {
-            return FOCUS_STYLE;
-        }
-        return 'hover:tw-border-line-x-strong';
-    };
-
     return (
         <div
             {...focusProps}
@@ -215,7 +203,15 @@ export const TextInput = ({
                 dotted ? 'tw-border-dashed' : 'tw-border-solid',
                 disabled || readonly
                     ? 'tw-border-black-5 tw-bg-black-5 dark:tw-bg-black-90 dark:tw-border-black-90'
-                    : merge(['focus-within:tw-border-black-90', validationClassMap[validation], setStylePrecedence()]),
+                    : merge([
+                          'focus-within:tw-border-line-xx-strong focus-within:hover:tw-border-line-xx-strong hover:tw-border-line-x-strong',
+                          validationClassMap[validation],
+                          isFocusVisible &&
+                              !clearButtonIsFocusVisible &&
+                              !passwordButtonIsFocusVisible &&
+                              !copyButtonIsFocusVisible &&
+                              FOCUS_STYLE,
+                      ]),
             ])}
             data-test-id="fondue-text-input-component"
         >

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -107,7 +107,7 @@ export const Textarea = ({
                     !!decorator && 'tw-pl-7 ',
                     disabled
                         ? 'tw-border-black-5 tw-bg-black-5 tw-text-black-40'
-                        : 'tw-text-black tw-border-black-20 hover:tw-border-line-x-strong',
+                        : 'tw-text-black tw-border-black-20 hover:tw-border-line-x-strong focus-within:tw-border-line-xx-strong focus-within:hover:tw-border-line-xx-strong',
                     isFocusVisible && FOCUS_STYLE,
                     validationClassMap[validation],
                     !resizeable && 'tw-resize-none',


### PR DESCRIPTION
Fix for `TextInput` and `Teaxtarea` to use `focus` border styling over hover when active.