### PR TITLE
fix(Textarea): add focus on click handler

### DIFF
--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -97,6 +97,7 @@ export const Textarea = ({
                         onInput && onInput((event.target as HTMLTextAreaElement).value),
                 }) as TextareaAutosizeProps)}
                 {...(autosize ? autosizeProps : { rows: minRows })}
+                onClick={() => textareaElement.current?.focus()}
                 id={useMemoizedId(propId)}
                 ref={textareaElement}
                 value={value}


### PR DESCRIPTION
Reported here:  https://app.clickup.com/t/8692yd696

`Textarea` cased accessibility issues when nested in a `Accordion`.  It was missing a `focus` handler in the `onClick` event.