### PR TITLE
feat: disabled items unchecked on multiselect tree

### DIFF
--- a/.changeset/five-moons-teach.md
+++ b/.changeset/five-moons-teach.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+feat: disabled items unchecked on multiselect tree

--- a/packages/fondue/src/components/Tree/TreeItem/TreeItemMultiselect.tsx
+++ b/packages/fondue/src/components/Tree/TreeItem/TreeItemMultiselect.tsx
@@ -14,7 +14,7 @@ import {
 } from '../helpers/multiselectTreeItemstyling';
 
 import { ExpandButton } from './ExpandButton';
-import { Checkbox, CheckboxEmphasis, CheckboxSize } from '@components/Checkbox/Checkbox';
+import { Checkbox, CheckboxEmphasis, CheckboxSize, CheckboxState } from '@components/Checkbox/Checkbox';
 import { Container } from '@components/Container';
 import { useMultiselectTreeItem } from './useMultiselectTreeItem';
 
@@ -139,7 +139,11 @@ export const TreeItemMultiselect = memo(
                         label=""
                         onChange={checkBoxOnSelect}
                         size={CheckboxSize.Default}
-                        state={getMultiselectCheckBoxState(isSelected, isPartialSelected)}
+                        state={
+                            isDisabled
+                                ? CheckboxState.Unchecked
+                                : getMultiselectCheckBoxState(isSelected, isPartialSelected)
+                        }
                         tooltip={[]}
                         value={id}
                     />

--- a/packages/fondue/src/components/Tree/utils/mocks.ts
+++ b/packages/fondue/src/components/Tree/utils/mocks.ts
@@ -3,11 +3,12 @@
 import { useEffect, useState } from 'react';
 import { TreeItemMultiselectProps, TreeItemProps } from '../types';
 
-export type TreeItemMock = TreeItemProps & {
-    id: string;
-    nodes?: TreeItemMock[];
-    numChildNodes?: number;
-};
+export type TreeItemMock = TreeItemMultiselectProps &
+    TreeItemProps & {
+        id: string;
+        nodes?: TreeItemMock[];
+        numChildNodes?: number;
+    };
 
 export type TreeItemMockMultiselect = TreeItemMultiselectProps & {
     id: string;
@@ -44,6 +45,7 @@ const testSubCategoryMock: TreeItemMock[] = [
         id: '1-2-3-2',
         label: 'SubItem 2',
         type: 'document-page',
+        isDisabled: true,
     },
     {
         id: '1-2-3-3',


### PR DESCRIPTION
Issue: disabled items get selected and disabled when selecting a parent.
The intention of this PR is not showing as selected a disabled item, it's confusing and misleading.


## Definition of Done
- [ ] User interface and experience have been verified by a designer
- [ ] I have added thorough Cypress tests (All properties and interactions have been tested).
- [ ] Cross-browser compatibility - The component look consistent in the latest version of Chrome, Safari, Firefox and Edge.
- [ ] I've added documentation in Storybook. all properties are reflected in table and controls.
- [ ] User interface is compliant with WCAG 2.1 AA. Ensure these items are fulfilled:
    - [ ] Keyboard operability: All functionality can be accessed using only the keyboard
    - [ ] Logical tab order: Interactive elements follow a consistent and logical tab order
    - [ ] Visual indication of focus: Focused elements are visually highlighted for keyboard navigation
    - [ ] Color contrast: Sufficient contrast is used between text and background, as well as form fields and background
    - [ ] Alternative visual cues: Information is not solely reliant on color and includes alternative visual indicators
    - [ ] Semantic markup: Headings, lists, and form elements are marked up with appropriate semantic tags
