### PR TITLE
fix(RTE): text style dropdown shows wrong value

### DIFF
--- a/.changeset/twelve-cars-lie.md
+++ b/.changeset/twelve-cars-lie.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix(RTE): text style dropdown shows wrong value

--- a/packages/fondue/src/components/RichTextEditor/Plugins/TextStylePlugin/TextStyleDropdown/useSelectedTextStyles.ts
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/TextStylePlugin/TextStyleDropdown/useSelectedTextStyles.ts
@@ -40,7 +40,7 @@ export const useSelectedTextStyles = (editor: PlateEditor): string[] => {
         const styleToAdd =
             node.type === ELEMENT_LIC || node.type === ELEMENT_CHECK_ITEM
                 ? getTextStyle(node)
-                : (node.textStyle as string);
+                : ((node.textStyle || node.type) as string);
 
         if (styleToAdd && !styles.includes(styleToAdd) && !excludeStyles.includes(styleToAdd)) {
             styles.push(styleToAdd);

--- a/packages/fondue/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/packages/fondue/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -326,6 +326,60 @@ describe('RichTextEditor Component', () => {
         });
     });
 
+    const RichTextEditorWithTextStyles = ({ value }: { value?: string }) => {
+        const pluginsWithColumns = new PluginComposer();
+        pluginsWithColumns.setPlugin([new TextStylePlugin({ textStyles: TextStylePlugins })]);
+
+        return <RichTextEditor plugins={pluginsWithColumns} value={value} />;
+    };
+
+    describe('TextStyle plugin', () => {
+        it('should display the correct text style in the dropdown', () => {
+            cy.mount(
+                <RichTextEditorWithTextStyles
+                    value={JSON.stringify([
+                        {
+                            type: 'heading1',
+                            children: [{ text: 'This a heading 1 text.', textStyle: 'heading1' }],
+                        },
+                    ])}
+                />,
+            );
+            cy.get('[contenteditable=true]').type('{selectall}');
+            cy.get(TOOLBAR_FLOATING).should('include.html', 'Heading 1');
+        });
+
+        it('should display the correct text style in the dropdown if the textstyle is missing', () => {
+            cy.mount(
+                <RichTextEditorWithTextStyles
+                    value={JSON.stringify([
+                        {
+                            type: 'heading1',
+                            children: [{ text: 'This a heading 1 text.' }],
+                        },
+                    ])}
+                />,
+            );
+            cy.get('[contenteditable=true]').type('{selectall}');
+            cy.get(TOOLBAR_FLOATING).should('include.html', 'Heading 1');
+        });
+
+        it('should display mixed if multiple text styles are defined', () => {
+            cy.mount(
+                <RichTextEditorWithTextStyles
+                    value={JSON.stringify([
+                        {
+                            type: 'p',
+                            children: [{ text: 'This a heading 1 text.', textStyle: 'heading1' }],
+                        },
+                    ])}
+                />,
+            );
+            cy.get('[contenteditable=true]').type('{selectall}');
+            cy.get(TOOLBAR_FLOATING).should('include.html', 'Mixed');
+        });
+    });
+
     const RichTextEditorWithTwoColumns = ({ value }: { value?: string }) => {
         const [initialValue, setInitialValue] = useState(value);
 


### PR DESCRIPTION
Try with

```
{
  "type": "heading1",
  "children": [{
    "text": "Sample text"
  }]
}
```

Text style dropdown should show heading1 but it doesn't.