### PR TITLE
fix: tailwind config: override the entire screens key for the right order of breakpoints

### DIFF
--- a/.changeset/seven-actors-greet.md
+++ b/.changeset/seven-actors-greet.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": minor
+"@frontify/fondue": minor
+---
+
+tailwind config: override the entire `screens` key to add smaller xs key at the beginning of the list

--- a/.changeset/seven-actors-greet.md
+++ b/.changeset/seven-actors-greet.md
@@ -3,4 +3,4 @@
 "@frontify/fondue": minor
 ---
 
-tailwind config: override the entire `screens` key to add smaller xs key at the beginning of the list
+fix: make the `xs:` breakpoint work correctly

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -125,14 +125,7 @@ export default {
                 height: 'height',
                 width: 'width',
             },
-            screens: {
-                xs: '390px',
-                sm: '600px',
-                md: '768px',
-                lg: '1024px',
-                xl: '1280px',
-                '2xl': '1536px',
-            },
+
             animation: {
                 'loading-bar-infinite': 'loading-bar-infinite 1s infinite linear',
             },
@@ -146,6 +139,14 @@ export default {
             transformOrigin: {
                 'left-right': '0% 50%',
             },
+        },
+        screens: {
+            xs: '390px',
+            sm: '600px',
+            md: '768px',
+            lg: '1024px',
+            xl: '1280px',
+            '2xl': '1536px',
         },
     },
 } satisfies Config;

--- a/packages/fondue/tailwind.config.ts
+++ b/packages/fondue/tailwind.config.ts
@@ -123,14 +123,14 @@ export default {
                 height: 'height',
                 width: 'width',
             },
-            screens: {
-                xs: '390px',
-                sm: '600px',
-                md: '768px',
-                lg: '1024px',
-                xl: '1280px',
-                '2xl': '1536px',
-            },
+        },
+        screens: {
+            xs: '390px',
+            sm: '600px',
+            md: '768px',
+            lg: '1024px',
+            xl: '1280px',
+            '2xl': '1536px',
         },
     },
 } satisfies Config;


### PR DESCRIPTION
If you want to add an additional small breakpoint, you can’t use extend because the small breakpoint would be added to the end of the breakpoint list
https://tailwindcss.com/docs/screens#adding-smaller-breakpoints