### PR TITLE
ci: should use pnpm version defined in package.json

### DIFF
--- a/.github/workflows/charts-pull-requests.yaml
+++ b/.github/workflows/charts-pull-requests.yaml
@@ -23,7 +23,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js
@@ -50,7 +49,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js
@@ -77,7 +75,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -19,8 +19,6 @@ jobs:
 
             - name: Use pnpm
               uses: pnpm/action-setup@v3
-              with:
-                  version: 9
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -60,8 +58,6 @@ jobs:
 
             - name: Use pnpm
               uses: pnpm/action-setup@v3
-              with:
-                  version: 9
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -112,7 +108,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Get pnpm store directory
@@ -153,7 +148,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js
@@ -191,8 +185,6 @@ jobs:
 
             - name: Use pnpm
               uses: pnpm/action-setup@v3
-              with:
-                  version: 9
 
             - name: Use Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/docs-pull-requests.yaml
+++ b/.github/workflows/docs-pull-requests.yaml
@@ -21,7 +21,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js

--- a/.github/workflows/fondue-pull-requests.yaml
+++ b/.github/workflows/fondue-pull-requests.yaml
@@ -23,7 +23,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js
@@ -56,7 +55,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js
@@ -108,7 +106,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Get pnpm store directory
@@ -148,7 +145,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Use Node.js

--- a/.github/workflows/pull-request-security-audit.yaml
+++ b/.github/workflows/pull-request-security-audit.yaml
@@ -25,7 +25,6 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: 9
                   run_install: false
 
             - name: Audit NPM packages

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "root",
     "private": true,
     "type": "module",
-    "packageManager": "pnpm@9.0.6+sha256.0624e30eff866cdeb363b15061bdb7fd9425b17bc1bb42c22f5f4efdea21f6b3",
+    "packageManager": "pnpm@9.1.0+sha512.67f5879916a9293e5cf059c23853d571beaf4f753c707f40cb22bed5fb1578c6aad3b6c4107ccb3ba0b35be003eb621a16471ac836c87beb53f9d54bb4612724",
     "engines": {
         "node": "^22",
         "npm": "<=0"


### PR DESCRIPTION
So [this](https://github.com/Frontify/fondue/actions/runs/8968679284/job/24628597757?pr=1855) (the ci) should not fail anymore, as it should use the pnpm version defined in the `package.json`

After discussion with @noahwaldner also bumping `pnpm` to `9.1.0`