### PR TITLE
chore: setup default owner for project in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,2 @@
-# The Design System will be the default owners for everything in
-# the repository except for package.json and src directory.
-# Some very complex components will be co-owned with other teams.
-
-# Components
-packages/fondue/src/components/RichTextEditor @Frontify/guidelines-one
-packages/fondue/src/components/Tree @Frontify/guidelines-navigation-themes
+# The Frontend Platform Team is the default owner for everything in the repo.
+* @Frontify/frontend-platform


### PR DESCRIPTION
## Description

This PR introduces a stricter CODEOWNERS configuration to elevate the ownership level of the Frontend Platform Team across all files.

This will help ensure consistency in PR reviews and prevent against unexpected breaking changes.

## Testing

If successful, this PR should already display a codeownership review.