### PR TITLE
fix: (Tree) Chrome ignores start dragging

### DIFF
--- a/src/components/Tree/TreeItem/TreeItemOverlay.tsx
+++ b/src/components/Tree/TreeItem/TreeItemOverlay.tsx
@@ -36,7 +36,7 @@ export const TreeItemOverlay = ({
     const liStyle = { marginLeft: indentation };
 
     const dragHandler = (
-        <button tabIndex={-1} className="tw-p-1">
+        <button tabIndex={-1} className="tw-p-1 tw-touch-none">
             <IconGrabHandle12 />
         </button>
     );

--- a/src/components/Tree/helpers/sensorsActivationConstraint.tsx
+++ b/src/components/Tree/helpers/sensorsActivationConstraint.tsx
@@ -17,5 +17,5 @@ export const sensorsActivationConstraint = ({
     enableDragDelay,
 }: SensorsActivationConstraintProps): SensorsActivationConstraint => {
     const delay = enableDragDelay ? 150 : 0;
-    return dragHandlerPosition === 'none' ? { delay, tolerance: 2 } : { delay: 0, tolerance: 0 };
+    return dragHandlerPosition === 'none' ? { delay, tolerance: 5 } : { delay: 0, tolerance: 5 };
 };


### PR DESCRIPTION
## Definition of Done
- [ ] User interface and experience have been verified by a designer
- [ ] I have added thorough Cypress tests (All properties and interactions have been tested).
- [x] Cross-browser compatibility - The component look consistent in the latest version of Chrome, Safari, Firefox and Edge.
- [ ] I've added documentation in Storybook. all properties are reflected in table and controls.
- [ ] User interface is compliant with WCAG 2.1 AA. Ensure these items are fulfilled:
    - [ ] Keyboard operability: All functionality can be accessed using only the keyboard
    - [ ] Logical tab order: Interactive elements follow a consistent and logical tab order
    - [ ] Visual indication of focus: Focused elements are visually highlighted for keyboard navigation
    - [ ] Color contrast: Sufficient contrast is used between text and background, as well as form fields and background
    - [ ] Alternative visual cues: Information is not solely reliant on color and includes alternative visual indicators
    - [ ] Semantic markup: Headings, lists, and form elements are marked up with appropriate semantic tags

No UI or logic changes. Fixes an issue where Chrome ignores initial dragging an element when it's done quick.