### PR TITLE
fix(Tree): update deeper group test to scope check in seperate get call

### DIFF
--- a/src/components/Tree/Tree.cy.tsx
+++ b/src/components/Tree/Tree.cy.tsx
@@ -244,9 +244,10 @@ describe('Tree and TreeItem components', () => {
 
         cy.get(TREE_ITEM_TOGGLE_ID).first().click();
         cy.get(TREE_ITEM_ID).should('have.length', 9);
-        cy.get(TREE_ITEM_DRAG_HANDLE_ID).eq(4).realMouseDown().realMouseMove(0, -80).realMouseMove(40, 0).realMouseUp();
-        cy.wait(400);
-        cy.get(TREE_ITEM_ID).should('have.length', 12);
+        cy.get(TREE_ITEM_DRAG_HANDLE_ID).eq(4).realMouseDown().realMouseMove(0, -80).realMouseMove(40, 0);
+        cy.get(TREE_ID).within(() => {
+            cy.get(TREE_ITEM_ID).should('have.length', 12);
+        });
     });
 
     it('should not allow to go deeper with levelConstraint 0', () => {


### PR DESCRIPTION
`Tree` still has one flaky test.  After discovery in Cypress about how to handle nested checks, they recommend using a new `get` call on the parent and then use the `within` callback to check the nested state.
