### PR TITLE
feat: add focus outline for all components

### DIFF
--- a/.changeset/unlucky-waves-shop.md
+++ b/.changeset/unlucky-waves-shop.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat: add focus outline for all components

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -2,7 +2,6 @@
 
 import { forwardRef, type ForwardedRef, type MouseEvent, type ReactNode } from 'react';
 
-import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { cn } from '#/utilities/styleUtilities';
 
 import { buttonStyles } from './styles/buttonStyles';
@@ -88,7 +87,6 @@ export const Button = forwardRef<HTMLButtonElement | null, ButtonProps>(
                     textStyles({ style, ...props }),
                     iconStyles({ style, ...props }),
                     className,
-                    FOCUS_OUTLINE,
                 )}
                 onClick={onPress}
                 {...props}

--- a/packages/components/src/components/Button/styles/buttonStyles.ts
+++ b/packages/components/src/components/Button/styles/buttonStyles.ts
@@ -1,9 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { sv } from '#/utilities/styleUtilities';
 
 export const buttonStyles = sv({
-    base: 'tw-group tw-border tw-relative tw-flex tw-flex-row tw-gap-2 tw-items-center tw-justify-center tw-cursor-pointer tw-font-body tw-font-medium',
+    base:
+        'tw-group tw-border tw-relative tw-flex tw-flex-row tw-gap-2 tw-items-center tw-justify-center tw-cursor-pointer tw-font-body tw-font-medium ' +
+        `${FOCUS_OUTLINE}`,
     variants: {
         disabled: {
             true: 'tw-not-allowed tw-pointer-events-none tw-border-transparent tw-text-box-disabled-inverse tw-bg-box-disabled',

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,6 @@ import { IconCheckMark, IconMinus } from '@frontify/fondue-icons';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { forwardRef, type FormEvent, type ForwardedRef } from 'react';
 
-import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { cn } from '#/utilities/styleUtilities';
 
 import { checkboxIndicatorStyles, checkboxStyles } from './styles/checkboxStyles';
@@ -83,7 +82,7 @@ export const CheckboxComponent = (
             ref={ref}
             checked={value}
             defaultChecked={defaultValue}
-            className={cn(checkboxStyles(props), FOCUS_OUTLINE, className)}
+            className={cn(checkboxStyles(props), className)}
             onClick={onChange}
             data-test-id={dataTestId}
             {...props}

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -4,9 +4,9 @@ import { IconCheckMark, IconMinus } from '@frontify/fondue-icons';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { forwardRef, type FormEvent, type ForwardedRef } from 'react';
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { cn } from '#/utilities/styleUtilities';
 
-import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { checkboxIndicatorStyles, checkboxStyles } from './styles/checkboxStyles';
 
 export type CheckboxProps = {

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -2,10 +2,11 @@
 
 import { IconCheckMark, IconMinus } from '@frontify/fondue-icons';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
-import { type FormEvent, forwardRef, type ForwardedRef } from 'react';
+import { forwardRef, type FormEvent, type ForwardedRef } from 'react';
 
 import { cn } from '#/utilities/styleUtilities';
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { checkboxIndicatorStyles, checkboxStyles } from './styles/checkboxStyles';
 
 export type CheckboxProps = {
@@ -82,7 +83,7 @@ export const CheckboxComponent = (
             ref={ref}
             checked={value}
             defaultChecked={defaultValue}
-            className={cn(checkboxStyles(props), className)}
+            className={cn(checkboxStyles(props), FOCUS_OUTLINE, className)}
             onClick={onChange}
             data-test-id={dataTestId}
             {...props}

--- a/packages/components/src/components/Checkbox/styles/checkboxStyles.ts
+++ b/packages/components/src/components/Checkbox/styles/checkboxStyles.ts
@@ -8,7 +8,6 @@ export const checkboxStyles = sv({
         'tw-peer tw-relative tw-inline-flex tw-bg-base tw-text-white tw-shrink-0 tw-rounded tw-border tw-border-line-x-strong group-hover:tw-border-line-xx-strong hover:tw-border-line-xx-strong tw-transition-colors ' +
         'data-[state="checked"]:tw-border-transparent data-[state="indeterminate"]:tw-border-transparent ' +
         'disabled:tw-border-line-strong disabled:tw-bg-base disabled:tw-cursor-not-allowed data-[state="checked"]:disabled:tw-bg-box-disabled-strong ' +
-        'focus-visible:tw-outline focus-visible:tw-outline-blue ' +
         `${FOCUS_OUTLINE}`,
     variants: {
         size: {

--- a/packages/components/src/components/Checkbox/styles/checkboxStyles.ts
+++ b/packages/components/src/components/Checkbox/styles/checkboxStyles.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { sv } from '#/utilities/styleUtilities';
 
 export const checkboxStyles = sv({
@@ -7,7 +8,8 @@ export const checkboxStyles = sv({
         'tw-peer tw-relative tw-inline-flex tw-bg-base tw-text-white tw-shrink-0 tw-rounded tw-border tw-border-line-x-strong group-hover:tw-border-line-xx-strong hover:tw-border-line-xx-strong tw-transition-colors ' +
         'data-[state="checked"]:tw-border-transparent data-[state="indeterminate"]:tw-border-transparent ' +
         'disabled:tw-border-line-strong disabled:tw-bg-base disabled:tw-cursor-not-allowed data-[state="checked"]:disabled:tw-bg-box-disabled-strong ' +
-        'focus-visible:tw-outline focus-visible:tw-outline-blue ',
+        'focus-visible:tw-outline focus-visible:tw-outline-blue ' +
+        `${FOCUS_OUTLINE}`,
     variants: {
         size: {
             default: 'tw-size-4',

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -4,8 +4,6 @@ import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { forwardRef, type ForwardedRef, type ReactNode } from 'react';
 
 import { useControllableState } from '#/hooks/useControllableState';
-import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
-import { cn } from '#/utilities/styleUtilities';
 
 import {
     segmentedControlActiveIndicatorStyles,
@@ -82,12 +80,7 @@ export const SegmentedControlItem = (
     { children, ...itemProps }: SegmentedControlItemProps,
     ref: ForwardedRef<HTMLButtonElement>,
 ) => (
-    <ToggleGroupPrimitive.Item
-        ref={ref}
-        {...itemProps}
-        className={cn(segmentedControlItemStyles, FOCUS_OUTLINE)}
-        asChild={false}
-    >
+    <ToggleGroupPrimitive.Item ref={ref} {...itemProps} className={segmentedControlItemStyles} asChild={false}>
         {/* Separator */}
         <span className={segmentedControlItemSeparatorStyles} />
         <span className={segmentedControlItemLabelStyles}>

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -5,6 +5,8 @@ import { forwardRef, type ForwardedRef, type ReactNode } from 'react';
 
 import { useControllableState } from '#/hooks/useControllableState';
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
+import { cn } from '#/utilities/styleUtilities';
 import {
     segmentedControlActiveIndicatorStyles,
     segmentedControlItemLabelActiveStyles,
@@ -80,7 +82,12 @@ export const SegmentedControlItem = (
     { children, ...itemProps }: SegmentedControlItemProps,
     ref: ForwardedRef<HTMLButtonElement>,
 ) => (
-    <ToggleGroupPrimitive.Item ref={ref} {...itemProps} className={segmentedControlItemStyles} asChild={false}>
+    <ToggleGroupPrimitive.Item
+        ref={ref}
+        {...itemProps}
+        className={cn(segmentedControlItemStyles, FOCUS_OUTLINE)}
+        asChild={false}
+    >
         {/* Separator */}
         <span className={segmentedControlItemSeparatorStyles} />
         <span className={segmentedControlItemLabelStyles}>

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -4,9 +4,9 @@ import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { forwardRef, type ForwardedRef, type ReactNode } from 'react';
 
 import { useControllableState } from '#/hooks/useControllableState';
-
 import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { cn } from '#/utilities/styleUtilities';
+
 import {
     segmentedControlActiveIndicatorStyles,
     segmentedControlItemLabelActiveStyles,

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -11,7 +11,7 @@ export const segmentedControlItemStyles =
     // Apply border radius based on the index
     'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
     // Focus styles for keyboard navigation
-    `${FOCUS_OUTLINE} focus-visible:!tw-rounded-[calc(var(--radius)-var(--line-width))]`;
+    `${FOCUS_OUTLINE} focus-visible:tw-rounded-[calc(var(--radius)-var(--line-width))]`;
 
 export const segmentedControlActiveIndicatorStyles =
     'tw-hidden tw-absolute -tw-z-[1] tw-top-0 tw-left-0 tw-h-full tw-pointer-events-none tw-transition-transform ' +

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -11,7 +11,7 @@ export const segmentedControlItemStyles =
     // Apply border radius based on the index
     'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
     // Focus styles for keyboard navigation
-    `${FOCUS_OUTLINE}`;
+    `${FOCUS_OUTLINE} focus-visible:!tw-rounded-[calc(var(--radius)-var(--line-width))]`;
 
 export const segmentedControlActiveIndicatorStyles =
     'tw-hidden tw-absolute -tw-z-[1] tw-top-0 tw-left-0 tw-h-full tw-pointer-events-none tw-transition-transform ' +

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -8,8 +8,6 @@ export const segmentedControlRootStyles =
 
 export const segmentedControlItemStyles =
     'tw-peer tw-group tw-flex tw-items-stretch tw-justify-center tw-select-none ' +
-    // Apply border radius based on the index
-    'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
     // Focus styles for keyboard navigation, custom rounding applied to match the active indicator
     `${FOCUS_OUTLINE} tw-rounded-[calc(var(--radius)-var(--line-width))]`;
 

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -10,8 +10,8 @@ export const segmentedControlItemStyles =
     'tw-peer tw-group tw-flex tw-items-stretch tw-justify-center tw-select-none ' +
     // Apply border radius based on the index
     'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
-    // Focus styles for keyboard navigation
-    `${FOCUS_OUTLINE} focus-visible:tw-rounded-[calc(var(--radius)-var(--line-width))]`;
+    // Focus styles for keyboard navigation, custom rounding applied to match the active indicator
+    `${FOCUS_OUTLINE} tw-rounded-[calc(var(--radius)-var(--line-width))]`;
 
 export const segmentedControlActiveIndicatorStyles =
     'tw-hidden tw-absolute -tw-z-[1] tw-top-0 tw-left-0 tw-h-full tw-pointer-events-none tw-transition-transform ' +

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -9,9 +9,9 @@ export const segmentedControlRootStyles =
 export const segmentedControlItemStyles =
     'tw-peer tw-group tw-flex tw-items-stretch tw-justify-center tw-select-none ' +
     // Apply border radius based on the index
-    'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
+    'first:tw-rounded-l-[calc(var(--radius)-var(--line-width))] [&:nth-last-child(2)]:tw-rounded-r-[calc(var(--radius)-var(--line-width))] ' +
     // Focus styles for keyboard navigation, custom rounding applied to match the active indicator
-    `${FOCUS_OUTLINE} tw-rounded-[calc(var(--radius)-var(--line-width))]`;
+    `${FOCUS_OUTLINE} focus-visible:tw-rounded-[calc(var(--radius)-var(--line-width))]`;
 
 export const segmentedControlActiveIndicatorStyles =
     'tw-hidden tw-absolute -tw-z-[1] tw-top-0 tw-left-0 tw-h-full tw-pointer-events-none tw-transition-transform ' +

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -8,6 +8,8 @@ export const segmentedControlRootStyles =
 
 export const segmentedControlItemStyles =
     'tw-peer tw-group tw-flex tw-items-stretch tw-justify-center tw-select-none ' +
+    // Apply border radius based on the index
+    'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
     // Focus styles for keyboard navigation, custom rounding applied to match the active indicator
     `${FOCUS_OUTLINE} tw-rounded-[calc(var(--radius)-var(--line-width))]`;
 

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -11,7 +11,6 @@ export const segmentedControlItemStyles =
     // Apply border radius based on the index
     'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
     // Focus styles for keyboard navigation
-    'focus-visible:tw-rounded-[inherit] focus-visible:tw-outline focus-visible:tw-outline-blue' +
     `${FOCUS_OUTLINE}`;
 
 export const segmentedControlActiveIndicatorStyles =

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControlStyles.ts
@@ -1,5 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
+
 export const segmentedControlRootStyles =
     'tw-inline-grid tw-h-9 tw-grid-flow-col tw-auto-cols-[1fr] tw-items-stretch tw-bg-base-alt disabled:tw-bg-base-alt ' +
     'tw-border tw-border-line-strong tw-rounded tw-relative tw-min-w-max tw-font-sans tw-font-normal tw-text-center tw-isolate';
@@ -9,7 +11,8 @@ export const segmentedControlItemStyles =
     // Apply border radius based on the index
     'first:tw-rounded-l-[inherit] [&:nth-last-child(2)]:tw-rounded-r-[inherit] ' +
     // Focus styles for keyboard navigation
-    'focus-visible:tw-rounded-[inherit] focus-visible:tw-outline focus-visible:tw-outline-blue';
+    'focus-visible:tw-rounded-[inherit] focus-visible:tw-outline focus-visible:tw-outline-blue' +
+    `${FOCUS_OUTLINE}`;
 
 export const segmentedControlActiveIndicatorStyles =
     'tw-hidden tw-absolute -tw-z-[1] tw-top-0 tw-left-0 tw-h-full tw-pointer-events-none tw-transition-transform ' +

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconCheckMark, IconExclamationMarkTriangle } from '@frontify/fondue-icons';
-import { forwardRef, type ChangeEvent, type ForwardedRef, type KeyboardEvent, type ReactNode } from 'react';
+import { forwardRef, useRef, type ChangeEvent, type ForwardedRef, type KeyboardEvent, type ReactNode } from 'react';
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { cn } from '#/utilities/styleUtilities';
 
 import { inputStyles, loadingStatusStyles, rootStyles, slotStyles } from './styles/textInputStyles';
@@ -103,13 +104,35 @@ export const TextFieldRoot = (
     }: TextInputProps,
     ref: ForwardedRef<HTMLInputElement>,
 ) => {
+    const wasClicked = useRef(false);
+
     return (
-        <div className={cn(rootStyles, className)} data-status={status} data-test-id={dataTestId}>
+        <div className={cn(rootStyles, FOCUS_OUTLINE, className)} data-status={status} data-test-id={dataTestId}>
             {status === 'loading' ? (
                 <div className={loadingStatusStyles} data-test-id={`${dataTestId}-loader`} />
             ) : null}
-
-            <input type="text" {...inputProps} ref={ref} className={inputStyles} aria-invalid={status === 'error'} />
+            <input
+                onMouseDown={(mouseEvent) => {
+                    wasClicked.current = true;
+                    mouseEvent.currentTarget.dataset.showFocusRing = 'false';
+                }}
+                type="text"
+                {...inputProps}
+                onFocus={(focusEvent) => {
+                    if (!wasClicked.current) {
+                        focusEvent.target.dataset.showFocusRing = 'true';
+                    }
+                    inputProps.onFocus?.(focusEvent);
+                }}
+                onBlur={(blurEvent) => {
+                    blurEvent.target.dataset.showFocusRing = 'false';
+                    wasClicked.current = false;
+                    inputProps.onBlur?.(blurEvent);
+                }}
+                ref={ref}
+                className={inputStyles}
+                aria-invalid={status === 'error'}
+            />
 
             {status === 'success' ? (
                 <IconCheckMark

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -11,7 +11,6 @@ import {
     type SyntheticEvent,
 } from 'react';
 
-import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
 import { cn } from '#/utilities/styleUtilities';
 
 import { inputStyles, loadingStatusStyles, rootStyles, slotStyles } from './styles/textInputStyles';
@@ -119,7 +118,7 @@ export const TextFieldRoot = (
     const wasClicked = useRef(false);
 
     return (
-        <div className={cn(rootStyles, FOCUS_OUTLINE, className)} data-status={status} data-test-id={dataTestId}>
+        <div className={cn(rootStyles, className)} data-status={status} data-test-id={dataTestId}>
             {status === 'loading' ? (
                 <div className={loadingStatusStyles} data-test-id={`${dataTestId}-loader`} />
             ) : null}

--- a/packages/components/src/components/TextInput/__tests__/TextInput.ct.tsx
+++ b/packages/components/src/components/TextInput/__tests__/TextInput.ct.tsx
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { TextInput } from '../TextInput';
 
 const TEXT_INPUT_TEXT = 'sample text input';
+const TEXT_INPUT_TEST_ID = 'fondue-text-input';
 const TEXT_INPUT_LOADER_TEST_ID = 'fondue-text-input-loader';
 const TEXT_INPUT_SUCCESS_ICON_TEST_ID = 'fondue-text-input-success-icon';
 const TEXT_INPUT_ERROR_ICON_TEST_ID = 'fondue-text-input-error-icon';
@@ -111,4 +112,24 @@ test('render slot on the right side and apply correct focus order', async ({ mou
     await component.press('Tab');
 
     await expect(component.getByTestId('right-button-slot')).toBeFocused();
+});
+
+test('render focus ring when keyboard focused', async ({ mount, page }) => {
+    const component = await mount(<TextInput value={TEXT_INPUT_TEXT} />);
+
+    await page.focus('body');
+    await expect(page.getByTestId(TEXT_INPUT_TEST_ID)).not.toHaveCSS('outline-width', '4px');
+    await page.keyboard.press('Tab');
+    await expect(component.getByRole('textbox')).toBeFocused();
+    await expect(page.getByTestId(TEXT_INPUT_TEST_ID)).toHaveCSS('outline-width', '4px');
+});
+
+test('render no focus ring when keyboard focused', async ({ mount, page }) => {
+    const component = await mount(<TextInput value={TEXT_INPUT_TEXT} />);
+
+    await page.focus('body');
+    await expect(page.getByTestId(TEXT_INPUT_TEST_ID)).not.toHaveCSS('outline-width', '4px');
+    await component.click();
+    await expect(component.getByRole('textbox')).toBeFocused();
+    await expect(page.getByTestId(TEXT_INPUT_TEST_ID)).not.toHaveCSS('outline-width', '4px');
 });

--- a/packages/components/src/components/TextInput/styles/textInputStyles.ts
+++ b/packages/components/src/components/TextInput/styles/textInputStyles.ts
@@ -1,5 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { FOCUS_OUTLINE } from '#/utilities/focusStyle';
+
 export const rootStyles =
     'tw-group tw-relative tw-flex tw-items-stretch tw-font-sans tw-font-normal tw-text-start tw-h-9 tw-text-body-medium tw-text-text tw-transition-colors ' +
     // Focus and border styles
@@ -9,7 +11,8 @@ export const rootStyles =
     // Disabled styles
     'has-[input:disabled]:tw-border-line-weak has-[input:disabled]:tw-bg-box-disabled ' +
     // Success and error status styles
-    'data-[status="success"]:tw-border-text-positive data-[status="error"]:tw-border-text-negative ';
+    'data-[status="success"]:tw-border-text-positive data-[status="error"]:tw-border-text-negative ' +
+    `${FOCUS_OUTLINE}`;
 
 export const inputStyles =
     'tw-peer/input tw-w-full tw-bg-transparent placeholder:tw-text-text-x-weak tw-flex tw-items-center [text-align:inherit] tw-indent-3 tw-outline-none tw-rounded-[calc(var(--radius)_-_var(--line-width))] ' +

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,3 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export const FOCUS_OUTLINE = 'focus-visible:tw-outline has-[[data-show-focus-ring="true"]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';
+export const FOCUS_OUTLINE =
+    'focus-visible:tw-outline has-[[data-show-focus-ring="true"]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,13 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { cn } from './styleUtilities';
-
-export const FOCUS_STYLE = 'tw-ring-4 tw-ring-blue tw-ring-offset-2 dark:tw-ring-offset-black tw-outline-none';
-export const FOCUS_STYLE_NO_OFFSET = 'tw-ring-4 tw-ring-blue dark:tw-ring-offset-black tw-outline-none';
-export const FOCUS_VISIBLE_STYLE =
-    'focus-visible:tw-ring-4 focus-visible:tw-ring-blue focus-visible:tw-ring-offset-2 focus-visible:dark:tw-ring-offset-black focus-visible:tw-outline-none';
-export const FOCUS_STYLE_INSET = cn([FOCUS_STYLE, 'tw-ring-inset']);
-export const FOCUS_VISIBLE_STYLE_INSET = cn([FOCUS_VISIBLE_STYLE, 'tw-ring-inset']);
-export const FOCUS_WITHIN_STYLE =
-    'focus-within:tw-ring-4 focus-within:tw-ring-blue focus-within:tw-ring-offset-2 focus-within:dark:tw-ring-offset-black focus-within:tw-outline-none';
 export const FOCUS_OUTLINE = 'focus-visible:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';
+

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,4 +1,3 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export const FOCUS_OUTLINE = 'focus-visible:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';
-
+export const FOCUS_OUTLINE = 'focus-visible:tw-outline has-[[data-show-focus-ring="true"]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';


### PR DESCRIPTION
This change adds our global focus ring to all components.

The TextInputField is handled manually, because text input elements behave differently with `:focus-visible`