### PR TITLE
feat(RTE): add custom class to column break plugin

### DIFF
--- a/.changeset/gentle-crabs-report.md
+++ b/.changeset/gentle-crabs-report.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+feat(RTE): add custom class to column break plugin

--- a/packages/fondue/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/createColumnBreakPlugin.ts
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/createColumnBreakPlugin.ts
@@ -1,9 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type BreakAfterPluginProps } from '@components/RichTextEditor/Plugins/ColumnBreakPlugin/types';
 import { type PlatePlugin, createPluginFactory } from '@udecode/plate-core';
 import { type CSSProperties } from 'react';
 
-import { Plugin, type PluginProps } from '../Plugin';
+import { Plugin } from '../Plugin';
 
 import { ColumnBreakButton } from './ColumnBreakButton';
 import { onKeyDownColumnBreak } from './onKeyDownColumnBreak';
@@ -15,21 +16,27 @@ export const GAP_DEFAULT = 'normal';
 export class BreakAfterPlugin extends Plugin {
     private columns: number;
     private gap: CSSProperties['gap'];
-    constructor(props?: PluginProps) {
+    private customClass: string | undefined;
+    constructor(props?: BreakAfterPluginProps) {
         super('break-after-plugin', {
             button: ColumnBreakButton,
             ...props,
         });
         this.columns = props?.columns ?? 1;
         this.gap = props?.gap ?? GAP_DEFAULT;
+        this.customClass = props?.customClass;
     }
 
     plugins(): PlatePlugin[] {
-        return [createColumnBreakPlugin(this.columns, this.gap)];
+        return [createColumnBreakPlugin(this.columns, this.gap, this.customClass)];
     }
 }
 
-export const createColumnBreakPlugin = (columns: number, gap: CSSProperties['gap']): PlatePlugin => {
+export const createColumnBreakPlugin = (
+    columns: number,
+    gap: CSSProperties['gap'],
+    customClass: string | undefined,
+): PlatePlugin => {
     return createPluginFactory({
         key: KEY_ELEMENT_BREAK_AFTER_COLUMN,
         handlers: {
@@ -39,6 +46,7 @@ export const createColumnBreakPlugin = (columns: number, gap: CSSProperties['gap
         options: {
             columns,
             gap,
+            customClass,
             hotkey: ['shift+ctrl+enter'],
         },
     })();

--- a/packages/fondue/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/createColumnBreakPlugin.ts
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/createColumnBreakPlugin.ts
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type BreakAfterPluginProps } from '@components/RichTextEditor/Plugins/ColumnBreakPlugin/types';
 import { type PlatePlugin, createPluginFactory } from '@udecode/plate-core';
 import { type CSSProperties } from 'react';
+
+import { type BreakAfterPluginProps } from '@components/RichTextEditor/Plugins/ColumnBreakPlugin/types';
 
 import { Plugin } from '../Plugin';
 

--- a/packages/fondue/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/types.ts
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/ColumnBreakPlugin/types.ts
@@ -1,0 +1,12 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type PluginProps } from '@components/RichTextEditor/Plugins/Plugin';
+
+export type BreakAfterPluginProps = PluginProps & {
+    columns?: number;
+    gap?: string | number;
+    /**
+     * If provided the `columns` and `gap` properties will be ignored
+     */
+    customClass?: string;
+};

--- a/packages/fondue/src/components/RichTextEditor/Plugins/Plugin.ts
+++ b/packages/fondue/src/components/RichTextEditor/Plugins/Plugin.ts
@@ -15,8 +15,6 @@ export type PluginProps = {
     markupInputElement?: MarkupElement;
     leafMarkupElements?: MarkupElement | MarkupElement[];
     showIn?: Position[];
-    columns?: number;
-    gap?: string | number;
     label?: string;
     textStyles?: Plugin<PluginProps>[];
     styles?: CSSProperties;

--- a/packages/fondue/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/fondue/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,11 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { BlurObserver } from '@components/RichTextEditor/BlurObserver';
-import { useMemoizedId } from '@hooks/useMemoizedId';
 import { Plate, PlateContent, type TEditableProps } from '@udecode/plate-core';
-import { merge } from '@utilities/merge';
 import { noop } from 'lodash-es';
 import { type KeyboardEvent, useCallback, useMemo } from 'react';
+
+import { BlurObserver } from '@components/RichTextEditor/BlurObserver';
+import { useMemoizedId } from '@hooks/useMemoizedId';
+import { merge } from '@utilities/merge';
 
 import { ContentReplacement } from './ContentReplacement';
 import { GAP_DEFAULT, KEY_ELEMENT_BREAK_AFTER_COLUMN, type PluginComposer, defaultPlugins } from './Plugins';

--- a/packages/fondue/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/fondue/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Plate, PlateContent, type TEditableProps } from '@udecode/plate-core';
-import { noop } from 'lodash-es';
-import { type KeyboardEvent, useCallback, useMemo } from 'react';
-
 import { BlurObserver } from '@components/RichTextEditor/BlurObserver';
 import { useMemoizedId } from '@hooks/useMemoizedId';
+import { Plate, PlateContent, type TEditableProps } from '@udecode/plate-core';
+import { merge } from '@utilities/merge';
+import { noop } from 'lodash-es';
+import { type KeyboardEvent, useCallback, useMemo } from 'react';
 
 import { ContentReplacement } from './ContentReplacement';
 import { GAP_DEFAULT, KEY_ELEMENT_BREAK_AFTER_COLUMN, type PluginComposer, defaultPlugins } from './Plugins';
@@ -59,8 +59,9 @@ export const RichTextEditor = ({
         onValueChanged,
     });
     const breakAfterPlugin = plugins.plugins.find((plugin) => plugin.key === KEY_ELEMENT_BREAK_AFTER_COLUMN);
-    const columns = breakAfterPlugin?.options?.columns ?? 1;
-    const columnGap = breakAfterPlugin?.options?.gap ?? GAP_DEFAULT;
+    const customClass = breakAfterPlugin?.options?.customClass as string | undefined;
+    const columns = customClass ? null : breakAfterPlugin?.options?.columns ?? 1;
+    const columnGap = customClass ? null : breakAfterPlugin?.options?.gap ?? GAP_DEFAULT;
 
     const style = useMemo(
         () => ({
@@ -88,7 +89,7 @@ export const RichTextEditor = ({
         renderPlaceholder: RenderPlaceholder,
         readOnly,
         onBlur: onBlurHandler,
-        className: `${padding}`,
+        className: merge([padding, customClass]),
         style,
         onKeyDown: onKeyDownHandler,
         scrollSelectionIntoView: noop,

--- a/packages/fondue/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
+++ b/packages/fondue/src/components/RichTextEditor/__tests__/RichTextEditor.cy.tsx
@@ -405,6 +405,28 @@ describe('RichTextEditor Component', () => {
         );
     };
 
+    const RichTextEditorWithCustomColumnClasses = ({ value }: { value?: string }) => {
+        const [initialValue, setInitialValue] = useState(value);
+
+        const pluginsWithColumns = new PluginComposer();
+        pluginsWithColumns
+            .setPlugin([new SoftBreakPlugin()])
+            .setPlugin([new TextStylePlugin({ textStyles: TextStylePlugins })])
+            .setPlugin(
+                [new BoldPlugin(), new BreakAfterPlugin({ customClass: 'tw-columns-1 @sm:tw-columns-2' })],
+                [new AlignRightPlugin(), new UnorderedListPlugin(), new OrderedListPlugin()],
+            );
+
+        return (
+            <RichTextEditor
+                border={false}
+                plugins={pluginsWithColumns}
+                value={initialValue}
+                onTextChange={(value) => setInitialValue(value)}
+            />
+        );
+    };
+
     describe('column break plugin', () => {
         it('it should add column break on paragraph', () => {
             cy.mount(<RichTextEditorWithTwoColumns />);
@@ -485,6 +507,13 @@ describe('RichTextEditor Component', () => {
             cy.get('[contenteditable=true]').should('not.include.html', ACTIVE_COLUMN_BREAK_CLASS_NAMES);
             cy.get(TOOLBAR_GROUP_1).children().eq(-1).click();
             cy.get('[contenteditable=true]').should('include.html', ACTIVE_COLUMN_BREAK_CLASS_NAMES);
+        });
+
+        it('it should add custom class if provided', () => {
+            cy.mount(<RichTextEditorWithCustomColumnClasses />);
+            insertTextAndOpenToolbar();
+            cy.get(TOOLBAR_FLOATING).should('be.visible');
+            cy.get('[contenteditable=true]').should('have.class', 'tw-columns-1 @sm:tw-columns-2');
         });
 
         it('it should move the text after the column break to the second column', () => {


### PR DESCRIPTION
This PR adds `customClass` to the `ColumnBreakPlugin`.

With this addition, you can create the plugin like this:

`new BreakAfterPlugin({ customClass: 'tw-columns-1 @sm:tw-columns-2' })`

This allows more fine-grained controls when needed while keeping the original implementation as well.