### PR TITLE
feat: passed callback prop

### DIFF
--- a/src/hooks/useToggleOverlay.ts
+++ b/src/hooks/useToggleOverlay.ts
@@ -4,19 +4,23 @@ import { useCallback, useEffect, useState } from 'react';
 
 export const useToggleOverlay = (
     initialState = false,
-    { isBlockingModal }: { isBlockingModal?: boolean } = { isBlockingModal: false },
+    { isBlockingModal, callback }: { isBlockingModal?: boolean; callback?: () => void } = { isBlockingModal: false },
 ): [boolean, (value: boolean) => void] => {
     const [open, setOpen] = useState<boolean>(initialState);
+
     const checkKeyboardEvent = useCallback(
         (event: KeyboardEvent) => {
+            const callbackFnc = typeof callback === 'function' ? callback : () => ({});
+
             if (open) {
                 event.stopPropagation();
             }
             if (open && !isBlockingModal && event.key === 'Escape') {
                 setOpen(false);
+                callbackFnc();
             }
         },
-        [isBlockingModal, open],
+        [callback, isBlockingModal, open],
     );
 
     useEffect(() => {
@@ -27,6 +31,5 @@ export const useToggleOverlay = (
         };
     }, [checkKeyboardEvent, isBlockingModal]);
 
-    const handler = useCallback((value: boolean): void => setOpen(value), []);
-    return [open, handler];
+    return [open, setOpen];
 };


### PR DESCRIPTION
If the component using modal needs to execute sam function at the closing event then this is the callback that can be triggered at closing modal.

I used effect instead of this and it was triggered twice if we use callback is triggered once.

And also removed the function on the 30 line because it is not needed the setAction can be passed directly.