### PR TITLE
feat: performance improvements

### DIFF
--- a/packages/fondue/src/components/RichTextEditor/Plugins/GeneratePlugins.tsx
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/GeneratePlugins.tsx
@@ -6,7 +6,7 @@ import { Toolbar } from '../components/Toolbar';
 import type { PluginComposer } from './PluginComposer';
 
 type GeneratePluginsReturn = {
-    create: () => PlatePlugin<Record<string, any>>[];
+    plugins: PlatePlugin<Record<string, any>>[];
     toolbar: (toolbarWidth: number | undefined) => ReactNode;
     inline: () => ReactNode;
     styles: () => Record<string, CSSProperties>;
@@ -19,7 +19,7 @@ export const createPlatePlugins = (pluginComposer: PluginComposer): PlatePlugin[
 
 export const GeneratePlugins = (editorId: string, pluginComposer: PluginComposer): GeneratePluginsReturn => {
     return {
-        create: () => createPlatePlugins(pluginComposer),
+        plugins: createPlatePlugins(pluginComposer),
         toolbar: (toolbarWidth) =>
             pluginComposer.hasToolbar ? (
                 <Toolbar toolbarButtons={pluginComposer.buttons} editorId={editorId} toolbarWidth={toolbarWidth} />

--- a/packages/fondue/src/components/RichTextEditor/components/RenderPlaceholder/RenderPlaceholder.tsx
+++ b/packages/fondue/src/components/RichTextEditor/components/RenderPlaceholder/RenderPlaceholder.tsx
@@ -1,0 +1,20 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type CSSProperties } from 'react';
+import { type RenderPlaceholderProps } from 'slate-react';
+
+const PLACEHOLDER_STYLES: CSSProperties = {
+    position: 'relative',
+    height: '0',
+};
+
+export const RenderPlaceholder = ({ children, attributes }: RenderPlaceholderProps) => {
+    const mergedAttributes = {
+        ...attributes,
+        style: {
+            ...attributes.style,
+            ...PLACEHOLDER_STYLES,
+        },
+    };
+    return <span {...mergedAttributes}>{children}</span>;
+};

--- a/packages/fondue/src/components/RichTextEditor/components/RenderPlaceholder/index.ts
+++ b/packages/fondue/src/components/RichTextEditor/components/RenderPlaceholder/index.ts
@@ -1,0 +1,3 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './RenderPlaceholder';

--- a/packages/fondue/src/components/RichTextEditor/context/EditorResizeContext.tsx
+++ b/packages/fondue/src/components/RichTextEditor/context/EditorResizeContext.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ReactNode, createContext, useContext } from 'react';
+import { ReactNode, createContext, useContext, useMemo } from 'react';
 import { useEditorResize } from '../hooks';
 import { PlateWrapper } from '../components/EditorPositioningWrapper/PlateWrapper';
 
@@ -19,10 +19,12 @@ type EditorResizeContextProviderProps = {
 };
 
 export const EditorResizeContextProvider = ({ children }: EditorResizeContextProviderProps) => {
-    const { editorWidth, editorRef } = useEditorResize();
+    const { editorRef, editorWidth } = useEditorResize();
+
+    const value = useMemo(() => ({ editorWidth, editorRef }), [editorWidth, editorRef]);
 
     return (
-        <EditorResizeContext.Provider value={{ editorWidth, editorRef }}>
+        <EditorResizeContext.Provider value={value}>
             <PlateWrapper ref={editorRef}>{children}</PlateWrapper>
         </EditorResizeContext.Provider>
     );

--- a/packages/fondue/src/components/RichTextEditor/context/RichTextEditorContext.tsx
+++ b/packages/fondue/src/components/RichTextEditor/context/RichTextEditorContext.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { CSSProperties, ReactNode, createContext, useContext } from 'react';
+import { CSSProperties, ReactNode, createContext, useContext, useMemo } from 'react';
 import { Position, getEditorWrapperClassNames } from '../components/EditorPositioningWrapper';
 import { EditorResizeContextProvider } from './EditorResizeContext';
 import { defaultStyles } from '../utils';
@@ -22,23 +22,28 @@ export const useRichTextEditorContext = () => useContext(RichTextEditorContext);
 
 type RichTextEditorProviderProps = {
     children: ReactNode;
-    value: {
-        styles: Record<string, CSSProperties>;
-        position: Position;
-        border: boolean;
-        editorId: string;
-    };
+    styles: Record<string, CSSProperties>;
+    position: Position;
+    border: boolean;
+    editorId: string;
 };
 
-export const RichTextEditorProvider = ({ children, value }: RichTextEditorProviderProps) => {
-    const { styles, position, border, editorId } = value;
-
-    const state = {
-        styles,
-        editorId,
-        position,
-        wrapperClassNames: getEditorWrapperClassNames(position, border),
-    };
+export const RichTextEditorProvider = ({
+    children,
+    styles,
+    position,
+    border,
+    editorId,
+}: RichTextEditorProviderProps) => {
+    const state = useMemo(
+        () => ({
+            styles,
+            editorId,
+            position,
+            wrapperClassNames: getEditorWrapperClassNames(position, border),
+        }),
+        [styles, editorId, position, border],
+    );
 
     return (
         <RichTextEditorContext.Provider value={state}>

--- a/packages/fondue/src/components/RichTextEditor/hooks/useEditorState.ts
+++ b/packages/fondue/src/components/RichTextEditor/hooks/useEditorState.ts
@@ -23,14 +23,14 @@ export const useEditorState = ({
 }: useEditorStateProps) => {
     const localValue = useRef<TreeOfNodes | null>(null);
 
-    const onChangeBase = useCallback(
+    const _onChange = useCallback(
         (value: TreeOfNodes) => {
             onTextChange && onTextChange(JSON.stringify(value));
         },
         [onTextChange],
     );
 
-    const debouncedOnChange = useDebounce(onChangeBase, ON_SAVE_DELAY_IN_MS);
+    const debouncedOnChange = useDebounce(_onChange, ON_SAVE_DELAY_IN_MS);
 
     const onChange = useCallback(
         (value: TreeOfNodes) => {

--- a/packages/fondue/src/components/RichTextEditor/hooks/useEditorState.ts
+++ b/packages/fondue/src/components/RichTextEditor/hooks/useEditorState.ts
@@ -23,9 +23,14 @@ export const useEditorState = ({
 }: useEditorStateProps) => {
     const localValue = useRef<TreeOfNodes | null>(null);
 
-    const debouncedOnChange = useDebounce((value: TreeOfNodes) => {
-        onTextChange && onTextChange(JSON.stringify(value));
-    }, ON_SAVE_DELAY_IN_MS);
+    const onChangeBase = useCallback(
+        (value: TreeOfNodes) => {
+            onTextChange && onTextChange(JSON.stringify(value));
+        },
+        [onTextChange],
+    );
+
+    const debouncedOnChange = useDebounce(onChangeBase, ON_SAVE_DELAY_IN_MS);
 
     const onChange = useCallback(
         (value: TreeOfNodes) => {
@@ -42,7 +47,7 @@ export const useEditorState = ({
         [editorId],
     );
 
-    const config = GeneratePlugins(editorId, plugins);
+    const config = useMemo(() => GeneratePlugins(editorId, plugins), [editorId, plugins]);
 
     return { localValue, onChange, memoizedValue, config };
 };

--- a/packages/fondue/src/components/RichTextEditor/utils/InitPlateEditor.ts
+++ b/packages/fondue/src/components/RichTextEditor/utils/InitPlateEditor.ts
@@ -18,7 +18,7 @@ export class InitPlateEditor {
 
     static init(editorId: string = generateRandomId(), plugins: PluginComposer = defaultPlugins) {
         const config = GeneratePlugins(editorId, plugins);
-        this.editor = createPlateEditor({ id: editorId, plugins: config.create() });
+        this.editor = createPlateEditor({ id: editorId, plugins: config.plugins });
         return this;
     }
 }

--- a/packages/fondue/src/hooks/useDebounce.ts
+++ b/packages/fondue/src/hooks/useDebounce.ts
@@ -1,14 +1,17 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 export const useDebounce = <T extends unknown[]>(func: (...args: T) => void, timeout = 10) => {
     const timer = useRef<ReturnType<typeof setTimeout>>();
 
-    const debouncedFunc = (...args: T) => {
-        clearTimeout(timer.current);
-        timer.current = setTimeout(() => func.apply(this, args), timeout);
-    };
+    const debouncedFunc = useCallback(
+        (...args: T) => {
+            clearTimeout(timer.current);
+            timer.current = setTimeout(() => func.apply(this, args), timeout);
+        },
+        [func, timeout],
+    );
 
     return debouncedFunc;
 };


### PR DESCRIPTION
Reduce the amount of time spent in rendering the RichTextEditor by approximately 20% through memoizing props:

To test:
Copy this code block and run in a storybook iframe for a good indication of the differences.

```
const RichTextEditorTemplate: StoryFn<RichTextEditorProps> = (args: RichTextEditorProps) => {
    const [readonly, setReadonly] = useState(false);

    return (
        <>
            <button onClick={() => setReadonly((r) => !r)}>Click {readonly ? 'on' : 'off'}</button>
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
            <RichTextEditorComponent {...args} readonly={readonly} />
        </>
    );
};

```

Before: 
<img width="1560" alt="Screenshot 2024-02-29 at 21 52 09" src="https://github.com/Frontify/fondue/assets/93908356/0e2d45a9-9f15-4e24-b179-c5b0f7422d3e">

After:
<img width="1560" alt="Screenshot 2024-02-29 at 21 52 34" src="https://github.com/Frontify/fondue/assets/93908356/5eec3f74-94ad-4d60-b39d-80ba8d34a9a8">
