### PR TITLE
fix(RTE): toolbar height is too big

### DIFF
--- a/src/components/RichTextEditor/EditorPositioningWrapper/ToolbarWrapper/ToolbarWrapperPositioningBottom.tsx
+++ b/src/components/RichTextEditor/EditorPositioningWrapper/ToolbarWrapper/ToolbarWrapperPositioningBottom.tsx
@@ -6,7 +6,7 @@ export const ToolbarWrapperPositioningBottom = ({ children }: ToolbarWrapperProp
     return (
         <div
             data-test-id="toolbar-bottom"
-            className="tw-relative tw-rounded-b tw-min-h-12 tw-border-t tw-border-line tw-bg-base tw-divide-y tw-divide-line tw-flex tw-flex-wrap"
+            className="tw-relative tw-rounded-b tw-border-t tw-border-line tw-bg-base tw-divide-y tw-divide-line tw-flex tw-flex-wrap"
         >
             {children}
         </div>

--- a/src/components/RichTextEditor/EditorPositioningWrapper/ToolbarWrapper/ToolbarWrapperPositioningFloating.tsx
+++ b/src/components/RichTextEditor/EditorPositioningWrapper/ToolbarWrapper/ToolbarWrapperPositioningFloating.tsx
@@ -58,7 +58,7 @@ export const ToolbarWrapperPositioningFloating = ({
             <div
                 data-selector="toolbar-floating"
                 data-test-id="toolbar-floating"
-                className="tw-rounded tw-min-h-12 tw-border tw-border-line tw-shadow-lg tw-bg-base tw-divide-y tw-divide-line tw-flex tw-flex-wrap"
+                className="tw-rounded tw-border tw-border-line tw-shadow-lg tw-bg-base tw-divide-y tw-divide-line tw-flex tw-flex-wrap"
             >
                 {children}
             </div>

--- a/src/components/RichTextEditor/EditorPositioningWrapper/ToolbarWrapper/ToolbarWrapperPositioningTop.tsx
+++ b/src/components/RichTextEditor/EditorPositioningWrapper/ToolbarWrapper/ToolbarWrapperPositioningTop.tsx
@@ -6,7 +6,7 @@ export const ToolbarWrapperPositioningTop = ({ children }: ToolbarWrapperProps) 
     return (
         <div
             data-test-id="toolbar-top"
-            className="tw-relative tw-min-h-12 tw-rounded-t tw-border-b tw-border-line tw-bg-base tw-divide-y tw-divide-line tw-flex tw-flex-wrap"
+            className="tw-relative tw-rounded-t tw-border-b tw-border-line tw-bg-base tw-divide-y tw-divide-line tw-flex tw-flex-wrap"
         >
             {children}
         </div>


### PR DESCRIPTION
![image](https://github.com/Frontify/fondue/assets/30796791/a7c1b588-fa5f-4841-99e8-e76f62e98840)

also on marketplace
![Screenshot 2024-01-18 at 11 15 55](https://github.com/Frontify/fondue/assets/9362990/6330e53e-1389-4cfc-947a-07be9a7c2f89)

Somehow the `.tw-min-h-12` wasn't included in the bundle before
