### PR TITLE
feat: added `whitespace="unset"` to the Text props

### DIFF
--- a/.changeset/smart-dolphins-look.md
+++ b/.changeset/smart-dolphins-look.md
@@ -2,4 +2,4 @@
 "@frontify/fondue": patch
 ---
 
-Text: added `none` as typography whitspace prop
+feat: added `whitespace="none"` to the Text props

--- a/.changeset/smart-dolphins-look.md
+++ b/.changeset/smart-dolphins-look.md
@@ -2,4 +2,4 @@
 "@frontify/fondue": patch
 ---
 
-feat: added `whitespace="none"` to the Text props
+feat: added `whitespace="unset"` to the Text props

--- a/.changeset/smart-dolphins-look.md
+++ b/.changeset/smart-dolphins-look.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+Text: added `none` as typography whitspace prop

--- a/packages/fondue/src/typography/Text/Text.tsx
+++ b/packages/fondue/src/typography/Text/Text.tsx
@@ -1,8 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type AriaAttributes, type ReactElement, type ReactNode } from 'react';
-
 import { merge } from '@utilities/merge';
+import { type AriaAttributes, type ReactElement, type ReactNode } from 'react';
 
 import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from '../shared/records';
 import { type SharedTypographyProps } from '../shared/types';

--- a/packages/fondue/src/typography/Text/Text.tsx
+++ b/packages/fondue/src/typography/Text/Text.tsx
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { merge } from '@utilities/merge';
 import { type AriaAttributes, type ReactElement, type ReactNode } from 'react';
+
+import { merge } from '@utilities/merge';
 
 import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from '../shared/records';
 import { type SharedTypographyProps } from '../shared/types';

--- a/packages/fondue/src/typography/shared/records.ts
+++ b/packages/fondue/src/typography/shared/records.ts
@@ -16,7 +16,7 @@ export const overflowMap: Record<TypographyOverflow, string> = {
 };
 
 export const whitespaceMap: Record<TypographyWhitespace, string> = {
-    none: 'tw-whitespace-none',
+    unset: '',
     normal: 'tw-whitespace-normal',
     nowrap: 'tw-whitespace-nowrap',
     pre: 'tw-whitespace-pre',

--- a/packages/fondue/src/typography/shared/records.ts
+++ b/packages/fondue/src/typography/shared/records.ts
@@ -16,7 +16,7 @@ export const overflowMap: Record<TypographyOverflow, string> = {
 };
 
 export const whitespaceMap: Record<TypographyWhitespace, string> = {
-    none: '',
+    unset: '',
     normal: 'tw-whitespace-normal',
     nowrap: 'tw-whitespace-nowrap',
     pre: 'tw-whitespace-pre',

--- a/packages/fondue/src/typography/shared/records.ts
+++ b/packages/fondue/src/typography/shared/records.ts
@@ -16,7 +16,7 @@ export const overflowMap: Record<TypographyOverflow, string> = {
 };
 
 export const whitespaceMap: Record<TypographyWhitespace, string> = {
-    unset: '',
+    none: '',
     normal: 'tw-whitespace-normal',
     nowrap: 'tw-whitespace-nowrap',
     pre: 'tw-whitespace-pre',

--- a/packages/fondue/src/typography/shared/records.ts
+++ b/packages/fondue/src/typography/shared/records.ts
@@ -16,6 +16,7 @@ export const overflowMap: Record<TypographyOverflow, string> = {
 };
 
 export const whitespaceMap: Record<TypographyWhitespace, string> = {
+    none: 'tw-whitespace-none',
     normal: 'tw-whitespace-normal',
     nowrap: 'tw-whitespace-nowrap',
     pre: 'tw-whitespace-pre',

--- a/packages/fondue/src/typography/shared/types.ts
+++ b/packages/fondue/src/typography/shared/types.ts
@@ -9,7 +9,7 @@ export type SharedTypographyProps = {
 };
 
 export type TypographyOverflow = 'truncate' | 'ellipsis' | 'clip' | 'visible';
-export type TypographyWhitespace = 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap';
+export type TypographyWhitespace = 'none' | 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap';
 export type TypographyDisplay = 'inline-block' | 'block' | 'inline' | 'none';
 export type TypographyWordBreak = 'break-words' | 'break-all' | 'normal';
 export type TypographyDecoration = 'underline' | 'line-through' | 'none';

--- a/packages/fondue/src/typography/shared/types.ts
+++ b/packages/fondue/src/typography/shared/types.ts
@@ -9,7 +9,7 @@ export type SharedTypographyProps = {
 };
 
 export type TypographyOverflow = 'truncate' | 'ellipsis' | 'clip' | 'visible';
-export type TypographyWhitespace = 'unset' | 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap';
+export type TypographyWhitespace = 'none' | 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap';
 export type TypographyDisplay = 'inline-block' | 'block' | 'inline' | 'none';
 export type TypographyWordBreak = 'break-words' | 'break-all' | 'normal';
 export type TypographyDecoration = 'underline' | 'line-through' | 'none';

--- a/packages/fondue/src/typography/shared/types.ts
+++ b/packages/fondue/src/typography/shared/types.ts
@@ -9,7 +9,7 @@ export type SharedTypographyProps = {
 };
 
 export type TypographyOverflow = 'truncate' | 'ellipsis' | 'clip' | 'visible';
-export type TypographyWhitespace = 'none' | 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap';
+export type TypographyWhitespace = 'unset' | 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap';
 export type TypographyDisplay = 'inline-block' | 'block' | 'inline' | 'none';
 export type TypographyWordBreak = 'break-words' | 'break-all' | 'normal';
 export type TypographyDecoration = 'underline' | 'line-through' | 'none';


### PR DESCRIPTION
Added additional prop to whitespace typography because the others are interfering with trucate and clamp over multiple lines. If you set nowrap then you have troubles with breakpoints and cant change without hack.

https://www.loom.com/share/b05eb765afb947899a757bcd1ff1d834?sid=7d50273f-aba6-41ea-8ce8-ab53fde96527