### PR TITLE
feat: flag to disable drag N drop delay

### DIFF
--- a/src/components/OrderableList/OrderableList.stories.tsx
+++ b/src/components/OrderableList/OrderableList.stories.tsx
@@ -23,6 +23,7 @@ export default {
     args: {
         dragDisabled: false,
         dragHandlerPosition: 'right',
+        disableDragDelay: false,
         spacingY: 'small',
         contentHight: 'content-fit',
         shadow: 'small',
@@ -39,6 +40,11 @@ export default {
             table: { category: 'Item Options' },
             options: ['left', 'right', 'none'],
             control: { type: 'inline-radio' },
+        },
+        disableDragDelay: {
+            table: { category: 'Item Options' },
+            defaultValue: false,
+            control: { type: 'boolean' },
         },
         spacingY: {
             table: { category: 'Item Style' },
@@ -100,6 +106,7 @@ export const OrderableList: StoryFn<OrderableListProps<StoryListItem> & Orderabl
     selectedId,
     dragDisabled,
     dragHandlerPosition,
+    disableDragDelay,
     spacingY,
     contentHight,
     shadow,
@@ -163,6 +170,7 @@ export const OrderableList: StoryFn<OrderableListProps<StoryListItem> & Orderabl
                 onMove={chain(handleMove, onMove)}
                 dragDisabled={dragDisabled}
                 dragHandlerPosition={dragHandlerPosition}
+                disableDragDelay={disableDragDelay}
                 selectedId={currentSelectedId}
                 itemStyle={{
                     spacingY,

--- a/src/components/OrderableList/OrderableList.tsx
+++ b/src/components/OrderableList/OrderableList.tsx
@@ -36,6 +36,7 @@ export const OrderableList = <T extends object>({
     dragDisabled,
     items,
     dragHandlerPosition = 'none',
+    disableDragDelay = false,
     itemStyle,
     selectedId,
     renderContent,
@@ -80,6 +81,7 @@ export const OrderableList = <T extends object>({
             showDragHandlerOnHoverOnly={!isDraggable}
             dragHandlerPosition={!isDraggable ? 'none' : dragHandlerPosition}
             showContentWhileDragging={true}
+            disableDragDelay={disableDragDelay}
         >
             {itemsState.map((item) => {
                 const identifier = `collection-item-${item.id}`;

--- a/src/components/OrderableList/types.ts
+++ b/src/components/OrderableList/types.ts
@@ -16,6 +16,8 @@ export type OrderableListProps<T> = {
     items: OrderableListItem<T>[];
     dragDisabled: boolean;
     dragHandlerPosition?: DragHandlerPosition;
+    /**@description Flag to disable the default drag sensor delay */
+    disableDragDelay?: boolean;
     itemStyle?: OrderableListItemStyle;
     selectedId?: string;
     onMove: (modifiedItems: DraggableItem<T>[]) => void;

--- a/src/components/OrderableList/types.ts
+++ b/src/components/OrderableList/types.ts
@@ -2,7 +2,7 @@
 
 import { ReactElement } from 'react';
 import { DraggableItem } from '@utilities/dnd';
-import { DragHandlerPosition, TreeItemStyling } from '..';
+import { DragHandlerPosition, TreeItemStyling, TreeProps } from '..';
 
 export type RenderListItem<T> = (items: OrderableListItem<T>) => ReactElement;
 
@@ -16,11 +16,9 @@ export type OrderableListProps<T> = {
     items: OrderableListItem<T>[];
     dragDisabled: boolean;
     dragHandlerPosition?: DragHandlerPosition;
-    /**@description Flag to disable the default drag sensor delay */
-    disableDragDelay?: boolean;
     itemStyle?: OrderableListItemStyle;
     selectedId?: string;
     onMove: (modifiedItems: DraggableItem<T>[]) => void;
     renderContent: RenderListItem<T>;
     'data-test-id'?: string;
-};
+} & Pick<TreeProps, 'disableDragDelay'>;

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -195,6 +195,7 @@ export const Tree = memo(
         draggable = false,
         multiselect = false,
         dragHandlerPosition = 'left',
+        disableDragDelay = false,
         showDragHandlerOnHoverOnly = true,
         showContentWhileDragging = false,
         itemStyle,
@@ -375,7 +376,9 @@ export const Tree = memo(
         });
 
         const [coordinateGetter] = useState(() => sortableTreeKeyboardCoordinates(sensorContext));
-        const activationConstraint = sensorsActivationConstraint(dragHandlerPosition);
+        const activationConstraint = disableDragDelay
+            ? sensorsActivationConstraint(undefined)
+            : sensorsActivationConstraint(dragHandlerPosition);
 
         const sensors = useSensors(
             useSensor(PointerSensor, { activationConstraint }),

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -139,6 +139,8 @@ export type TreeProps = {
     selectedIds?: string[];
     expandedIds?: string[];
     dragHandlerPosition?: DragHandlerPosition;
+    /**@description Flag to disable the default sensor delay */
+    disableDragDelay?: boolean;
     showDragHandlerOnHoverOnly?: boolean;
     showContentWhileDragging?: boolean;
     itemStyle?: TreeItemStyling;


### PR DESCRIPTION
Optional `flag` to disable the default `150 millisecond` delay when `onMouseDown` on a Tree item to initiate drag.  `Prop` is also extended to the `OrderableList` component.

Slack request:
https://frontify.slack.com/archives/C02PSJTPA3D/p1696940357966949

ClickUp Task:
https://app.clickup.com/t/8692wupy2