### PR TITLE
feat: add tabIndex prop to Button

### DIFF
--- a/.changeset/nasty-cameras-remember.md
+++ b/.changeset/nasty-cameras-remember.md
@@ -2,4 +2,4 @@
 "@frontify/fondue": minor
 ---
 
-add `tabIndex` prop to `Button`
+feat(Button): add `tabIndex` prop

--- a/.changeset/nasty-cameras-remember.md
+++ b/.changeset/nasty-cameras-remember.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": minor
+---
+
+add `tabIndex` prop to `Button`

--- a/packages/fondue/src/components/Button/Button.tsx
+++ b/packages/fondue/src/components/Button/Button.tsx
@@ -51,6 +51,7 @@ export type ButtonProps = {
     /** @deprecated inverted can be done by wrapping the component in a className="tw-dark" */
     inverted?: boolean;
     'data-test-id'?: string;
+    tabIndex?: number;
 };
 
 const ButtonComponent: ForwardRefRenderFunction<HTMLButtonElement | null, ButtonProps> = (
@@ -73,6 +74,7 @@ const ButtonComponent: ForwardRefRenderFunction<HTMLButtonElement | null, Button
         solid,
         inverted,
         'data-test-id': dataTestId = 'button',
+        tabIndex,
     },
     externalRef,
 ) => {
@@ -122,6 +124,7 @@ const ButtonComponent: ForwardRefRenderFunction<HTMLButtonElement | null, Button
             disabled={disabled}
             form={formId}
             title={title}
+            tabIndex={tabIndex}
             {...buttonProps}
             {...focusProps}
         >


### PR DESCRIPTION
This adds a prop to the Button to control the `tabIndex` of the child `button` element. Increases opportunities for a11y compliance

CU-869447ekj

## Definition of Done
- [ ] User interface and experience have been verified by a designer
- [ ] I have added thorough Cypress tests (All properties and interactions have been tested).
- [ ] Cross-browser compatibility - The component look consistent in the latest version of Chrome, Safari, Firefox and Edge.
- [ ] I've added documentation in Storybook. all properties are reflected in table and controls.
- [ ] User interface is compliant with WCAG 2.1 AA. Ensure these items are fulfilled:
    - [ ] Keyboard operability: All functionality can be accessed using only the keyboard
    - [ ] Logical tab order: Interactive elements follow a consistent and logical tab order
    - [ ] Visual indication of focus: Focused elements are visually highlighted for keyboard navigation
    - [ ] Color contrast: Sufficient contrast is used between text and background, as well as form fields and background
    - [ ] Alternative visual cues: Information is not solely reliant on color and includes alternative visual indicators
    - [ ] Semantic markup: Headings, lists, and form elements are marked up with appropriate semantic tags
