### PR TITLE
chore: added unsafe_zIndex property to `InlineDialog`

### DIFF
--- a/src/components/InlineDialog/InlineDialog.cy.tsx
+++ b/src/components/InlineDialog/InlineDialog.cy.tsx
@@ -13,6 +13,7 @@ const INLINE_DIALOG_TRIGGER_SELECTOR = '[data-test-id=fondue-inlineDialog-trigge
 const INLINE_DIALOG_SELECTOR = '[data-test-id=fondue-inlineDialog-content]';
 const OUTSIDE_DIALOG_BUTTON = '[data-test-id=outside-button]';
 const INLINE_DIALOG_UNDERLAY = '[data-test-id=fondue-inlineDialog-underlay]';
+const INLINE_DIALOG_CONTENT = '[data-test-id=fondue-inlineDialog-content]';
 
 const InlineDialogComponent = (props: Omit<InlineDialogProps, 'open' | 'anchor' | 'handleClose'>) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -280,6 +281,14 @@ describe('InlineDialog Component', () => {
             cy.viewport(360, 745);
             cy.get(INLINE_DIALOG_TRIGGER_SELECTOR).children().eq(0).click();
             cy.get(INLINE_DIALOG_UNDERLAY).should('exist');
+        });
+    });
+
+    describe('Unsafe zIndex', () => {
+        it('renders with Unsafe custom zIndex', () => {
+            cy.mount(<InlineDialogComponent unsafe_zIndex={2020} />);
+            cy.get(INLINE_DIALOG_TRIGGER_SELECTOR).children().eq(0).click();
+            cy.get(INLINE_DIALOG_CONTENT).parent().should('have.css', 'z-index', '2020');
         });
     });
 });

--- a/src/components/InlineDialog/InlineDialog.stories.tsx
+++ b/src/components/InlineDialog/InlineDialog.stories.tsx
@@ -48,6 +48,9 @@ export default {
             type: 'boolean',
         },
         zIndex: { table: { disable: true } },
+        unsafe_zIndex: {
+            type: 'number',
+        },
     },
 } as Meta<InlineDialogProps>;
 

--- a/src/components/InlineDialog/InlineDialog.tsx
+++ b/src/components/InlineDialog/InlineDialog.tsx
@@ -8,7 +8,7 @@ export type InlineDialogProps = Omit<
     OverlayProps,
     'theme' | 'isDetached' | 'verticalAlignment' | 'withArrow' | 'arrowCustomColors' | 'shadow' | 'isDialog'
 > &
-    Omit<BaseDialogProps, 'darkUnderlay'>;
+    Omit<BaseDialogProps, 'darkUnderlay'> & { unsafe_zIndex?: number };
 
 export const InlineDialog = ({
     children,
@@ -28,6 +28,12 @@ export const InlineDialog = ({
     autoHeight = false,
     roundedCorners = true,
     width = 360,
+    /**
+     * This property is used to override the default zIndex of the overlay.
+     * This is needed to support the legacy Terrific Modal, which dynamically compounds z-indexes to create a "stacked" modal approach.
+     * Once the legacy Terrific Modal is removed/refactored to a pre-determined set of z-indexes, this property can be removed as well.
+     */
+    unsafe_zIndex,
 }: InlineDialogProps) => {
     return (
         <Overlay
@@ -46,11 +52,11 @@ export const InlineDialog = ({
             handleClose={handleClose}
             role={modality === Modality.NonModal ? 'region' : 'dialog'}
             autoHeight={autoHeight}
-            zIndex={Z_INDEX_MODAL}
             roundedCorners={roundedCorners}
             borderRadius="small"
             shadow="medium"
             width={width}
+            zIndex={unsafe_zIndex || Z_INDEX_MODAL}
         >
             {children}
         </Overlay>


### PR DESCRIPTION
Conversation behind the changes in [this PR](https://github.com/Frontify/fondue/pull/1755)

## Definition of Done
- [ ] User interface and experience have been verified by a designer
- [ ] I have added thorough Cypress tests (All properties and interactions have been tested).
- [ ] Cross-browser compatibility - The component look consistent in the latest version of Chrome, Safari, Firefox and Edge.
- [ ] I've added documentation in Storybook. all properties are reflected in table and controls.
- [ ] User interface is compliant with WCAG 2.1 AA. Ensure these items are fulfilled:
    - [ ] Keyboard operability: All functionality can be accessed using only the keyboard
    - [ ] Logical tab order: Interactive elements follow a consistent and logical tab order
    - [ ] Visual indication of focus: Focused elements are visually highlighted for keyboard navigation
    - [ ] Color contrast: Sufficient contrast is used between text and background, as well as form fields and background
    - [ ] Alternative visual cues: Information is not solely reliant on color and includes alternative visual indicators
    - [ ] Semantic markup: Headings, lists, and form elements are marked up with appropriate semantic tags
