### PR TITLE
fix: [TASK-9408] removed unused aria attribute

### DIFF
--- a/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
+++ b/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
@@ -22,13 +22,11 @@ export const LegacyCollectionItem = <T extends object>({
         type: listId,
         canDrag: !dragDisabled,
     });
-    const id = useId();
 
     return (
         <div
             ref={drag}
             className={merge(['tw-relative tw-outline-none', isFocusVisible ? 'tw-z-30' : 'tw-z-0'])}
-            aria-labelledby={id}
             data-test-id="draggable-item"
             aria-disabled={dragDisabled}
         >

--- a/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
+++ b/src/components/LegacyOrderableList/LegacyCollectionItem.tsx
@@ -1,7 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useFocusRing } from '@react-aria/focus';
-import { useId } from '@react-aria/utils';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 import { LegacyCollectionItemProps, LegacyItemDragState } from './types';


### PR DESCRIPTION
- removed "labelledby" attribute

The `labelledby` attribute does not make sense on this component as it refernces just an random Id wich doesn't exist anywhere in it's subcomponents. Removing it doesn't change it's accessibility, but gets rid of the forbidden usage warning.