### PR TITLE
[WIP]feat(Dropdown): open to opposite direction if there is no space

### DIFF
--- a/src/components/Dropdown/Dropdown.cy.tsx
+++ b/src/components/Dropdown/Dropdown.cy.tsx
@@ -173,7 +173,7 @@ describe('Dropdown Component', () => {
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const { bottom } = $el[0].getBoundingClientRect();
-            expect(Number(bottom.toFixed(0))).to.equal(220 - 8);
+            expect(Number(bottom.toFixed(0))).to.equal(220 - 16);
         });
     });
 
@@ -197,7 +197,7 @@ describe('Dropdown Component', () => {
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const height = $el[0].clientHeight;
-            expect(height).to.equal(109);
+            expect(height).to.equal(101);
         });
     });
 
@@ -211,7 +211,7 @@ describe('Dropdown Component', () => {
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const height = $el[0].clientHeight;
-            expect(height).to.equal(109);
+            expect(height).to.equal(101);
         });
         cy.get(TOP_DROPDOWN_ID).should('exist');
     });

--- a/src/components/Dropdown/Dropdown.cy.tsx
+++ b/src/components/Dropdown/Dropdown.cy.tsx
@@ -18,6 +18,7 @@ const MENU_ITEM_ID = '[data-test-id=menu-item]';
 const MENU_ITEM_ACTIVE_ID = '[data-test-id=menu-item-active]';
 const MENU_ITEM_TITLE_ID = '[data-test-id=menu-item-title]';
 const EXCLAMATION_MARK_ICON_ID = '[data-test-id=error-state-exclamation-mark-icon]';
+const TOP_DROPDOWN_ID = '[data-popper-placement=top-start]';
 
 const ITEMS = [
     {
@@ -63,6 +64,7 @@ type Props = {
     decorator?: ReactElement;
     autoResize?: boolean;
     validation?: Validation;
+    flip?: boolean;
 };
 
 const Component = ({
@@ -74,6 +76,7 @@ const Component = ({
     decorator,
     autoResize = true,
     validation = Validation.Default,
+    flip = false,
 }: Props): ReactElement => {
     const [activeItemId, setActiveItemId] = useState(initialActiveId);
     return (
@@ -87,6 +90,7 @@ const Component = ({
             decorator={decorator}
             autoResize={autoResize}
             validation={validation}
+            flip={flip}
         />
     );
 };
@@ -187,14 +191,29 @@ describe('Dropdown Component', () => {
         });
     });
 
-    it('should have a minimum height of 130px', () => {
+    it('should shrink height so it does not overflow', () => {
         cy.viewport(550, 160);
         cy.mount(<Component menuBlocks={ITEMS} decorator={<IconIcon />} />);
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const height = $el[0].clientHeight;
-            expect(height).to.equal(130);
+            expect(height).to.equal(84);
         });
+    });
+
+    it('should open to top and shrink so it does not overflow', () => {
+        cy.viewport(550, 160);
+        cy.mount(
+            <div style={{ height: 160, display: 'flex', alignItems: 'flex-end' }}>
+                <Component flip menuBlocks={ITEMS} decorator={<IconIcon />} />
+            </div>,
+        );
+        cy.get(DROPDOWN_TRIGGER_ID).click();
+        cy.get(DROPDOWN_MENU_ID).then(($el) => {
+            const height = $el[0].clientHeight;
+            expect(height).to.equal(84);
+        });
+        cy.get(TOP_DROPDOWN_ID).should('exist');
     });
 
     it('should open dropdown on click next to the caret icon', () => {

--- a/src/components/Dropdown/Dropdown.cy.tsx
+++ b/src/components/Dropdown/Dropdown.cy.tsx
@@ -173,7 +173,7 @@ describe('Dropdown Component', () => {
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const { bottom } = $el[0].getBoundingClientRect();
-            expect(Number(bottom.toFixed(0))).to.equal(220 - 33);
+            expect(Number(bottom.toFixed(0))).to.equal(220 - 8);
         });
     });
 
@@ -197,7 +197,7 @@ describe('Dropdown Component', () => {
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const height = $el[0].clientHeight;
-            expect(height).to.equal(84);
+            expect(height).to.equal(109);
         });
     });
 
@@ -211,7 +211,7 @@ describe('Dropdown Component', () => {
         cy.get(DROPDOWN_TRIGGER_ID).click();
         cy.get(DROPDOWN_MENU_ID).then(($el) => {
             const height = $el[0].clientHeight;
-            expect(height).to.equal(84);
+            expect(height).to.equal(109);
         });
         cy.get(TOP_DROPDOWN_ID).should('exist');
     });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -188,7 +188,7 @@ export const Dropdown = ({
         ['Bottom-End']: 'bottom-end',
     };
     const popperInstance = usePopper(triggerRef?.current, dropdownRef.current, {
-        placement: placementMap[`${adjustedPosition}-${alignment}`],
+        placement: placementMap[`${position}-${alignment}`],
         strategy: 'fixed',
         modifiers: [
             {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -155,7 +155,14 @@ export const Dropdown = ({
             return DropdownPosition.Bottom;
         }
     })();
-    const adjustedMaxHeight = adjustedPosition === DropdownPosition.Top ? maxHeight.toTop : maxHeight.toBottom;
+
+    const adjustedMaxHeight = (() => {
+        if (flip) {
+            return adjustedPosition === DropdownPosition.Top ? maxHeight.toTop : maxHeight.toBottom;
+        } else {
+            return position === DropdownPosition.Top ? maxHeight.toTop : maxHeight.toBottom;
+        }
+    })();
 
     const heightIsReady = !autoResize || maxHeight.toBottom || maxHeight.toTop;
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -136,11 +136,11 @@ export const Dropdown = ({
     const spaceAvailableToTop = maxHeight.toTop ?? 0;
     const spaceAvailableToBottom = maxHeight.toBottom ?? 0;
 
-    const hasTopMoreSpaceThanBottom = spaceAvailableToTop > spaceAvailableToBottom;
-    const hasBottomMoreSpaceThanTop = !hasTopMoreSpaceThanBottom;
+    const isTopSpaceLarger = spaceAvailableToTop > spaceAvailableToBottom;
+    const isBottomSpaceLarger = !isTopSpaceLarger;
 
-    const canOpenToBottom = spaceAvailableToBottom >= minimumSpaceNeededToOpen || hasBottomMoreSpaceThanTop;
-    const canOpenToTop = maxHeight.toTop && (maxHeight.toTop >= minimumSpaceNeededToOpen || hasTopMoreSpaceThanBottom);
+    const canOpenToBottom = spaceAvailableToBottom >= minimumSpaceNeededToOpen || isBottomSpaceLarger;
+    const canOpenToTop = maxHeight.toTop && (maxHeight.toTop >= minimumSpaceNeededToOpen || isTopSpaceLarger);
 
     const adjustedPosition = (() => {
         if (position === DropdownPosition.Bottom) {
@@ -149,12 +149,10 @@ export const Dropdown = ({
             } else {
                 return DropdownPosition.Top;
             }
+        } else if (canOpenToTop || !canOpenToBottom) {
+            return DropdownPosition.Top;
         } else {
-            if (canOpenToTop || !canOpenToBottom) {
-                return DropdownPosition.Top;
-            } else {
-                return DropdownPosition.Bottom;
-            }
+            return DropdownPosition.Bottom;
         }
     })();
     const adjustedMaxHeight = adjustedPosition === DropdownPosition.Top ? maxHeight.toTop : maxHeight.toBottom;

--- a/src/components/InlineDialog/InlineDialog.cy.tsx
+++ b/src/components/InlineDialog/InlineDialog.cy.tsx
@@ -271,7 +271,7 @@ describe('InlineDialog Component', () => {
             cy.mount(<InlineDialogComponent autoHeight={true} maxHeight={100} />);
             cy.get(INLINE_DIALOG_TRIGGER_SELECTOR).children().eq(0).click();
             cy.viewport(550, 150);
-            cy.get(INLINE_DIALOG_SELECTOR).should('have.css', 'height', '98px');
+            cy.get(INLINE_DIALOG_SELECTOR).should('have.css', 'height', '90px');
         });
     });
 

--- a/src/components/InlineDialog/InlineDialog.cy.tsx
+++ b/src/components/InlineDialog/InlineDialog.cy.tsx
@@ -271,7 +271,7 @@ describe('InlineDialog Component', () => {
             cy.mount(<InlineDialogComponent autoHeight={true} maxHeight={100} />);
             cy.get(INLINE_DIALOG_TRIGGER_SELECTOR).children().eq(0).click();
             cy.viewport(550, 150);
-            cy.get(INLINE_DIALOG_SELECTOR).should('have.css', 'height', '130px');
+            cy.get(INLINE_DIALOG_SELECTOR).should('have.css', 'height', '98px');
         });
     });
 

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -298,7 +298,7 @@ export const LinkChooser = ({
                             popoverRef={popoverRef}
                             isOpen={matches(LinkChooserState.Focused)}
                             onClose={handleDropdownClose}
-                            maxHeight={maxHeight}
+                            maxHeight={`${maxHeight.toBottom}px`}
                         >
                             <SearchResultsList
                                 {...listBoxProps}

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -298,7 +298,7 @@ export const LinkChooser = ({
                             popoverRef={popoverRef}
                             isOpen={matches(LinkChooserState.Focused)}
                             onClose={handleDropdownClose}
-                            maxHeight={`${maxHeight.toBottom}px`}
+                            maxHeight={maxHeight.toBottom !== undefined ? `${maxHeight.toBottom}px` : 'auto'}
                         >
                             <SearchResultsList
                                 {...listBoxProps}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -13,7 +13,7 @@ import { getPaddingClasses } from './helpers';
 import { useClickOutside } from '@hooks/useClickOutside';
 import { CheckboxState } from '@components/Checkbox/Checkbox';
 import { usePopper } from 'react-popper';
-import { DEFAULT_DROPDOWN_MAX_HEIGHT, useDropdownAutoHeight } from '@hooks/useDropdownAutoHeight';
+import { useDropdownAutoHeight } from '@hooks/useDropdownAutoHeight';
 import { EnablePortalWrapper } from '@utilities/dialogs/EnablePortalWrapper';
 
 export enum MultiSelectType {
@@ -99,7 +99,7 @@ export const MultiSelect = ({
 
     useClickOutside(null, handleClose, [multiSelectRef?.current as HTMLElement, multiSelectMenuRef as HTMLElement]);
 
-    const heightIsReady = maxHeight !== DEFAULT_DROPDOWN_MAX_HEIGHT;
+    const heightIsReady = maxHeight.toBottom !== undefined;
 
     const toggleOpen = () => setOpen((open) => !open);
 
@@ -250,7 +250,7 @@ export const MultiSelect = ({
                         <FocusScope restoreFocus>
                             <div
                                 className="tw-p-4 tw-overflow-y-auto tw-overflow-x-hidden tw-w-full tw-relative"
-                                style={{ maxHeight }}
+                                style={{ maxHeight: maxHeight.toBottom }}
                             >
                                 <Checklist
                                     activeValues={activeItemKeys.map((key) => key.toString())}

--- a/src/hooks/useDropdownAutoHeight.ts
+++ b/src/hooks/useDropdownAutoHeight.ts
@@ -2,8 +2,6 @@
 
 import { MutableRefObject, useLayoutEffect, useState } from 'react';
 
-export const DEFAULT_DROPDOWN_MAX_HEIGHT = 'auto';
-
 type DropdownAutoHeightProps = {
     isOpen: boolean;
     autoResize?: boolean;
@@ -11,13 +9,14 @@ type DropdownAutoHeightProps = {
 };
 
 export const getInnerOverlayHeight = (triggerRef: MutableRefObject<HTMLElement | null>) => {
-    let maxHeight = 'auto';
+    const maxHeight: { toTop?: number; toBottom?: number } = {};
     if (triggerRef.current) {
         const { innerHeight } = window;
-        const { bottom } = triggerRef.current.getBoundingClientRect();
+        const { bottom, top } = triggerRef.current.getBoundingClientRect();
         const viewportPadding = 33;
         const triggerMargin = 8;
-        maxHeight = `${Math.max(innerHeight - (bottom + viewportPadding + triggerMargin), 130)}px`;
+        maxHeight.toBottom = innerHeight - (bottom + viewportPadding + triggerMargin);
+        maxHeight.toTop = top - (viewportPadding + triggerMargin);
     }
     return maxHeight;
 };
@@ -26,14 +25,14 @@ export const useDropdownAutoHeight = (
     triggerRef: MutableRefObject<HTMLElement | null>,
     { isOpen, autoResize }: DropdownAutoHeightProps,
 ) => {
-    const [maxHeight, setMaxHeight] = useState(DEFAULT_DROPDOWN_MAX_HEIGHT);
+    const [maxHeight, setMaxHeight] = useState<{ toTop?: number; toBottom?: number }>({});
     useLayoutEffect(() => {
         const updateMaxHeight = () => setMaxHeight(getInnerOverlayHeight(triggerRef));
         if (autoResize && isOpen) {
             updateMaxHeight();
             window.addEventListener('resize', updateMaxHeight);
         } else if (autoResize && !isOpen) {
-            setMaxHeight(DEFAULT_DROPDOWN_MAX_HEIGHT);
+            setMaxHeight({});
         }
 
         return () => {
@@ -41,7 +40,7 @@ export const useDropdownAutoHeight = (
                 window.removeEventListener('resize', updateMaxHeight);
             }
         };
-    }, [isOpen, autoResize, triggerRef]);
+    }, [isOpen, autoResize]);
 
     return { maxHeight };
 };

--- a/src/hooks/useDropdownAutoHeight.ts
+++ b/src/hooks/useDropdownAutoHeight.ts
@@ -18,7 +18,7 @@ export const getInnerOverlayHeight = (triggerRef: MutableRefObject<HTMLElement |
     if (triggerRef.current) {
         const { innerHeight } = window;
         const { bottom, top } = triggerRef.current.getBoundingClientRect();
-        const viewportPadding = 33;
+        const viewportPadding = 8;
         const triggerMargin = 8;
         maxHeight.toBottom = innerHeight - (bottom + viewportPadding + triggerMargin);
         maxHeight.toTop = top - (viewportPadding + triggerMargin);

--- a/src/hooks/useDropdownAutoHeight.ts
+++ b/src/hooks/useDropdownAutoHeight.ts
@@ -8,8 +8,13 @@ type DropdownAutoHeightProps = {
     isDialog?: boolean;
 };
 
+type AvailableSpace = {
+    toTop?: number;
+    toBottom?: number;
+};
+
 export const getInnerOverlayHeight = (triggerRef: MutableRefObject<HTMLElement | null>) => {
-    const maxHeight: { toTop?: number; toBottom?: number } = {};
+    const maxHeight: AvailableSpace = {};
     if (triggerRef.current) {
         const { innerHeight } = window;
         const { bottom, top } = triggerRef.current.getBoundingClientRect();
@@ -25,7 +30,7 @@ export const useDropdownAutoHeight = (
     triggerRef: MutableRefObject<HTMLElement | null>,
     { isOpen, autoResize }: DropdownAutoHeightProps,
 ) => {
-    const [maxHeight, setMaxHeight] = useState<{ toTop?: number; toBottom?: number }>({});
+    const [maxHeight, setMaxHeight] = useState<AvailableSpace>({});
     useLayoutEffect(() => {
         const updateMaxHeight = () => setMaxHeight(getInnerOverlayHeight(triggerRef));
         if (autoResize && isOpen) {

--- a/src/hooks/useDropdownAutoHeight.ts
+++ b/src/hooks/useDropdownAutoHeight.ts
@@ -18,7 +18,7 @@ export const getInnerOverlayHeight = (triggerRef: MutableRefObject<HTMLElement |
     if (triggerRef.current) {
         const { innerHeight } = window;
         const { bottom, top } = triggerRef.current.getBoundingClientRect();
-        const viewportPadding = 8;
+        const viewportPadding = 16;
         const triggerMargin = 8;
         maxHeight.toBottom = innerHeight - (bottom + viewportPadding + triggerMargin);
         maxHeight.toTop = top - (viewportPadding + triggerMargin);

--- a/src/utilities/dialogs/Overlay.tsx
+++ b/src/utilities/dialogs/Overlay.tsx
@@ -44,7 +44,7 @@ export const Overlay = ({
         { isOpen: open, autoResize: true },
     );
 
-    const maxContentHeight = autoHeight ? maxAutoHeight : maxHeight;
+    const maxContentHeight = autoHeight ? maxAutoHeight.toBottom : maxHeight;
     const handleClosingInteraction = useCallback(() => {
         if (open && modality !== Modality.BlockingModal) {
             if (handleClose) {

--- a/src/utilities/dialogs/Overlay.tsx
+++ b/src/utilities/dialogs/Overlay.tsx
@@ -44,7 +44,7 @@ export const Overlay = ({
         { isOpen: open, autoResize: true },
     );
 
-    const maxContentHeight = autoHeight ? maxAutoHeight.toBottom : maxHeight;
+    const maxContentHeight = autoHeight ? maxAutoHeight.toBottom ?? 'auto' : maxHeight;
     const handleClosingInteraction = useCallback(() => {
         if (open && modality !== Modality.BlockingModal) {
             if (handleClose) {


### PR DESCRIPTION
The dropdown component always opened to the direction specified by the `position` prop, even if there was not enough space.

This PR proposes to automatically open to top if there is not at least 130px available space below the trigger.

Tests have not been modified yet.