### PR TITLE
fix(NumberInput): update shared input references and disabled state

### DIFF
--- a/src/components/NumberInput/NumberInput.stories.tsx
+++ b/src/components/NumberInput/NumberInput.stories.tsx
@@ -6,6 +6,7 @@ import { NumberInputProps } from './types';
 import { useState } from 'react';
 import { IconNook16 } from '@foundation/Icon';
 import { Validation } from '@utilities/validation';
+import { Box } from '..';
 
 export default {
     title: 'Components/Number Input',
@@ -25,6 +26,20 @@ export default {
             defaultValue: undefined,
             control: { type: 'text' },
         },
+        disabled: {
+            type: 'boolean',
+            table: {
+                type: { summary: 'boolean | undefined' },
+                defaultValue: { summary: false },
+            },
+        },
+        readOnly: {
+            type: 'boolean',
+            table: {
+                type: { summary: 'boolean | undefined' },
+                defaultValue: { summary: false },
+            },
+        },
         controls: {
             description: 'Enable increment buttons',
             name: 'controls',
@@ -34,6 +49,11 @@ export default {
         clearable: {
             description: 'Enable clear button',
             name: 'clearable',
+            defaultValue: false,
+            control: { type: 'boolean' },
+        },
+        hugWidth: {
+            description: 'If `true` element will have a `auto` width, else `full` width',
             defaultValue: false,
             control: { type: 'boolean' },
         },
@@ -92,5 +112,13 @@ export const WithErrorLessThanZero: StoryFn<NumberInputProps> = (args) => {
             valueSelect={valueSelect}
             defaultValue={3}
         />
+    );
+};
+
+export const WithHugWidth: StoryFn<NumberInputProps> = (args) => {
+    return (
+        <Box className="tw-w-[400px]">
+            <NumberInput {...args} controls hugWidth placeholder="Input has a width of `auto`" />
+        </Box>
     );
 };

--- a/src/components/NumberInput/NumberInput.stories.tsx
+++ b/src/components/NumberInput/NumberInput.stories.tsx
@@ -12,7 +12,7 @@ export default {
     title: 'Components/Number Input',
     component: NumberInput,
     tags: ['autodocs'],
-    args: {},
+    args: { clearable: false },
     argTypes: {
         decorator: {
             description: 'Add decorator element to start of the input',
@@ -89,7 +89,11 @@ export default {
 } as Meta<NumberInputProps>;
 
 export const BaseUsage: StoryFn<NumberInputProps> = (args) => {
-    return <NumberInput {...args} placeholder="Enter a number..." clearable />;
+    return <NumberInput {...args} placeholder="Enter a number..." />;
+};
+
+BaseUsage.args = {
+    clearable: true,
 };
 
 export const WithDecoratorAndIncrementable: StoryFn<NumberInputProps> = (args) => {

--- a/src/utilities/input.tsx
+++ b/src/utilities/input.tsx
@@ -36,7 +36,7 @@ export const InputStyles: Record<InputStyleGroup, string> = {
     base: 'tw-flex tw-items-center tw-justify-between tw-gap-2 tw-px-3 tw-transition tw-text-sm tw-font-sans tw-relative tw-bg-base tw-border tw-rounded tw-line-strong',
     width: 'tw-w-full',
     height: 'tw-h-9 tw-min-h-[2.35rem]',
-    element: 'tw-bg-base tw-border-line-strong tw-text-text tw-placeholder-text-x-weak tw-outline-none tw-p-2',
+    element: 'tw-bg-transparent tw-border-line-strong tw-text-text tw-placeholder-text-x-weak tw-outline-none tw-p-2',
     focus: 'focus:tw-border-line-xx-strong',
     focusWithin: 'focus-within:tw-border-line-xx-strong focus-within:hover:tw-border-line-xx-strong',
     hover: 'hover:tw-border-line-x-strong',


### PR DESCRIPTION
[ClickUp](https://app.clickup.com/t/8693a8auu)
Action buttons were clickable on  `disabled` and `readOnly` states.  This fixes this, as well as updates styles to the `InputStyles` object and the `clearable` button to shared `InputActions` component