### PR TITLE
fix: fix sass deprecation warning

### DIFF
--- a/.changeset/shy-jeans-rescue.md
+++ b/.changeset/shy-jeans-rescue.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: sass deprecation warning

--- a/packages/components/src/helpers/layout.module.scss
+++ b/packages/components/src/helpers/layout.module.scss
@@ -230,17 +230,23 @@ $layoutProperties: (
                 @error 'Value for "#{$property}" at breakpoint "#{$breakpoint}" is not defined.';
             }
 
-            --#{$breakpoint}-#{$property}: $value-at-breakpoint;
+            & {
+                --#{$breakpoint}-#{$property}: $value-at-breakpoint;
+            }
 
             @if $breakpoint == base {
                 --#{$property}: $value-at-breakpoint;
             }
         }
     } @else {
-        --#{$property}: #{$value};
+        & {
+            --#{$property}: #{$value};
+        }
 
         @each $breakpoint, $min-width in $screens {
-            --#{$breakpoint}-#{$property}: var(--#{$breakpoint}-#{$property}, #{$value});
+            & {
+                --#{$breakpoint}-#{$property}: var(--#{$breakpoint}-#{$property}, #{$value});
+            }
         }
     }
 }


### PR DESCRIPTION
wrap the declerations in `$ {}` to get rid of the deprecation warning in the new sass version