### PR TITLE
fix(Tree): Multiselect item checkbox alignment

### DIFF
--- a/src/components/Tree/TreeItem/TreeItemMultiselect.tsx
+++ b/src/components/Tree/TreeItem/TreeItemMultiselect.tsx
@@ -127,7 +127,7 @@ export const TreeItemMultiselect = memo(
         const checkBoxOnSelect = isDisabled ? () => void 0 : () => onSelect?.(id, false);
         const checkBox =
             checkBoxPosition !== 'none' ? (
-                <Container maxWidth="16px">
+                <Container maxWidth="16px" maxHeight="16px">
                     <Checkbox
                         id={`checkbox-${id}`}
                         ref={setActiveNodeRef}


### PR DESCRIPTION
The checkbox is not aligned vertically: https://beta-fondue-components.frontify.com/?path=/story/components-tree-multiselect--multiselect-with-basic-item

In the `MultiselectTreeItem` component there is a `Container` wrapper with `maxWidth="16px"`, we should do the same for that `Container` `maxHeight` prop.