### PR TITLE
fix(SegmentedControls): hook and state to set active border dimensions

### DIFF
--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -147,10 +147,7 @@ export const SegmentedControls = ({
     const radioGroupState = useRadioGroupState(groupProps);
     const { radioGroupProps } = useRadioGroup(groupProps, radioGroupState);
     const itemsRef = useRef<(HTMLDivElement | null)[]>([]);
-    const [activeBorderDimensions, setActiveBorderDimensions] = useState<{ x: string; width: string }>({
-        x: '0px',
-        width: '0px',
-    });
+    const [activeBorderDimensions, setActiveBorderDimensions] = useState<{ x: string; width: string } | null>(null);
     const itemElements = useMemo(() => {
         return items.map((item, index) => (
             <SegmentedControlsItem
@@ -186,22 +183,27 @@ export const SegmentedControls = ({
     }, [isSmallOrHugWidth, selectedIndex]);
 
     useEffect(() => {
-        setActiveBorderDimensions({ x: getSliderX(), width: getSliderWidth() });
         function handleResize() {
             setActiveBorderDimensions({ x: getSliderX(), width: getSliderWidth() });
         }
+
+        if (!activeBorderDimensions) {
+            handleResize();
+        }
+
         window.addEventListener('resize', handleResize);
+
         return () => {
             window.removeEventListener('resize', handleResize);
         };
-    }, [setActiveBorderDimensions, getSliderWidth, getSliderX]);
+    }, [activeBorderDimensions, setActiveBorderDimensions, getSliderWidth, getSliderX]);
 
     return (
         <div className="tw-flex">
             <motion.div
                 aria-hidden="true"
                 // div border is not included in width so it must be subtracted from translation.
-                animate={activeBorderDimensions}
+                animate={activeBorderDimensions ?? { x: '0px', width: '0px' }}
                 initial={false}
                 transition={{ type: 'tween', duration: 0.3 }}
                 hidden={!activeItemId}

--- a/src/components/SegmentedControls/SegmentedControls.tsx
+++ b/src/components/SegmentedControls/SegmentedControls.tsx
@@ -101,11 +101,9 @@ const SegmentedControlsItem = forwardRef<HTMLDivElement, SegmentedControlsItemPr
                 className={merge([
                     'tw-relative tw-w-full tw-py-2 tw-inline-flex tw-justify-center tw-items-center tw-font-sans tw-font-normal tw-h-full tw-text-center',
                     size === 'small' ? 'tw-px-2' : 'tw-px-4',
-                    isActive && !disabled
-                        ? 'tw-text-text tw-bg-base tw-ease-in tw-duration-300'
-                        : 'tw-bg-box-disabled tw-text-box-disabled-inverse tw-ease-out tw-duration-100',
+                    isActive && !disabled ? 'tw-text-text' : 'tw-text-text-weak',
                     disabled
-                        ? 'tw-text-box-disabled-inverse hover:tw-cursor-not-allowed'
+                        ? 'tw-text-box-disabled-inverse tw-bg-box-disabled hover:tw-cursor-not-allowed'
                         : 'hover:tw-text-text hover:tw-cursor-pointer',
                 ])}
             >
@@ -165,53 +163,38 @@ export const SegmentedControls = ({
     const width = hugWidth ? '' : 'tw-w-full';
     const alignment = hugWidth ? 'tw-flex' : 'tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly';
 
-    const isSmallOrHugWidth = size === 'small' || hugWidth;
     const getSliderX = useCallback(() => {
+        const isSmallOrHugWidth = size === 'small' || hugWidth;
         let translateX = isSmallOrHugWidth ? -1 : 0;
         for (let i = 0; i < selectedIndex; i++) {
             translateX += itemsRef.current[i]?.clientWidth ?? 0;
         }
+
         return `${translateX}px`;
-    }, [isSmallOrHugWidth, selectedIndex]);
+    }, [hugWidth, selectedIndex, size]);
 
     const getSliderWidth = useCallback(() => {
         const isLastElement = selectedIndex === itemsRef.current.length - 1;
-        const baseValue = isSmallOrHugWidth ? 1 : 2;
-        const width = isLastElement ? baseValue + 1 : baseValue;
+        const width = isLastElement ? 1 : -1;
 
         return `${(itemsRef.current[selectedIndex]?.clientWidth ?? 0) + width}px`;
-    }, [isSmallOrHugWidth, selectedIndex]);
+    }, [selectedIndex]);
+
+    const setSliderDimensions = () => {
+        setActiveBorderDimensions({ x: getSliderX(), width: getSliderWidth() });
+    };
 
     useEffect(() => {
-        function handleResize() {
-            setActiveBorderDimensions({ x: getSliderX(), width: getSliderWidth() });
-        }
-
-        if (!activeBorderDimensions) {
-            handleResize();
-        }
-
-        window.addEventListener('resize', handleResize);
+        setSliderDimensions();
+        window.addEventListener('resize', setSliderDimensions);
 
         return () => {
-            window.removeEventListener('resize', handleResize);
+            window.removeEventListener('resize', setSliderDimensions);
         };
-    }, [activeBorderDimensions, setActiveBorderDimensions, getSliderWidth, getSliderX]);
+    });
 
     return (
         <div className="tw-flex">
-            <motion.div
-                aria-hidden="true"
-                // div border is not included in width so it must be subtracted from translation.
-                animate={activeBorderDimensions ?? { x: '0px', width: '0px' }}
-                initial={false}
-                transition={{ type: 'tween', duration: 0.3 }}
-                hidden={!activeItemId}
-                className={merge([
-                    'tw-absolute tw-h-9 tw-border tw-rounded tw-pointer-events-none tw-z-10',
-                    disabled ? 'tw-border-line-x-strong hover:tw-cursor-not-allowed' : 'tw-border-line-xx-strong',
-                ])}
-            />
             <fieldset
                 {...radioGroupProps}
                 data-test-id="fondue-segmented-controls"
@@ -221,6 +204,20 @@ export const SegmentedControls = ({
                     alignment,
                 ])}
             >
+                <motion.div
+                    aria-hidden="true"
+                    // div border is not included in width so it must be subtracted from translation.
+                    animate={activeBorderDimensions ?? { x: '0px', width: '0px' }}
+                    initial={false}
+                    transition={{ type: 'tween', duration: 0.3 }}
+                    hidden={!activeItemId}
+                    className={merge([
+                        'tw-absolute tw--inset-px tw-h-full tw-box-content tw-border tw-rounded tw-pointer-events-none',
+                        disabled
+                            ? 'tw-border-line-x-strong hover:tw-cursor-not-allowed'
+                            : 'tw-border-line-xx-strong tw-bg-base',
+                    ])}
+                />
                 {itemElements}
             </fieldset>
         </div>


### PR DESCRIPTION
Reported Bug: https://app.clickup.com/t/8692zxk9b

Active border does not resize one window resize.  This updated the reference of the dimension object to a `state` variable and adds a `useEffect` hook to update the `state` when window is resized.