### PR TITLE
fix: ternary for onKeyDown event when isCalendarOpen

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -110,7 +110,7 @@ export const DatePicker = forwardRef<ReactDatePicker<never, boolean>, DatePicker
                     maxDate={maxDate}
                     calendarStartDay={1}
                     onChange={onChange}
-                    onKeyDown={onKeyDown}
+                    onKeyDown={isCalendarOpen ? undefined : onKeyDown}
                     onBlur={onBlur}
                     selectsRange={variant === 'range'}
                     showPopperArrow={hasPopperArrow}


### PR DESCRIPTION
Adds ternary operator to `onKeyDown` prop to restrict any external keyboard actions when the calendar is open.

ClickUp Inbox Card
https://app.clickup.com/t/8692mrjv0