### PR TITLE
chore: remove design system team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,6 @@
 # the repository except for package.json and src directory.
 # Some very complex components will be co-owned with other teams.
 
-# Core
-* @Frontify/design-system
-package.json
-pnpm-lock.yaml
-/src
-
 # Components
-/src/components/RichTextEditor @Frontify/design-system @Frontify/guidelines-one
-/src/components/Tree @Frontify/design-system @Frontify/guidelines-navigation-themes
+/src/components/RichTextEditor @Frontify/guidelines-one
+/src/components/Tree @Frontify/guidelines-navigation-themes


### PR DESCRIPTION
This change removes the Design System team from `CODEOWNERS` as it's no longer set up as such.