### PR TITLE
fix(RichTextEditor): flyout modals not closing when clicked outside

### DIFF
--- a/.changeset/gold-dragons-compare.md
+++ b/.changeset/gold-dragons-compare.md
@@ -1,0 +1,7 @@
+---
+"@frontify/fondue": patch
+---
+
+feat(RichTextEditor): `FloatingModalWrapper` component has been created. Use this when a custom plugin requires a flyout. An example of it's usage be found in `src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx`
+
+fix(RichTextEditor): The `BlurObserver` element has been updated to close floating modals when the user clicks inside the richTextEditor content. In addition, it will only be activated once the user has focused the editor, reducing the number of event listeners active on the page.

--- a/packages/fondue/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
@@ -4,6 +4,7 @@ import { MouseEvent } from 'react';
 import IconPen16 from '@foundation/Icon/Generated/IconPen16';
 import IconTrashBin16 from '@foundation/Icon/Generated/IconTrashBin16';
 import { useRichTextEditorContext } from '@components/RichTextEditor/context';
+import { FloatingModalWrapper } from '@components/RichTextEditor/components';
 import { LINK_PLUGIN } from '../../id';
 import { useLinkOpenButtonState } from '@udecode/plate-link';
 import { getUrlFromLinkOrLegacyLink } from '@components/RichTextEditor/Plugins/LinkPlugin/utils';
@@ -24,7 +25,7 @@ export const EditModal = ({ editButtonProps, unlinkButtonProps }: EditModalProps
     const url = element ? getUrlFromLinkOrLegacyLink(element) : '';
 
     return (
-        <div data-test-id="floating-link-edit" className="tw-bg-white tw-rounded tw-shadow tw-p-4 tw-min-w-[400px]">
+        <FloatingModalWrapper data-test-id="floating-link-edit" padding="16px" minWidth="400px">
             <span data-test-id={'preview-link-flyout'} className="tw-flex tw-justify-between">
                 <span style={styles[LINK_PLUGIN]} className="tw-pointer-events-none">
                     {url}
@@ -49,6 +50,6 @@ export const EditModal = ({ editButtonProps, unlinkButtonProps }: EditModalProps
                     </button>
                 </span>
             </span>
-        </div>
+        </FloatingModalWrapper>
     );
 };

--- a/packages/fondue/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/LinkPlugin/FloatingLink/InsertLinkModal/InsertModal.tsx
@@ -4,6 +4,7 @@ import { ButtonEmphasis, ButtonSize, ButtonStyle } from '@components/Button';
 import { Button } from '@components/Button/Button';
 import { Checkbox } from '@components/Checkbox';
 import { FormControl } from '@components/FormControl';
+import { FloatingModalWrapper } from '@components/RichTextEditor/components';
 import { TextInput } from '@components/TextInput';
 import IconCheckMark20 from '@foundation/Icon/Generated/IconCheckMark20';
 import { MouseEvent, ReactElement, ReactNode } from 'react';
@@ -34,7 +35,7 @@ export const InsertModal = ({
     testId,
     children,
 }: Props): ReactElement => (
-    <div data-test-id={testId} className="tw-bg-white tw-rounded tw-shadow tw-p-7 tw-min-w-[400px] tw-overflow-y-auto">
+    <FloatingModalWrapper data-test-id={testId} minWidth="400px" padding="28px">
         <FormControl
             label={{
                 children: 'Text',
@@ -87,5 +88,5 @@ export const InsertModal = ({
                 </Button>
             </div>
         </div>
-    </div>
+    </FloatingModalWrapper>
 );

--- a/packages/fondue/src/components/RichTextEditor/components/FloatingModal/FloatingModal.tsx
+++ b/packages/fondue/src/components/RichTextEditor/components/FloatingModal/FloatingModal.tsx
@@ -1,0 +1,28 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type CSSProperties, type ReactNode } from 'react';
+
+export const FLOATING_MODAL_SELECTOR = '[data-floating-modal]';
+
+export type FloatingModalWrapperProps = {
+    children: ReactNode;
+    minWidth: CSSProperties['minWidth'];
+    padding: CSSProperties['padding'];
+    'data-test-id'?: string;
+};
+
+export const FloatingModalWrapper = ({
+    children,
+    minWidth,
+    padding,
+    'data-test-id': dataTestId = 'floating-modal',
+}: FloatingModalWrapperProps) => (
+    <div
+        data-test-id={dataTestId}
+        className="tw-bg-white tw-rounded tw-shadow tw-overflow-y-auto"
+        style={{ minWidth, padding }}
+        data-floating-modal
+    >
+        {children}
+    </div>
+);

--- a/packages/fondue/src/components/RichTextEditor/components/FloatingModal/index.ts
+++ b/packages/fondue/src/components/RichTextEditor/components/FloatingModal/index.ts
@@ -1,5 +1,3 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export * from './Toolbar';
 export * from './FloatingModal';
-export * from './EditorPositioningWrapper';


### PR DESCRIPTION
Fixes an issue where toolbar flyouts would remain open when the user clicked a different spot inside the RichTextEditor.
Also reduces the number of calls and the complexity of the blur observer by only activating it when the editor is in focus.

Linked pr: https://github.com/Frontify/brand-sdk/pull/803

How to test with a guideline-block:
To be sure that you are using local code add a console.log() to the RTE component. (It will only show in edit mode since view mode uses the serialized html)

In @frontify/fondue
```
pnpm link --global
pnpm build
```

In @frontify/brand-sdk
```
rm -rf node_modules/.vite && rm -rf packages/guideline-blocks-settings/node_modules/.vite && pnpm build 
cd packages/guideline-blocks-settings
pnpm link --global
cd ../app-bridge
pnpm link --global

```

In @frontify/guideline-blocks
```
cd packages/text-block
pnpm i --frozen-lockfile
pnpm link --global @frontify/fondue @frontify/app-bridge @frontify/guideline-blocks-settings
rm -rf node_modules/.vite && pnpm serve

```