### PR TITLE
fix: Allow closing tooltip when it's disabled

### DIFF
--- a/packages/fondue/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.tsx
@@ -76,9 +76,7 @@ export const Tooltip = ({
     const [hasInteractiveElements, setHasInteractiveElements] = useState(false);
 
     const handleHideTooltip = useCallback(() => {
-        if (!disabled) {
-            handleTimeout(() => setOpen(false), leaveDelay, timeoutRef);
-        }
+        handleTimeout(() => setOpen(false), leaveDelay, timeoutRef);
     }, [disabled, leaveDelay, setOpen]);
 
     const handleShowTooltip = useCallback(() => {


### PR DESCRIPTION
Bug report by @ryancarville 

When the tooltip switches to `disabled` while open, it gets stuck in the open state.

Removing the condition to check for disabled when closing the tooltip.