### PR TITLE
fix: A11y Issues

### DIFF
--- a/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -75,6 +75,7 @@ export const SelectedAsset = ({
             aria-labelledby={labelId}
             title={title}
             data-test-id="asset-single-input"
+            role="group"
         >
             <button
                 {...mergeProps(buttonProps, focusProps)}

--- a/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -72,14 +72,13 @@ export const SelectedAsset = ({
     return (
         <div
             className="tw-font-sans tw-w-full tw-text-s tw-bg-transparent tw-font-normal tw-min-w-0"
-            aria-labelledby={labelId}
             title={title}
             data-test-id="asset-single-input"
-            role="group"
         >
             <button
                 {...mergeProps(buttonProps, focusProps)}
                 ref={buttonRef}
+                aria-labelledby={labelId}
                 className={merge([
                     'tw-w-full tw-flex tw-border tw-rounded tw-overflow-hidden hover:tw-border-black-90 dark:hover:tw-border-black-40 focus-visible:tw-outline-none',
                     isFocusVisible && FOCUS_STYLE,

--- a/src/components/Breadcrumbs/FormattedBreadcrumbs.tsx
+++ b/src/components/Breadcrumbs/FormattedBreadcrumbs.tsx
@@ -84,7 +84,7 @@ export const FormattedBreadcrumbs = ({
                 );
 
             default:
-                return <span key={key} />;
+                return <li key={key} />;
         }
     });
     return [...elements];

--- a/src/components/InlineDialog/InlineDialog.stories.tsx
+++ b/src/components/InlineDialog/InlineDialog.stories.tsx
@@ -76,6 +76,7 @@ const Template: StoryFn<InlineDialogProps> = (args) => {
                         emphasis={ButtonEmphasis.Default}
                         icon={<IconDotsVertical16 />}
                         onClick={() => setIsOpen(!isOpen)}
+                        aria-label="Dialog Trigger"
                     ></Button>
                 </InlineDialog.Trigger>
                 <InlineDialog.Content>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -98,7 +98,6 @@ export const Menu = ({
     return (
         <nav
             className={merge([CONTAINER_CLASSES, isMenuOpen ? 'tw-block' : 'tw-hidden'])}
-            role={isMenuOpen ? 'dialog' : ''}
             ref={setMenuContainerRef}
             style={menuOpenerRef ? popperInstance.styles.popper : {}}
             {...(menuOpenerRef ? popperInstance.attributes.popper : {})}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -102,6 +102,7 @@ export const Menu = ({
             style={menuOpenerRef ? popperInstance.styles.popper : {}}
             {...(menuOpenerRef ? popperInstance.attributes.popper : {})}
             data-test-id={dataTestId}
+            role={isMenuOpen ? 'dialog' : ''}
         >
             <ol className="tw-list-none" role="menu">
                 {children}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -102,7 +102,7 @@ export const Menu = ({
             style={menuOpenerRef ? popperInstance.styles.popper : {}}
             {...(menuOpenerRef ? popperInstance.attributes.popper : {})}
             data-test-id={dataTestId}
-            role={isMenuOpen ? 'dialog' : ''}
+            role={isMenuOpen ? 'navigation' : ''}
         >
             <ol className="tw-list-none" role="menu">
                 {children}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -8,7 +8,7 @@ import { useButton } from '@react-aria/button';
 import { FocusScope, useFocusRing } from '@react-aria/focus';
 import { merge } from '@utilities/merge';
 import { Validation } from '@utilities/validation';
-import { KeyboardEvent, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, ReactElement, ReactNode, useEffect, useId, useRef, useState } from 'react';
 import { getPaddingClasses } from './helpers';
 import { useClickOutside } from '@hooks/useClickOutside';
 import { CheckboxState } from '@components/Checkbox/Checkbox';
@@ -100,6 +100,8 @@ export const MultiSelect = ({
     useClickOutside(null, handleClose, [multiSelectRef?.current as HTMLElement, multiSelectMenuRef as HTMLElement]);
 
     const heightIsReady = maxHeight !== DEFAULT_DROPDOWN_MAX_HEIGHT;
+
+    const muliSelectContentId = useId();
 
     const toggleOpen = () => setOpen((open) => !open);
 
@@ -200,7 +202,10 @@ export const MultiSelect = ({
                             }
                             toggleOpen();
                         }}
-                        role="button"
+                        role="combobox"
+                        aria-expanded={open}
+                        aria-controls={muliSelectContentId}
+                        aria-label={ariaLabel}
                         {...focusProps}
                         tabIndex={0}
                         onKeyDown={handleSpacebarToggle}
@@ -238,6 +243,7 @@ export const MultiSelect = ({
             {open && heightIsReady && (
                 <EnablePortalWrapper enablePortal={enablePortal}>
                     <div
+                        id={muliSelectContentId}
                         ref={setMultiSelectMenuRef}
                         className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-[120000] tw-bg-base tw-min-w-[18rem]"
                         key="content"

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -6,7 +6,6 @@ import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { InputLabel, InputLabelTooltipProps } from '@components/InputLabel/InputLabel';
-
 export const SWITCH_ID = 'switch-container';
 
 export type SwitchSize = 'small' | 'medium';
@@ -45,6 +44,7 @@ export type SwitchProps = {
     size?: SwitchSize;
     hug?: boolean;
     tooltip?: InputLabelTooltipProps;
+    ariaLabel?: string;
     onChange?: (e: MouseEvent) => void;
     'data-test-id'?: string;
 };
@@ -58,6 +58,7 @@ export const Switch = ({
     size = 'medium',
     mode = 'off',
     labelStyle = 'default',
+    ariaLabel = 'Switch',
     hug = false,
     tooltip,
     'data-test-id': dataTestId = 'switch',
@@ -158,6 +159,7 @@ export const Switch = ({
                 value={mode}
                 onClick={onChange}
                 type="button"
+                aria-label={ariaLabel}
             >
                 <div className={dotWrapperClasses}>
                     <div className={dotClasses} />


### PR DESCRIPTION
- asset picker
	- Added a role to the element
- inline dialog trigger
	- Added a Aria Label to the Provided Trigger in the story
- menu
	- removed unnecessary role
- switch
	- added customizable aria label
- breadcrumbs
	- replaced "empty" element span by li
- multiselect
	- fix role 

