### PR TITLE
fix: remove double quote breaking tests

### DIFF
--- a/.changeset/lovely-frogs-judge.md
+++ b/.changeset/lovely-frogs-judge.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: remove double quote breaking tests

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,4 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export const FOCUS_OUTLINE =
-    'focus-visible:tw-outline has-[[data-show-focus-ring="true"]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';
+    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';


### PR DESCRIPTION
In vitest, the component double quote makes the rest of the class unescaped and interpreted as props
`class="focus-visible:tw-outline has-[[data-show-focus-ring="true"]]:tw-outline tw-outline-4"` is going to be rendered as
`class="focus-visible:tw-outline has-[[data-show-focus-ring=" true="" :tw-outline="" tw-outline-4=""`