### PR TITLE
fix: replaced mouse events with pointer events

### DIFF
--- a/.changeset/lucky-rivers-doubt.md
+++ b/.changeset/lucky-rivers-doubt.md
@@ -1,5 +1,5 @@
 ---
-"@frontify/fondue": major
+"@frontify/fondue": minor
 ---
 
-fix(Tooltip): Replaced onmouse events with pointer events, to distinguish between devices.
+refactor(Tooltip): replaced `onMouse` events with `onPointer` events to distinguish between devices.

--- a/.changeset/lucky-rivers-doubt.md
+++ b/.changeset/lucky-rivers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": major
+---
+
+fix(Tooltip): Replaced onmouse events with pointer events, to distinguish between devices.

--- a/packages/fondue/src/components/FormField/FormField.cy.tsx
+++ b/packages/fondue/src/components/FormField/FormField.cy.tsx
@@ -147,14 +147,5 @@ describe('Form Field Component', () => {
             });
             cy.get(FORM_FIELD_TOOLTIP_TWO).should('exist');
         });
-
-        it('should not open 1st tooltip on touch event', () => {
-            cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
-            cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'touch',
-            });
-            cy.get(FORM_FIELD_TOOLTIP_ONE).should('not.exist');
-        });
     });
 });

--- a/packages/fondue/src/components/FormField/FormField.cy.tsx
+++ b/packages/fondue/src/components/FormField/FormField.cy.tsx
@@ -117,27 +117,44 @@ describe('Form Field Component', () => {
         cy.get(FORM_FIELD_TEXT_INPUT).focused();
     });
 
-    it('should render tooltip', () => {
-        cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
-        cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).should('exist');
-    });
+    describe('Tooltips', () => {
+        it('should render', () => {
+            cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
+            cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).should('exist');
+        });
 
-    it('should render multiple tooltips', () => {
-        cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
-        cy.get(FORM_FIELD_LABEL).children().should('have.length', 2);
-        cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).should('exist');
-        cy.get(FORM_FIELD_TOOLTIP_TWO_ICON).should('exist');
-    });
+        it('should render multiple', () => {
+            cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
+            cy.get(FORM_FIELD_LABEL).children().should('have.length', 2);
+            cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).should('exist');
+            cy.get(FORM_FIELD_TOOLTIP_TWO_ICON).should('exist');
+        });
 
-    it('should open 1st tooltip dialog on hover', () => {
-        cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
-        cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).trigger('mouseover');
-        cy.get(FORM_FIELD_TOOLTIP_ONE).should('exist');
-    });
+        it('should open 1st tooltip dialog on hover', () => {
+            cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
+            cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
+            cy.get(FORM_FIELD_TOOLTIP_ONE).should('exist');
+        });
 
-    it('should open 2nd tooltip dialog on hover', () => {
-        cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
-        cy.get(FORM_FIELD_TOOLTIP_TWO_ICON).trigger('mouseover');
-        cy.get(FORM_FIELD_TOOLTIP_TWO).should('exist');
+        it('should open 2nd tooltip dialog on hover', () => {
+            cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
+            cy.get(FORM_FIELD_TOOLTIP_TWO_ICON).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
+            cy.get(FORM_FIELD_TOOLTIP_TWO).should('exist');
+        });
+
+        it('should not open 1st tooltip on touch event', () => {
+            cy.mount(COMPONENT_BASE_WITH_TOOLTIPS);
+            cy.get(FORM_FIELD_TOOLTIP_ONE_ICON).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'touch',
+            });
+            cy.get(FORM_FIELD_TOOLTIP_ONE).should('not.exist');
+        });
     });
 });

--- a/packages/fondue/src/components/Tooltip/Tooltip.cy.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.cy.tsx
@@ -139,22 +139,6 @@ describe('Tooltip Component', () => {
             });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom');
         });
-
-        it('should not flip if disabled', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="top" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'top');
-        });
     });
 
     describe('Appearance/Disappearance', () => {

--- a/packages/fondue/src/components/Tooltip/Tooltip.cy.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.cy.tsx
@@ -17,7 +17,10 @@ describe('Tooltip Component', () => {
             </Tooltip>,
         );
         cy.get(TOOLTIP_TRIGGER).should('exist');
-        cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+        cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+            eventConstructor: 'MouseEvent',
+            pointerType: 'mouse',
+        });
         cy.get(TOOLTIP_SELECTOR).should('exist');
         cy.get(TOOLTIP_SELECTOR).should('have.text', 'Hello There');
     });
@@ -32,7 +35,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'top');
         });
 
@@ -45,7 +51,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom');
         });
 
@@ -58,7 +67,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'right');
         });
 
@@ -71,7 +83,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'left');
         });
 
@@ -84,7 +99,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom-start');
         });
 
@@ -97,7 +115,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom-end');
         });
     });
@@ -112,7 +133,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom');
         });
 
@@ -125,7 +149,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'top');
         });
     });
@@ -140,7 +167,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).should('not.exist');
         });
 
@@ -165,7 +195,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).should('not.exist');
             cy.wait(2000);
             cy.get(TOOLTIP_SELECTOR).should('exist');
@@ -180,7 +213,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).should('exist');
             cy.get(TOOLTIP_TRIGGER).trigger('mouseleave');
             cy.get(TOOLTIP_SELECTOR).should('exist');
@@ -199,7 +235,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_ARROW).should('exist');
         });
 
@@ -212,7 +251,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_ARROW).should('not.exist');
         });
 
@@ -225,7 +267,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).find('p').should('have.css', 'padding', '8px 12px 10px');
         });
 
@@ -238,7 +283,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).find('p').should('have.css', 'padding', '4px 8px 6px');
         });
 
@@ -251,7 +299,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).should('have.text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.');
             cy.get(TOOLTIP_SELECTOR).should('have.css', 'max-width', '200px');
         });
@@ -265,7 +316,10 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).should('have.text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.');
             cy.get(TOOLTIP_SELECTOR).should('have.css', 'max-width', '150px');
         });
@@ -279,9 +333,46 @@ describe('Tooltip Component', () => {
                 </Tooltip>,
             );
             cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('mouseover');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'mouse',
+            });
             cy.get(TOOLTIP_SELECTOR).should('have.text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.');
             cy.get(TOOLTIP_SELECTOR).should('have.css', 'max-height', '50px');
+        });
+    });
+
+    describe('Pointer Events for touch devices', () => {
+        it('should not open tooltip on touch event', () => {
+            cy.mount(
+                <Tooltip content="No Touch" maxHeight={50}>
+                    <span data-test-id="tooltip-trigger">
+                        <IconIcon24 />
+                    </span>
+                </Tooltip>,
+            );
+            cy.get(TOOLTIP_TRIGGER).should('exist');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'touch',
+            });
+            cy.get(TOOLTIP_SELECTOR).should('not.exist');
+        });
+
+        it('should not open tooltip on pen event', () => {
+            cy.mount(
+                <Tooltip content="No Pen" maxHeight={50}>
+                    <span data-test-id="tooltip-trigger">
+                        <IconIcon24 />
+                    </span>
+                </Tooltip>,
+            );
+            cy.get(TOOLTIP_TRIGGER).should('exist');
+            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                eventConstructor: 'MouseEvent',
+                pointerType: 'pen',
+            });
+            cy.get(TOOLTIP_SELECTOR).should('not.exist');
         });
     });
 });

--- a/packages/fondue/src/components/Tooltip/Tooltip.cy.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.cy.tsx
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { PopperPlacement } from '@components/Popper/types';
 import { Tooltip } from '@components/Tooltip/Tooltip';
 import IconIcon24 from '@foundation/Icon/Generated/IconIcon24';
 
@@ -26,101 +27,24 @@ describe('Tooltip Component', () => {
     });
 
     describe('Positioning', () => {
-        it('should render the tooltip in an initial Top placement', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="top" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
+        const positions = ['top', 'bottom', 'right', 'left', 'bottom-start', 'bottom-end'];
+        for (const position of positions) {
+            it(`should render the tooltip in a position: ${position}`, () => {
+                cy.mount(
+                    <Tooltip content="Hello Positioning" placement={`${position}` as PopperPlacement} flip={false}>
+                        <span data-test-id="tooltip-trigger">
+                            <IconIcon24 />
+                        </span>
+                    </Tooltip>,
+                );
+                cy.get(TOOLTIP_TRIGGER).should('exist');
+                cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                    eventConstructor: 'MouseEvent',
+                    pointerType: 'mouse',
+                });
+                cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', position);
             });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'top');
-        });
-
-        it('should render the tooltip in an initial Bottom placement', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="bottom" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom');
-        });
-
-        it('should render the tooltip in an initial Right placement', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="right" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'right');
-        });
-
-        it('should render the tooltip in an initial Left placement', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="left" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'left');
-        });
-
-        it('should render the tooltip with start alignment', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="bottom-start" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom-start');
-        });
-
-        it('should render the tooltip with start alignment', () => {
-            cy.mount(
-                <Tooltip content="Hello There" placement="bottom-end" flip={false}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).parent().should('have.attr', 'data-popper-placement', 'bottom-end');
-        });
+        }
     });
 
     describe('Flip', () => {
@@ -274,39 +198,28 @@ describe('Tooltip Component', () => {
             cy.get(TOOLTIP_SELECTOR).find('p').should('have.css', 'padding', '4px 8px 6px');
         });
 
-        it('should render with a default max width of 200px', () => {
-            cy.mount(
-                <Tooltip content="Lorem ipsum dolor sit amet, consectetur adipisicing elit.">
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
+        const widthTests = [
+            { value: undefined, expected: '200px' },
+            { value: 150, expected: '150px' },
+        ];
+        for (const test of widthTests) {
+            it(`should render with a max width of: ${test.expected}`, () => {
+                cy.mount(
+                    <Tooltip content="Hello max Width of the Tooltip" maxWidth={test.value}>
+                        <span data-test-id="tooltip-trigger">
+                            <IconIcon24 />
+                        </span>
+                    </Tooltip>,
+                );
+                cy.get(TOOLTIP_TRIGGER).should('exist');
+                cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
+                    eventConstructor: 'MouseEvent',
+                    pointerType: 'mouse',
+                });
+                cy.get(TOOLTIP_SELECTOR).should('have.text', 'Hello max Width of the Tooltip');
+                cy.get(TOOLTIP_SELECTOR).should('have.css', 'max-width', `${test.expected}`);
             });
-            cy.get(TOOLTIP_SELECTOR).should('have.text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.');
-            cy.get(TOOLTIP_SELECTOR).should('have.css', 'max-width', '200px');
-        });
-
-        it('should render with a custom max width', () => {
-            cy.mount(
-                <Tooltip content="Lorem ipsum dolor sit amet, consectetur adipisicing elit." maxWidth={150}>
-                    <span data-test-id="tooltip-trigger">
-                        <IconIcon24 />
-                    </span>
-                </Tooltip>,
-            );
-            cy.get(TOOLTIP_TRIGGER).should('exist');
-            cy.get(TOOLTIP_TRIGGER).trigger('pointerover', {
-                eventConstructor: 'MouseEvent',
-                pointerType: 'mouse',
-            });
-            cy.get(TOOLTIP_SELECTOR).should('have.text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.');
-            cy.get(TOOLTIP_SELECTOR).should('have.css', 'max-width', '150px');
-        });
+        }
 
         it('should render with a custom max height', () => {
             cy.mount(

--- a/packages/fondue/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.stories.tsx
@@ -52,6 +52,18 @@ const Template: StoryFn<TooltipProps> = (args) => (
     </Tooltip>
 );
 
+const DoubleTooltipTemplate: StoryFn<TooltipProps> = (args) => (
+    <div>
+        <Tooltip {...args}>
+            <IconIcon24 />
+        </Tooltip>
+
+        <Tooltip {...args}>
+            <IconIcon24 />
+        </Tooltip>
+    </div>
+);
+
 export const Default = Template.bind({});
 Default.args = {
     leaveDelay: 0,
@@ -71,3 +83,5 @@ export const Disabled = Template.bind({});
 Disabled.args = {
     disabled: true,
 };
+
+export const DoubleTooltip = DoubleTooltipTemplate.bind({});

--- a/packages/fondue/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.tsx
@@ -36,14 +36,14 @@ const formatTooltipText = (text: string) => {
     return text.split(lineBreakRegex).join('\n');
 };
 
-let timeoutId: NodeJS.Timeout | undefined;
+let timeoutId: number | undefined;
 const handleTimeout = (callback: () => void, delay: number) => {
     if (timeoutId) {
-        clearTimeout(timeoutId);
+        window.clearTimeout(timeoutId);
     }
 
     if (delay) {
-        timeoutId = setTimeout(callback, delay);
+        timeoutId = window.setTimeout(callback, delay);
     } else {
         callback();
     }

--- a/packages/fondue/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fondue/src/components/Tooltip/Tooltip.tsx
@@ -91,14 +91,14 @@ export const Tooltip = ({
     const focusAndMouseAttributes = {
         onBlur: handleHideTooltip,
         onFocus: handleShowTooltip,
-        onPointerLeave: (event: PointerEvent) => {
-            if (isPointerEventTypeMouse(event)) {
-                handleHideTooltip();
-            }
-        },
         onPointerEnter: (event: PointerEvent) => {
             if (isPointerEventTypeMouse(event)) {
                 handleShowTooltip();
+            }
+        },
+        onPointerLeave: (event: PointerEvent) => {
+            if (isPointerEventTypeMouse(event)) {
+                handleHideTooltip();
             }
         },
     };


### PR DESCRIPTION
In tooltip replaced mouse events with pointer events to have control over tooltip and dont show it on touch devices if the type of it is touch or pen. Only show it when pointer type is mouse.