### PR TITLE
chore: add @udecode/plate-common dependency explicitly

### DIFF
--- a/.changeset/old-walls-invent.md
+++ b/.changeset/old-walls-invent.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+chore: add @udecode/plate-common dependency explicitly

--- a/packages/fondue/package.json
+++ b/packages/fondue/package.json
@@ -151,6 +151,7 @@
         "@udecode/plate-break": "^31.0.0",
         "@udecode/plate-code-block": "31.3.4",
         "@udecode/plate-combobox": "^31.0.0",
+        "@udecode/plate-common": "^31.3.2",
         "@udecode/plate-core": "^31.3.2",
         "@udecode/plate-emoji": "^31.0.0",
         "@udecode/plate-floating": "^31.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 5.0.0
       '@frontify/eslint-config-react':
         specifier: ^0.17.6
-        version: 0.17.6(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
+        version: 0.17.6(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
       '@frontify/fondue-tokens':
         specifier: workspace:^
         version: link:../tokens
@@ -246,7 +246,7 @@ importers:
         version: 5.0.0
       '@frontify/eslint-config-react':
         specifier: ^0.17.6
-        version: 0.17.6(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
+        version: 0.17.6(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
       '@frontify/fondue-icons':
         specifier: workspace:^
         version: link:../icons
@@ -267,7 +267,7 @@ importers:
         version: 8.1.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: ^8.1.10
-        version: 8.1.10(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))
+        version: 8.1.10(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))
       '@storybook/addon-links':
         specifier: ^8.1.10
         version: 8.1.10(react@18.3.1)
@@ -294,7 +294,7 @@ importers:
         version: 10.1.0
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))
+        version: 6.4.6(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.0.0(@testing-library/dom@10.1.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -556,6 +556,9 @@ importers:
       '@udecode/plate-combobox':
         specifier: ^31.0.0
         version: 31.0.0(@udecode/plate-common@31.3.2(@types/react@18.3.3)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.0(@babel/core@7.24.7)(@babel/preset-env@7.24.4(@babel/core@7.24.7))(@types/react@18.3.3)(react@18.3.1))(react@18.3.1)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.100.0(slate@0.102.0))(slate-hyperscript@0.100.0(slate@0.102.0))(slate-react@0.102.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.102.0))(slate@0.102.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.102.0))(slate-hyperscript@0.100.0(slate@0.102.0))(slate-react@0.102.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.102.0))(slate@0.102.0)
+      '@udecode/plate-common':
+        specifier: ^31.3.2
+        version: 31.3.2(@types/react@18.3.3)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.0(@babel/core@7.24.7)(@babel/preset-env@7.24.4(@babel/core@7.24.7))(@types/react@18.3.3)(react@18.3.1))(react@18.3.1)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.100.0(slate@0.102.0))(slate-hyperscript@0.100.0(slate@0.102.0))(slate-react@0.102.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.102.0))(slate@0.102.0)
       '@udecode/plate-core':
         specifier: ^31.3.2
         version: 31.3.2(@types/react@18.3.3)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.0(@babel/core@7.24.7)(@babel/preset-env@7.24.4(@babel/core@7.24.7))(@types/react@18.3.3)(react@18.3.1))(react@18.3.1)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.100.0(slate@0.102.0))(slate-hyperscript@0.100.0(slate@0.102.0))(slate-react@0.102.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.102.0))(slate@0.102.0)
@@ -673,7 +676,7 @@ importers:
         version: 5.0.0
       '@frontify/eslint-config-react':
         specifier: ^0.17.6
-        version: 0.17.6(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
+        version: 0.17.6(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
       '@storybook/addon-a11y':
         specifier: ^8.1.10
         version: 8.1.10
@@ -847,7 +850,7 @@ importers:
         version: 5.0.0
       '@frontify/eslint-config-react':
         specifier: ^0.17.6
-        version: 0.17.6(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
+        version: 0.17.6(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
       '@frontify/fondue-tokens':
         specifier: workspace:^
         version: link:../tokens
@@ -862,7 +865,7 @@ importers:
         version: 8.1.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: ^8.1.10
-        version: 8.1.10(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))
+        version: 8.1.10(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))
       '@storybook/addon-links':
         specifier: ^8.1.10
         version: 8.1.10(react@18.3.1)
@@ -1015,7 +1018,7 @@ importers:
         version: 5.0.0
       '@frontify/eslint-config-react':
         specifier: ^0.17.6
-        version: 0.17.6(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
+        version: 0.17.6(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)
       '@storybook/addon-a11y':
         specifier: ^8.1.10
         version: 8.1.10
@@ -1024,7 +1027,7 @@ importers:
         version: 8.1.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: ^8.1.10
-        version: 8.1.10(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))
+        version: 8.1.10(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))
       '@storybook/addon-links':
         specifier: ^8.1.10
         version: 8.1.10(react@18.3.1)
@@ -11852,7 +11855,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@frontify/eslint-config-basic@0.20.5(eslint@8.57.0)(prettier@3.3.2)(typescript@5.5.2)':
+  '@frontify/eslint-config-basic@0.20.5(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.4.0(@typescript-eslint/parser@7.4.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser': 7.4.0(eslint@8.57.0)(typescript@5.5.2)
@@ -11878,9 +11881,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@frontify/eslint-config-react@0.17.6(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)':
+  '@frontify/eslint-config-react@0.17.6(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(react@18.3.1)(typescript@5.5.2)':
     dependencies:
-      '@frontify/eslint-config-basic': 0.20.5(eslint@8.57.0)(prettier@3.3.2)(typescript@5.5.2)
+      '@frontify/eslint-config-basic': 0.20.5(@types/eslint@8.56.9)(eslint@8.57.0)(prettier@3.3.2)(typescript@5.5.2)
       eslint: 8.57.0
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
@@ -13777,11 +13780,11 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/addon-interactions@8.1.10(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))':
+  '@storybook/addon-interactions@8.1.10(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.1.10
-      '@storybook/test': 8.1.10(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))
+      '@storybook/test': 8.1.10(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))
       '@storybook/types': 8.1.10
       polished: 4.2.2
       ts-dedent: 2.2.0
@@ -14320,14 +14323,14 @@ snapshots:
       - prettier
       - supports-color
 
-  '@storybook/test@8.1.10(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))':
+  '@storybook/test@8.1.10(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))':
     dependencies:
       '@storybook/client-logger': 8.1.10
       '@storybook/core-events': 8.1.10
       '@storybook/instrumenter': 8.1.10
       '@storybook/preview-api': 8.1.10
       '@testing-library/dom': 9.3.4
-      '@testing-library/jest-dom': 6.4.6(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))
+      '@testing-library/jest-dom': 6.4.6(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))
       '@testing-library/user-event': 14.5.2(@testing-library/dom@9.3.4)
       '@vitest/expect': 1.3.1
       '@vitest/spy': 1.6.0
@@ -14489,7 +14492,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.6(vitest@1.6.0(@types/node@20.14.7)(@vitest/ui@1.6.0)(happy-dom@14.12.3)(sass@1.77.6)(terser@5.31.1))':
+  '@testing-library/jest-dom@6.4.6(vitest@1.6.0(@types/node@20.14.7)(sass@1.77.6)(terser@5.31.1))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.7


### PR DESCRIPTION
`@udecode/plate-common` is an implicit dependency, however when trying to bump fondue in other packages, the `@udecode/plate-common` dependency resolves to `34.0.0` instead of `31.3.2` which causes a bunch of typeerrors.

[Example](https://github.com/Frontify/brand-sdk/actions/runs/9598422554/job/26469694277?pr=976)


