### PR TITLE
fix: prevent firefox from overriding outline class with global pseudo class def

### DIFF
--- a/.changeset/button-outline-firefox-fix.md
+++ b/.changeset/button-outline-firefox-fix.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+bugfix: prevent firefox from overriding outline class with global pseudo class def

--- a/packages/components/src/utilities/focusStyle.module.scss
+++ b/packages/components/src/utilities/focusStyle.module.scss
@@ -1,15 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 @mixin focus-outline {
-    outline-width: 4px;
-    outline-offset: 2px;
-    outline-color: #5495cf;
-
     &:focus-visible {
         outline-style: solid;
     }
-
     &:has([data-show-focus-ring='true']) {
         outline-style: solid;
+    }
+    &:focus-visible,
+    &:has([data-show-focus-ring='true']) {
+        outline-width: 4px;
+        outline-offset: 2px;
+        outline-color: #5495cf;
     }
 }

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,4 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export const FOCUS_OUTLINE =
-    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue';
+    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue focus-visible:tw-outline-blue'; // second declaration of tw-outline-blue is to assure that in firefox the outline isn't overriden by a global definition of :focus-visible which will take precedence over a class definition (go figure)

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,4 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export const FOCUS_OUTLINE =
-    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue focus-visible:tw-outline-blue'; // second declaration of tw-outline-blue is to assure that in firefox the outline isn't overriden by a global definition of :focus-visible which will take precedence over a class definition (firefox seems to prioritize pseudo classes over classes, go figure)
+    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue focus-visible:tw-outline-blue'; // second declaration of tw-outline-blue is to assure that in firefox the outline isn't overriden by a global definition of :-moz-focusring which is coming from tailwinds normalization styling

--- a/packages/components/src/utilities/focusStyle.ts
+++ b/packages/components/src/utilities/focusStyle.ts
@@ -1,4 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export const FOCUS_OUTLINE =
-    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue focus-visible:tw-outline-blue'; // second declaration of tw-outline-blue is to assure that in firefox the outline isn't overriden by a global definition of :focus-visible which will take precedence over a class definition (go figure)
+    'focus-visible:tw-outline has-[[data-show-focus-ring=true]]:tw-outline tw-outline-4 tw-outline-offset-2 tw-outline-blue focus-visible:tw-outline-blue'; // second declaration of tw-outline-blue is to assure that in firefox the outline isn't overriden by a global definition of :focus-visible which will take precedence over a class definition (firefox seems to prioritize pseudo classes over classes, go figure)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dfa872b3-e2f2-40fa-921f-decb75f96d28)

![image](https://github.com/user-attachments/assets/9ba9c1af-d06a-4161-b15a-d647c4c90e76)

This here global style is given priority over the class declaration that assigns the proper outline. This is a firefox specific declaration that sets `outline:auto` and seems to be coming from [tailwind's normalization styles](https://cdn.frontify.com/css/spa-frontify-index.7dcb291c092af233ee86.css). The `currentcolor` definition basically inherits from the button's text color, which in some cases will match the background color where the button is located (ie. if the button is black with white text on white background) giving the impression that no outline is present. By making the class declaration more specific the issue is fixed.

[CU-869519gyp](https://app.clickup.com/t/869519gyp)