### PR TITLE
fix(TextInput): update invalid tailwind class for font size

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -199,7 +199,7 @@ export const TextInput = ({
             {...focusProps}
             {...props}
             className={merge([
-                'tw-flex tw-items-center tw-h-9 tw-gap-2 tw-px-3 tw-border tw-transition tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent',
+                'tw-flex tw-items-center tw-h-9 tw-gap-2 tw-px-3 tw-border tw-transition tw-rounded tw-text-sm tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent',
                 dotted ? 'tw-border-dashed' : 'tw-border-solid',
                 disabled || readonly
                     ? 'tw-border-black-5 tw-bg-black-5 dark:tw-bg-black-90 dark:tw-border-black-90'
@@ -236,7 +236,7 @@ export const TextInput = ({
                         : 'tw-text-black tw-placeholder-black-60 dark:tw-text-white',
                 ])}
                 onClick={() => inputElement.current?.focus()}
-                onChange={(event) => onChange && onChange(event.currentTarget.value)}
+                onChange={(event) => onChange?.(event.currentTarget.value)}
                 onBlur={onBlur}
                 onKeyDown={onKeyDown}
                 placeholder={placeholder}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -199,7 +199,7 @@ export const TextInput = ({
             {...focusProps}
             {...props}
             className={merge([
-                'tw-flex tw-items-center tw-h-9 tw-gap-2 tw-px-3 tw-border tw-transition tw-rounded tw-text-sm tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent',
+                'tw-flex tw-items-center tw-h-9 tw-gap-2 tw-px-3 tw-border tw-transition tw-rounded tw-text-body-small tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent',
                 dotted ? 'tw-border-dashed' : 'tw-border-solid',
                 disabled || readonly
                     ? 'tw-border-black-5 tw-bg-black-5 dark:tw-bg-black-90 dark:tw-border-black-90'


### PR DESCRIPTION
[Bug Report](https://frontify.slack.com/archives/C02PSJTPA3D/p1698223512499749)
[ClickUp](https://app.clickup.com/t/8692zy02m)

`TextInput` had odd behaviour when text was selected and `mouseDown` held while moving `pointer` up and down (2px shift).  Seems that the tailwind class for `font` size `small` was not correct (`tw-font-s`) and when updated to `tw-font-sm` shift was removed.

