### PR TITLE
feat: add disabled prop for AssetInput & ColorPIcker

### DIFF
--- a/packages/fondue/src/components/AssetInput/AssetInput.cy.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.cy.tsx
@@ -122,4 +122,21 @@ describe('MultiAssetPreview Component', () => {
         cy.get(ASSET_SINGLE_INPUT_ID).should('contain', 'Uploading').and('contain', 'Your Asset');
         cy.get(SPINNING_CIRCLE_ID).should('exist');
     });
+
+    it('renders the disabled state', () => {
+        const onLibraryClickStub = cy.stub().as('onLibraryClickStub');
+        const onUploadClickStub = cy.stub().as('onUploadClickStub');
+        cy.mount(
+            <AssetInput
+                size={AssetInputSize.Small}
+                disabled={true}
+                onLibraryClick={onLibraryClickStub}
+                onUploadClick={onUploadClickStub}
+            />,
+        );
+
+        cy.get(ASSET_PLACEHOLDER_UPLOAD_ID).find('[data-test-id="button"]').should('be.disabled');
+        cy.get(ASSET_PLACEHOLDER_UPLOAD_ID).find('input').should('be.disabled');
+        cy.get(ASSET_PLACEHOLDER_LIBRARY_ID).find('[data-test-id="button"]').should('be.disabled');
+    });
 });

--- a/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
@@ -18,6 +18,13 @@ export default {
         onMultiAssetClick: {
             action: 'onMultiAssetClick',
         },
+        disabled: {
+            type: 'boolean',
+            table: {
+                type: { summary: 'boolean | undefined' },
+                defaultValue: { summary: false },
+            },
+        },
     },
     args: {
         size: AssetInputSize.Small,
@@ -25,6 +32,7 @@ export default {
         hideSize: false,
         hideExtension: false,
         numberOfLocations: 1,
+        disabled: false,
     },
 } as Meta<AssetInputProps>;
 

--- a/packages/fondue/src/components/AssetInput/AssetInput.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.tsx
@@ -71,6 +71,7 @@ export type AssetInputProps = {
     onLibraryClick?: () => void;
     onMultiAssetClick?: () => void;
     acceptFileType?: string;
+    disabled?: boolean;
 };
 
 export const AssetInput = ({
@@ -85,6 +86,7 @@ export const AssetInput = ({
     onUploadClick,
     onMultiAssetClick,
     acceptFileType,
+    disabled = false,
 }: AssetInputProps): ReactElement => {
     const assetsLength = assets.length;
     const inputFile = useRef<HTMLInputElement | null>(null);
@@ -139,6 +141,7 @@ export const AssetInput = ({
                         onClick={onOpenFileUpload}
                         emphasis={ButtonEmphasis.Weak}
                         icon={<IconArrowCircleUp />}
+                        disabled={disabled}
                     >
                         Upload
                     </Button>
@@ -150,6 +153,7 @@ export const AssetInput = ({
                         accept={acceptFileType}
                         multiple={!!onMultiAssetClick}
                         onChange={onFileChange}
+                        disabled={disabled}
                     />
                 </div>
             )}
@@ -163,6 +167,7 @@ export const AssetInput = ({
                         onClick={onLibraryClick}
                         emphasis={ButtonEmphasis.Weak}
                         icon={<IconImageStack />}
+                        disabled={disabled}
                     >
                         Browse
                     </Button>


### PR DESCRIPTION
## Definition of Done
- [ ] User interface and experience have been verified by a designer
- [ ] I have added thorough Cypress tests (All properties and interactions have been tested).
- [ ] Cross-browser compatibility - The component look consistent in the latest version of Chrome, Safari, Firefox and Edge.
- [ ] I've added documentation in Storybook. all properties are reflected in table and controls.
- [ ] User interface is compliant with WCAG 2.1 AA. Ensure these items are fulfilled:
    - [ ] Keyboard operability: All functionality can be accessed using only the keyboard
    - [ ] Logical tab order: Interactive elements follow a consistent and logical tab order
    - [ ] Visual indication of focus: Focused elements are visually highlighted for keyboard navigation
    - [ ] Color contrast: Sufficient contrast is used between text and background, as well as form fields and background
    - [ ] Alternative visual cues: Information is not solely reliant on color and includes alternative visual indicators
    - [ ] Semantic markup: Headings, lists, and form elements are marked up with appropriate semantic tags
