### PR TITLE
fix: export tooltip

### DIFF
--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,3 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './Tooltip';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -64,6 +64,7 @@ export * from './TextInput';
 export * from './LegacyTextarea';
 export * from './Toast';
 export * from './LegacyTooltip';
+export * from './Tooltip';
 export * from './TooltipIcon';
 export * from './Tree';
 export * from './Trigger';


### PR DESCRIPTION
Tooltip was not included in the package due to not being exported correctly.