### PR TITLE
fix: prevent overwrite of onClick

### DIFF
--- a/.changeset/gentle-dots-drum.md
+++ b/.changeset/gentle-dots-drum.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix(ActionMenu): Stop internal `onClick` prop of `AriaMenuItem` being overwritten by `ActionMenu` level onClick prop, even if this prop is not supplied. This fixes an issue where touch-to-click commands were not recognised by the `AriaMenuItem`.

--- a/packages/fondue/src/components/ActionMenu/ActionMenu/ActionMenu.cy.tsx
+++ b/packages/fondue/src/components/ActionMenu/ActionMenu/ActionMenu.cy.tsx
@@ -110,4 +110,27 @@ describe('ActionMenu Component', () => {
         cy.get('[data-test-id="add-block-button"]').first().click();
         cy.get(MENU_ITEM_LIST_ID).should('have.length', 3);
     });
+
+    it('should fire both onClick events when touch-to-click is used', () => {
+        const onClickStub = cy.stub().as('onClickStub');
+        const menuOnClickStub = cy.stub().as('menuOnClickStub');
+
+        const menuBlocks = MENU_BLOCKS.map((block) => ({
+            ...block,
+            menuItems: block.menuItems.map((item) => ({
+                ...item,
+                onClick: onClickStub,
+            })),
+        }));
+
+        cy.mount(<ActionMenu menuBlocks={menuBlocks} onClick={menuOnClickStub} />);
+
+        cy.get('@onClickStub').should('not.be.called');
+        // Cypress .click() triggers other events that are not reflected by touch-to-click.
+        cy.get(MENU_ITEM_ID).then(($item) => {
+            $item[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        cy.get('@onClickStub').should('be.calledOnce');
+        cy.get('@menuOnClickStub').should('be.calledOnce');
+    });
 });

--- a/packages/fondue/src/components/ActionMenu/ActionMenu/ActionMenu.tsx
+++ b/packages/fondue/src/components/ActionMenu/ActionMenu/ActionMenu.tsx
@@ -30,6 +30,24 @@ export type ActionMenuProps = {
     focus?: FocusStrategy;
     border?: boolean;
     scrollable?: boolean;
+    /**
+     * @deprecated Use the onClick method available on each `menuItem` in the `menuBlocks` instead.
+     * @example
+     *  <ActionMenu
+          menuBlocks={[
+              {
+                  id: 'menu-block-1',
+                  menuItems: [
+                      {
+                          id: 'menu-item-1',
+                          label: 'Item 1',
+                          onClick: () => console.log('Item 1 clicked');
+                      },
+                  ],
+              },
+          ]}
+        />
+     *  */
     onClick?: () => void;
 };
 

--- a/packages/fondue/src/components/ActionMenu/Aria/AriaMenuItem.tsx
+++ b/packages/fondue/src/components/ActionMenu/Aria/AriaMenuItem.tsx
@@ -19,6 +19,9 @@ export type AriaOptionProps = {
     node: Node<object>;
     isSelected?: boolean;
     state: TreeState<object>;
+    /**
+     *  @deprecated Use `menuItem.onClick` instead
+     *  */
     onClick?: () => void;
 };
 
@@ -94,7 +97,7 @@ export const AriaMenuItem = ({ menuItem, node, state, isSelected, onClick }: Ari
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
         <li
-            {...mergeProps(menuItemProps, focusProps)}
+            {...mergeProps(menuItemProps, focusProps, { onClick: () => onClick?.() })}
             data-test-id="menu-item"
             className={merge([
                 'tw-relative hover:tw-bg-box-neutral-hover tw-list-none tw-outline-none',
@@ -102,12 +105,6 @@ export const AriaMenuItem = ({ menuItem, node, state, isSelected, onClick }: Ari
                 isFocusVisible && FOCUS_STYLE_INSET,
             ])}
             ref={ref}
-            onClick={(event) => {
-                event.stopPropagation();
-                if (onClick) {
-                    onClick();
-                }
-            }}
         >
             <MenuItem
                 title={title}


### PR DESCRIPTION
TASK-10958

Deprecate the `ActionMenu` level `onClick`. (I'm not exactly sure why this was added but there were no instances of it's usage that I could find).

By adding the `onClick` command to the `mergeProps` function it is added to a chain of functions, instead of overwriting the internal `onClick` provided by `useMenuItem`.

This fixes an issue where touch-to-click commands were not recognised by the `ActionMenu`