### PR TITLE
fix: MultiSelect component not a11y compliant

### DIFF
--- a/.changeset/brave-masks-argue.md
+++ b/.changeset/brave-masks-argue.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix: `MultiSelect` component not a11y compliant

--- a/packages/fondue/src/components/Checkbox/Checkbox.tsx
+++ b/packages/fondue/src/components/Checkbox/Checkbox.tsx
@@ -108,7 +108,6 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
         isSelected: state === CheckboxState.Checked,
     });
     const [showFocus, setShowFocus] = useState<Nullable<boolean>>();
-    const [listeningForKeyboardEvents, setListeningForKeyboardEvents] = useState<Nullable<boolean>>();
     const labelContainer = useRef<HTMLSpanElement>(null);
     const helperTextContainer = useRef<HTMLSpanElement>(null);
     const [isLabelOverflowing, setIsLabelOverflowing] = useState(false);
@@ -125,15 +124,14 @@ const CheckboxComponent: ForwardRefRenderFunction<HTMLInputElement, CheckboxProp
     };
 
     useEffect(() => {
-        if (!listeningForKeyboardEvents) {
-            inputRef?.current?.removeEventListener('keyup', tabFocusListener);
-            inputRef?.current?.addEventListener('keyup', tabFocusListener);
-            inputRef?.current?.removeEventListener('blur', blurListener);
-            inputRef?.current?.addEventListener('blur', blurListener);
+        inputRef?.current?.addEventListener('keyup', tabFocusListener);
+        inputRef?.current?.addEventListener('blur', blurListener);
 
-            setListeningForKeyboardEvents(true);
-        }
-    }, [listeningForKeyboardEvents, inputRef]);
+        return () => {
+            inputRef?.current?.removeEventListener('keyup', tabFocusListener);
+            inputRef?.current?.removeEventListener('blur', blurListener);
+        };
+    }, []);
 
     const { inputProps } = useCheckbox(
         {

--- a/packages/fondue/src/components/Checklist/Checklist.tsx
+++ b/packages/fondue/src/components/Checklist/Checklist.tsx
@@ -113,15 +113,25 @@ export const Checklist = ({
             const currentIndex = focusableElements.indexOf(document.activeElement as HTMLInputElement);
             let nextIndex = currentIndex;
 
-            switch (event.key) {
-                case 'ArrowDown':
-                    nextIndex = (currentIndex + 1) % focusableElements.length;
-                    break;
-                case 'ArrowUp':
-                    nextIndex = (currentIndex - 1 + focusableElements.length) % focusableElements.length;
-                    break;
-                default:
-                    return;
+            if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+                nextIndex++;
+                if (nextIndex === focusableElements.length) {
+                    nextIndex = 0;
+                }
+                if (focusableElements[nextIndex].disabled) {
+                    nextIndex++;
+                }
+            } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+                nextIndex--;
+                if (nextIndex === -1) {
+                    nextIndex = focusableElements.length - 1;
+                }
+
+                if (focusableElements[nextIndex].disabled) {
+                    nextIndex--;
+                }
+            } else {
+                return;
             }
 
             focusableElements[nextIndex].focus();
@@ -155,26 +165,24 @@ export const Checklist = ({
             ])}
             ref={listContainerRef}
         >
-            {checkboxes.map((checkbox, index) => {
-                return (
-                    <div
-                        key={checkbox.value}
-                        style={{
-                            maxWidth: listContainerRef?.current?.getBoundingClientRect().width,
-                            gridColumn:
-                                index === checkboxes.length - 1 && direction === ChecklistDirection.Vertical
-                                    ? getLastItemColumnSpan(checkboxes, columns)
-                                    : undefined,
-                        }}
-                    >
-                        <ChecklistItem
-                            checkbox={checkbox}
-                            state={state}
-                            forwardedRef={(el) => (checkboxRefs.current[index] = el)}
-                        />
-                    </div>
-                );
-            })}
+            {checkboxes.map((checkbox, index) => (
+                <div
+                    key={checkbox.value}
+                    style={{
+                        maxWidth: listContainerRef?.current?.getBoundingClientRect().width,
+                        gridColumn:
+                            index === checkboxes.length - 1 && direction === ChecklistDirection.Vertical
+                                ? getLastItemColumnSpan(checkboxes, columns)
+                                : undefined,
+                    }}
+                >
+                    <ChecklistItem
+                        checkbox={checkbox}
+                        state={state}
+                        forwardedRef={(el) => (checkboxRefs.current[index] = el)}
+                    />
+                </div>
+            ))}
         </div>
     );
 };

--- a/packages/fondue/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fondue/src/components/MultiSelect/MultiSelect.tsx
@@ -2,7 +2,17 @@
 
 import { useButton } from '@react-aria/button';
 import { FocusScope, useFocusRing } from '@react-aria/focus';
-import { type KeyboardEvent, type ReactElement, type ReactNode, useEffect, useId, useRef, useState } from 'react';
+import {
+    type KeyboardEvent,
+    type ReactElement,
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useId,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from 'react';
 import { usePopper } from 'react-popper';
 
 import { CheckboxState } from '@components/Checkbox/Checkbox';
@@ -132,7 +142,7 @@ export const MultiSelect = ({
     };
 
     const handleSpacebarToggle = (e: KeyboardEvent<HTMLDivElement>) => {
-        if (e.code === 'Space') {
+        if (e.code === 'Space' || e.code === 'Enter') {
             toggleOpen();
         }
     };
@@ -187,6 +197,20 @@ export const MultiSelect = ({
         updatePopper().catch(console.error);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeItemKeys]);
+
+    useLayoutEffect(() => {
+        const handleEscapeKey = (event: globalThis.KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setOpen(false);
+            }
+        };
+
+        window.addEventListener('keyup', handleEscapeKey);
+
+        return () => {
+            window.removeEventListener('keyup', handleEscapeKey);
+        };
+    }, []);
 
     return (
         <div className="tw-relative" ref={multiSelectRef}>

--- a/packages/fondue/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fondue/src/components/MultiSelect/MultiSelect.tsx
@@ -6,7 +6,6 @@ import {
     type KeyboardEvent,
     type ReactElement,
     type ReactNode,
-    useCallback,
     useEffect,
     useId,
     useLayoutEffect,


### PR DESCRIPTION
Clickup task: [2523021/TASK-10714](https://app.clickup.com/t/2523021/TASK-10714)

I went ahead and enabled arrow navigation without too much fanciness (no multi directional stuff), it should be enough to make this usable. 

For the life of me I can't get the keyboard nav tests to work here and since this didn't have any of those before and we'll replace this component soon anyway maybe we can let it slide. 