### PR TITLE
fix: change the type by which are children filtered

### DIFF
--- a/src/components/Popper/Popper.tsx
+++ b/src/components/Popper/Popper.tsx
@@ -23,6 +23,7 @@ export const Popper = ({
     verticalAlignment,
     strategy = 'absolute',
 }: PopperProps) => {
+    const arrayChildren = Children.toArray(children);
     const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null);
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
     const [popperDimensions, setPopperDimensions] = useState({
@@ -42,6 +43,7 @@ export const Popper = ({
         strategy,
     });
 
+    console.log(arrayChildren);
     useEffect(() => {
         const updatePopper = async () => {
             if (popperInstance.update) {
@@ -73,13 +75,15 @@ export const Popper = ({
         <>
             {Children.map(children, (child) => {
                 if (isValidElement(child) && typeof child.type === 'function') {
-                    const { name } = child.type;
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore Property 'displayName' does not exist on type 'JSXElementConstructor<any>'.ts(2339)
+                    const { displayName } = child.type;
 
-                    if (name === Trigger.name) {
+                    if (displayName === Trigger.name) {
                         return <div ref={setReferenceElement}>{child}</div>;
                     }
 
-                    if (name === Content.name && open) {
+                    if (displayName === Content.name && open) {
                         return enablePortal ? (
                             <Portal>
                                 <div

--- a/src/components/Popper/Popper.tsx
+++ b/src/components/Popper/Popper.tsx
@@ -23,7 +23,6 @@ export const Popper = ({
     verticalAlignment,
     strategy = 'absolute',
 }: PopperProps) => {
-    const arrayChildren = Children.toArray(children);
     const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null);
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
     const [popperDimensions, setPopperDimensions] = useState({
@@ -43,7 +42,6 @@ export const Popper = ({
         strategy,
     });
 
-    console.log(arrayChildren);
     useEffect(() => {
         const updatePopper = async () => {
             if (popperInstance.update) {

--- a/src/components/Popper/Popper.tsx
+++ b/src/components/Popper/Popper.tsx
@@ -79,11 +79,11 @@ export const Popper = ({
                     // @ts-ignore Property 'displayName' does not exist on type 'JSXElementConstructor<any>'.ts(2339)
                     const { displayName } = child.type;
 
-                    if (displayName === Trigger.name) {
+                    if (displayName === Trigger.displayName) {
                         return <div ref={setReferenceElement}>{child}</div>;
                     }
 
-                    if (displayName === Content.name && open) {
+                    if (displayName === Content.displayName && open) {
                         return enablePortal ? (
                             <Portal>
                                 <div


### PR DESCRIPTION
It turns out that our app build has is optimized for production which includes also minification. All of our component names and types have now been minified to something that is completely unpredictable. 
For that purposes I used displayName which we already set and will be the same also in production environment.