### PR TITLE
fix: remove accordion's empty aria-labelledby, add aria-hidden to icon generator

### DIFF
--- a/.changeset/two-ants-lick.md
+++ b/.changeset/two-ants-lick.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": minor
+"@frontify/fondue-icons": minor
+---
+
+fix: remove empty aria-labelledby from `accordion`, add aria-hidden to `icons`

--- a/packages/fondue/scripts/generateReactIcons.ts
+++ b/packages/fondue/scripts/generateReactIcons.ts
@@ -69,6 +69,7 @@ const generateSvgComponent = async (svgPath: Entry) => {
             svgProps: {
                 className: '{customClassName}',
                 name: `${ICON_COMPONENT_PREFIX}${svgFileName}`,
+                'aria-hidden': 'true',
             },
         },
         { componentName: `${ICON_COMPONENT_PREFIX}${svgFileName}` },

--- a/packages/fondue/src/components/Accordion/AccordionHeaderIcon.tsx
+++ b/packages/fondue/src/components/Accordion/AccordionHeaderIcon.tsx
@@ -22,7 +22,6 @@ export const AccordionHeaderIcon = ({
     'data-test-id': dataTestId = ACCORDION_HEADER_ICON_ID,
 }: AccordionHeaderIconProps): ReactElement => {
     const props = {
-        'aria-labelledby': '',
         size: sizeMap[size],
     };
 

--- a/packages/fondue/src/components/Accordion/AccordionHeaderIcon.tsx
+++ b/packages/fondue/src/components/Accordion/AccordionHeaderIcon.tsx
@@ -20,20 +20,15 @@ export const AccordionHeaderIcon = ({
     size = 'medium',
     isOpen,
     'data-test-id': dataTestId = ACCORDION_HEADER_ICON_ID,
-}: AccordionHeaderIconProps): ReactElement => {
-    const props = {
-        size: sizeMap[size],
-    };
-
-    return (
-        <span data-test-id={`${dataTestId}-wrapper`} className="tw-block">
-            <span
-                data-test-id={dataTestId}
-                className={merge(['tw-block tw-transition-transform', isOpen && 'tw-rotate-180 tw-duration-300'])}
-            >
-                <IconCaretDown {...props} />
-            </span>
+}: AccordionHeaderIconProps): ReactElement => (
+    <span data-test-id={`${dataTestId}-wrapper`} className="tw-block">
+        <span
+            data-test-id={dataTestId}
+            className={merge(['tw-block tw-transition-transform', isOpen && 'tw-rotate-180 tw-duration-300'])}
+        >
+            <IconCaretDown size={sizeMap[size]} />
         </span>
-    );
-};
+    </span>
+);
+
 AccordionHeaderIcon.displayName = 'FondueAccordionHeaderIcon';


### PR DESCRIPTION
Clickup task: [2523021/TASK-11732](https://app.clickup.com/t/2523021/TASK-11732)

This should fix an array of issues for screen readers stumbling into icons and confusing users but it was done in light of an issue reported in respect to the accordion.