### PR TITLE
fix(SegmentedControls): update element and multipliers to correct active border positions

### DIFF
--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -164,17 +164,24 @@ export const SegmentedControls = ({
     const width = hugWidth ? '' : 'tw-w-full';
     const alignment = hugWidth ? 'tw-flex' : 'tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly';
 
+    const isSmallOrHugWidth = size === 'small' || hugWidth;
     const getSliderX = () => {
-        const isLastElement = selectedIndex === itemsRef.current.length - 1;
-        let translateX = isLastElement && !hugWidth ? 1 : 0;
+        let translateX = isSmallOrHugWidth ? -1 : 0;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }
         return `${translateX}px`;
     };
 
+    const getSliderWidth = () => {
+        const isLastElement = selectedIndex === itemsRef.current.length - 1;
+        const baseValue = isSmallOrHugWidth ? 1 : 2;
+        const width = isLastElement ? baseValue + 1 : baseValue;
+
+        return `${(itemsRef.current[selectedIndex]?.clientWidth ?? 0) + width}px`;
+    };
     const sliderTranslation = getSliderX();
-    const sliderWidth = `${itemsRef.current[selectedIndex]?.clientWidth ?? 0}px`;
+    const sliderWidth = getSliderWidth();
 
     return (
         <div className="tw-flex">

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -163,15 +163,15 @@ export const SegmentedControls = ({
     const alignment = hugWidth ? 'tw-flex' : 'tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly';
 
     const getSliderX = () => {
-        let translateX = 0;
+        let translateX = size === 'small' ? -1 : 0;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }
         return `${translateX}px`;
     };
 
-    const sliderWidth = hugWidth ? `${itemsRef.current[selectedIndex]?.clientWidth}px` : `${100 / items.length}%`;
-    const sliderTranslation = hugWidth ? getSliderX() : `calc(${100 * selectedIndex}% - ${selectedIndex}px)`;
+    const sliderTranslation = getSliderX();
+    const sliderWidth = `${itemsRef.current[selectedIndex]?.clientWidth ?? 0}px`;
 
     return (
         <div className="tw-flex">

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -165,13 +165,13 @@ export const SegmentedControls = ({
     const getSliderX = () => {
         let translateX = -1;
         for (let i = 0; i < selectedIndex; i++) {
-            translateX += itemsRef.current[i]?.clientWidth || 0;
+            translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }
         return `${translateX}px`;
     };
 
     const sliderWidth = hugWidth ? `${itemsRef.current[selectedIndex]?.clientWidth}px` : `${100 / items.length}%`;
-    const sliderTranslation = hugWidth ? getSliderX() : `calc(${100 * selectedIndex}% - ${2 * selectedIndex}px)`;
+    const sliderTranslation = hugWidth ? getSliderX() : `calc(${100 * selectedIndex}% - ${1.2 * selectedIndex}px)`;
 
     return (
         <div className="tw-flex">

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -101,7 +101,9 @@ const SegmentedControlsItem = forwardRef<HTMLDivElement, SegmentedControlsItemPr
                 className={merge([
                     'tw-relative tw-w-full tw-py-2 tw-inline-flex tw-justify-center tw-items-center tw-font-sans tw-font-normal tw-h-full tw-text-center',
                     size === 'small' ? 'tw-px-2' : 'tw-px-4',
-                    isActive && !disabled ? 'tw-text-text' : 'tw-text-text-weak',
+                    isActive && !disabled
+                        ? 'tw-text-text tw-bg-base tw-ease-in tw-duration-300'
+                        : 'tw-text-text-weak tw-ease-out tw-duration-100',
                     !disabled
                         ? 'hover:tw-text-text hover:tw-cursor-pointer'
                         : 'tw-text-box-disabled-inverse hover:tw-cursor-not-allowed',
@@ -164,7 +166,7 @@ export const SegmentedControls = ({
 
     const getSliderX = () => {
         const isLastElement = selectedIndex === itemsRef.current.length - 1;
-        let translateX = isLastElement && !hugWidth ? 0 : -1;
+        let translateX = isLastElement && !hugWidth ? 1 : 0;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }
@@ -176,6 +178,18 @@ export const SegmentedControls = ({
 
     return (
         <div className="tw-flex">
+            <motion.div
+                aria-hidden="true"
+                // div border is not included in width so it must be subtracted from translation.
+                animate={{ x: sliderTranslation, width: sliderWidth }}
+                initial={false}
+                transition={{ type: 'tween', duration: 0.3 }}
+                hidden={!activeItemId}
+                className={merge([
+                    'tw-absolute tw-h-9 tw-border tw-rounded tw-pointer-events-none tw-z-10',
+                    disabled ? 'tw-border-line-x-strong tw-bg-box-disabled' : 'tw-border-line-xx-strong',
+                ])}
+            />
             <fieldset
                 {...radioGroupProps}
                 data-test-id="fondue-segmented-controls"
@@ -185,18 +199,6 @@ export const SegmentedControls = ({
                     alignment,
                 ])}
             >
-                <motion.div
-                    aria-hidden="true"
-                    // div border is not included in width so it must be subtracted from translation.
-                    animate={{ x: sliderTranslation, width: sliderWidth }}
-                    initial={false}
-                    transition={{ type: 'tween', duration: 0.3 }}
-                    hidden={!activeItemId}
-                    className={merge([
-                        'tw-absolute tw--inset-px tw-h-full tw-box-content tw-border tw-rounded tw-pointer-events-none',
-                        disabled ? 'tw-border-line-x-strong tw-bg-box-disabled' : 'tw-border-line-xx-strong tw-bg-base',
-                    ])}
-                />
                 {itemElements}
             </fieldset>
         </div>

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -163,7 +163,7 @@ export const SegmentedControls = ({
     const alignment = hugWidth ? 'tw-flex' : 'tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly';
 
     const getSliderX = () => {
-        let translateX = -1;
+        let translateX = 0;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }
@@ -171,7 +171,7 @@ export const SegmentedControls = ({
     };
 
     const sliderWidth = hugWidth ? `${itemsRef.current[selectedIndex]?.clientWidth}px` : `${100 / items.length}%`;
-    const sliderTranslation = hugWidth ? getSliderX() : `calc(${100 * selectedIndex}% - ${1.2 * selectedIndex}px)`;
+    const sliderTranslation = hugWidth ? getSliderX() : `calc(${100 * selectedIndex}% - ${selectedIndex}px)`;
 
     return (
         <div className="tw-flex">

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -164,7 +164,7 @@ export const SegmentedControls = ({
 
     const getSliderX = () => {
         const isLastElement = selectedIndex === itemsRef.current.length - 1;
-        let translateX = isLastElement ? 0 : -1;
+        let translateX = isLastElement && !hugWidth ? 0 : -1;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -163,7 +163,8 @@ export const SegmentedControls = ({
     const alignment = hugWidth ? 'tw-flex' : 'tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly';
 
     const getSliderX = () => {
-        let translateX = size === 'small' ? -1 : 0;
+        const isLastElement = selectedIndex === itemsRef.current.length - 1;
+        let translateX = isLastElement ? 0 : -1;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }


### PR DESCRIPTION
Active border not properly aligned in `Segmented Controls`.  This fix adjusts the calculation of its position by removing multiplier and initiated `translateX` value, moving the `motion.div` outside the `Fieldset` and updating the element stying.

Bug Repot: https://frontify.slack.com/archives/C02PSJTPA3D/p1693467213832059

ClickUp: https://app.clickup.com/t/8692mtd17
