### PR TITLE
fix(TextInput): remove invalid tailwind class - extra actions

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -106,7 +106,7 @@ const ExtraActionButton: ForwardRefRenderFunction<HTMLButtonElement | null, Extr
     return (
         <button
             className={merge([
-                'tw-flex tw-items-center tw-justify-center tw-transition-colors tw-rounded tw-p-1 -tw-mr-2',
+                'tw-flex tw-items-center tw-justify-center tw-transition-colors tw-rounded tw-p-1',
                 isDisabled
                     ? 'tw-cursor-default tw-text-text-disabled'
                     : 'tw-text-text-weak hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',


### PR DESCRIPTION
[Bug Report](https://frontify.slack.com/archives/C02PSJTPA3D/p1699030331837289)
[ClickUp](https://app.clickup.com/t/8693252ef)

`ExtraActions` button spacing pushed button beyond input spacing area.  Looks like a invalid tailwind class was applied.  Removed class and styling renders within boundaries.