### PR TITLE
fix(Accordion): update focus styling to include header

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -34,7 +34,7 @@ const AriaAccordionItem = ({
         <div
             key={item.key}
             className={merge([
-                isFocusVisible ? `${FOCUS_STYLE_NO_OFFSET} tw-relative` : '',
+                isFocusVisible ? `${FOCUS_STYLE_NO_OFFSET} tw-relative tw-rounded` : '',
                 divider && 'tw-divide-y tw-divide-black-10',
             ])}
         >
@@ -65,7 +65,7 @@ const AriaAccordionItem = ({
                 <HeaderComponent isOpen={isOpen} {...headerProps} />
             </button>
             <CollapsibleWrap isOpen={isOpen} preventInitialAnimation={active}>
-                <div {...regionProps} className={merge([padding && 'tw-px-8 tw-pb-6', 'tw-mt-1'])}>
+                <div {...regionProps} className={merge([padding && 'tw-px-8 tw-pb-6', 'tw-mt-2'])}>
                     {item.props.children?.()}
                 </div>
             </CollapsibleWrap>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -6,7 +6,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { Item as StatelyItem } from '@react-stately/collections';
 import { useTreeState } from '@react-stately/tree';
-import { FOCUS_STYLE } from '@utilities/focusStyle';
+import { FOCUS_STYLE_NO_OFFSET } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Children, Key, KeyboardEvent, ReactElement, ReactNode, isValidElement, useEffect, useRef } from 'react';
 import { AccordionHeader } from './AccordionHeader';
@@ -34,7 +34,7 @@ const AriaAccordionItem = ({
         <div
             key={item.key}
             className={merge([
-                isFocusVisible ? `${FOCUS_STYLE} tw-relative` : '',
+                isFocusVisible ? `${FOCUS_STYLE_NO_OFFSET} tw-relative` : '',
                 divider && 'tw-divide-y tw-divide-black-10',
             ])}
         >
@@ -65,7 +65,7 @@ const AriaAccordionItem = ({
                 <HeaderComponent isOpen={isOpen} {...headerProps} />
             </button>
             <CollapsibleWrap isOpen={isOpen} preventInitialAnimation={active}>
-                <div {...regionProps} className={merge([padding && 'tw-px-8 tw-pb-6'])}>
+                <div {...regionProps} className={merge([padding && 'tw-px-8 tw-pb-6', 'tw-mt-1'])}>
                     {item.props.children?.()}
                 </div>
             </CollapsibleWrap>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -6,7 +6,7 @@ import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { Item as StatelyItem } from '@react-stately/collections';
 import { useTreeState } from '@react-stately/tree';
-import { FOCUS_STYLE_INSET } from '@utilities/focusStyle';
+import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { Children, Key, KeyboardEvent, ReactElement, ReactNode, isValidElement, useEffect, useRef } from 'react';
 import { AccordionHeader } from './AccordionHeader';
@@ -33,7 +33,10 @@ const AriaAccordionItem = ({
     return (
         <div
             key={item.key}
-            className={merge([isFocusVisible ? FOCUS_STYLE_INSET : '', divider && 'tw-divide-y tw-divide-black-10'])}
+            className={merge([
+                isFocusVisible ? `${FOCUS_STYLE} tw-relative` : '',
+                divider && 'tw-divide-y tw-divide-black-10',
+            ])}
         >
             <button
                 {...mergeProps(buttonProps, focusProps)}
@@ -154,7 +157,7 @@ export const Accordion = (props: AccordionProps): ReactElement => {
         const key = (event.target as HTMLButtonElement).dataset.key;
         const isFocused = state.selectionManager.focusedKey === key;
         if (key && isFocused) {
-            onKeyDown && onKeyDown(event);
+            onKeyDown?.(event);
         }
     };
 

--- a/src/utilities/focusStyle.ts
+++ b/src/utilities/focusStyle.ts
@@ -3,6 +3,7 @@
 import { merge } from './merge';
 
 export const FOCUS_STYLE = 'tw-ring-4 tw-ring-blue tw-ring-offset-2 dark:tw-ring-offset-black tw-outline-none';
+export const FOCUS_STYLE_NO_OFFSET = 'tw-ring-4 tw-ring-blue dark:tw-ring-offset-black tw-outline-none';
 export const FOCUS_VISIBLE_STYLE =
     'focus-visible:tw-ring-4 focus-visible:tw-ring-blue focus-visible:tw-ring-offset-2 focus-visible:dark:tw-ring-offset-black focus-visible:tw-outline-none';
 export const FOCUS_STYLE_INSET = merge([FOCUS_STYLE, 'tw-ring-inset']);


### PR DESCRIPTION
Update to the `FOCUS_STYLE` properties on the `Accordion` to wrap all elements and not just collapsible content.  

Secondly, because the neighbouring `div` has a `button` child, the focused element needs to be set to `position: relative` to allow for the z-index to take priority and not be overlapped.

Bug Report: https://frontify.slack.com/archives/C02PSJTPA3D/p1689079198399909

ClickUp: https://app.clickup.com/t/862k4a2gm