### PR TITLE
fix(SegmentedControls): correct text color when disabled

### DIFF
--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -103,10 +103,10 @@ const SegmentedControlsItem = forwardRef<HTMLDivElement, SegmentedControlsItemPr
                     size === 'small' ? 'tw-px-2' : 'tw-px-4',
                     isActive && !disabled
                         ? 'tw-text-text tw-bg-base tw-ease-in tw-duration-300'
-                        : 'tw-text-text-weak tw-ease-out tw-duration-100',
-                    !disabled
-                        ? 'hover:tw-text-text hover:tw-cursor-pointer'
-                        : 'tw-text-box-disabled-inverse hover:tw-cursor-not-allowed',
+                        : 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-ease-out tw-duration-100',
+                    disabled
+                        ? 'tw-text-box-disabled-inverse hover:tw-cursor-not-allowed'
+                        : 'hover:tw-text-text hover:tw-cursor-pointer',
                 ])}
             >
                 <VisuallyHidden>
@@ -194,7 +194,7 @@ export const SegmentedControls = ({
                 hidden={!activeItemId}
                 className={merge([
                     'tw-absolute tw-h-9 tw-border tw-rounded tw-pointer-events-none tw-z-10',
-                    disabled ? 'tw-border-line-x-strong tw-bg-box-disabled' : 'tw-border-line-xx-strong',
+                    disabled ? 'tw-border-line-x-strong hover:tw-cursor-not-allowed' : 'tw-border-line-xx-strong',
                 ])}
             />
             <fieldset

--- a/src/components/SegmentedControls/Slider.stories.tsx
+++ b/src/components/SegmentedControls/Slider.stories.tsx
@@ -13,6 +13,10 @@ export default {
     argTypes: {
         id: { type: 'string' },
         hugWidth: { type: 'boolean' },
+        disabled: {
+            control: { type: 'boolean' },
+        },
+        size: { control: { type: 'select' }, options: ['small', 'medium'] },
     },
     args: {
         disabled: false,


### PR DESCRIPTION
Reported Bug: https://app.clickup.com/t/8692ztja2

Style logic was not correct and made the active elements `text` color the same as the `bg` color making it invisible.  This corrects this.

## Definition of Done
- [x] User interface and experience have been verified by a designer
- [x] I have added thorough Cypress tests (All properties and interactions have been tested).
- [x] Cross-browser compatibility - The component look consistent in the latest version of Chrome, Safari, Firefox and Edge.
- [x] I've added documentation in Storybook. all properties are reflected in table and controls.
- [x] User interface is compliant with WCAG 2.1 AA. Ensure these items are fulfilled:
    - [x] Keyboard operability: All functionality can be accessed using only the keyboard
    - [x] Logical tab order: Interactive elements follow a consistent and logical tab order
    - [x] Visual indication of focus: Focused elements are visually highlighted for keyboard navigation
    - [x] Color contrast: Sufficient contrast is used between text and background, as well as form fields and background
    - [x] Alternative visual cues: Information is not solely reliant on color and includes alternative visual indicators
    - [x] Semantic markup: Headings, lists, and form elements are marked up with appropriate semantic tags
