### PR TITLE
feat(bar chart): tooltip changes [CU-8695881ux]

### DIFF
--- a/.changeset/kind-ears-divide.md
+++ b/.changeset/kind-ears-divide.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-charts": patch
+---
+
+Update fondue charts tooltip

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -86,8 +86,8 @@ export default {
             description:
                 'An optional function to format the displayed labels both on the axis and in the tooltip. BarChart data requires unique labels to work well, which can lead to the necessity of enriching the labels so that they are unique, for example appending an id. This prop can be used to format the labels back to its original form.',
         },
-        valueInfoBySeries: {
-            name: 'valueInfoBySeries',
+        valueContextBySeries: {
+            name: 'valueContextBySeries',
             type: { name: 'other', value: 'string[]', required: false },
             description: 'An optional function to individually add info after the formatted value.',
         },
@@ -210,7 +210,7 @@ MultipleDataSets.args = {
     series: filterOnePointPerMonth(browserUsageData),
     width: 1000,
     height: 500,
-    valueInfoBySeries: ['%', 'ºC', '...'],
+    valueContextBySeries: ['%', 'ºC', '...'],
 };
 
 export const MultipleDataSetsWithOnClick = TemplateWithUrl.bind({});

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -86,6 +86,11 @@ export default {
             description:
                 'An optional function to format the displayed labels both on the axis and in the tooltip. BarChart data requires unique labels to work well, which can lead to the necessity of enriching the labels so that they are unique, for example appending an id. This prop can be used to format the labels back to its original form.',
         },
+        valueInfoBySeries: {
+            name: 'valueInfoBySeries',
+            type: { name: 'other', value: 'string[]', required: false },
+            description: 'An optional function to individually add info after the formatted value.',
+        },
     },
 } as Meta<BarChartProps>;
 
@@ -205,6 +210,7 @@ MultipleDataSets.args = {
     series: filterOnePointPerMonth(browserUsageData),
     width: 1000,
     height: 500,
+    valueInfoBySeries: ['%', 'ºC', '...'],
 };
 
 export const MultipleDataSetsWithOnClick = TemplateWithUrl.bind({});

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -31,7 +31,7 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
     legendPosition = 'top',
     valueFormatter = DEFAULT_VALUE_FORMATTER,
     labelFormatter = DEFAULT_LABEL_FORMATTER,
-    valueInfoBySeries = undefined,
+    valueContextBySeries = undefined,
     onBarClick,
 }: BarChartProps<DataPointDetails>) => {
     const [maxLabelHeight, setMaxLabelHeight] = useState<number>(0);
@@ -103,7 +103,7 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
                             scalePadding={scalePadding}
                             valueFormatter={valueFormatter}
                             labelFormatter={labelFormatter}
-                            valueInfoBySeries={valueInfoBySeries}
+                            valueContextBySeries={valueContextBySeries}
                         />
                     </XYChart>
                 </span>

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -31,6 +31,7 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
     legendPosition = 'top',
     valueFormatter = DEFAULT_VALUE_FORMATTER,
     labelFormatter = DEFAULT_LABEL_FORMATTER,
+    valueInfoBySeries = undefined,
     onBarClick,
 }: BarChartProps<DataPointDetails>) => {
     const [maxLabelHeight, setMaxLabelHeight] = useState<number>(0);
@@ -54,7 +55,7 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
     return (
         <div className="tw-flex tw-flex-col tw-gap-6">
             {!hideLegend && legendPosition === 'top' && (
-                <Legend style={'rectangle'} names={series.map((series) => series.name)} />
+                <Legend style="rectangle" names={series.map((series) => series.name)} />
             )}
             {margin && (
                 <span className={onBarClick ? 'bar-chart-cursor-pointer' : ''}>
@@ -95,19 +96,20 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
                         />
                         <Bars series={series} horizontal={horizontal} displayStyle={displayStyle} />
                         <Tooltip
-                            crossHairStyle={'bar'}
+                            crossHairStyle="bar"
                             hideGlyphs
                             colorAccessor={(key) => colorAccessorByKey(key, series)}
                             horizontal={horizontal}
                             scalePadding={scalePadding}
                             valueFormatter={valueFormatter}
                             labelFormatter={labelFormatter}
+                            valueInfoBySeries={valueInfoBySeries}
                         />
                     </XYChart>
                 </span>
             )}
             {!hideLegend && legendPosition === 'bottom' && (
-                <Legend style={'rectangle'} names={series.map((series) => series.name)} />
+                <Legend style="rectangle" names={series.map((series) => series.name)} />
             )}
         </div>
     );

--- a/packages/charts/src/components/BarChart/components/Axes.tsx
+++ b/packages/charts/src/components/BarChart/components/Axes.tsx
@@ -1,10 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { Axis as VisxAxis } from '@visx/xychart';
+import { type Dispatch, type SetStateAction } from 'react';
+
 import { useBandTicks } from '@components/BarChart/components/hooks/useBandTicks';
 import { useRotatedLabel } from '@components/BarChart/components/hooks/useRotatedLabel';
 import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
-import { Axis as VisxAxis } from '@visx/xychart';
-import { type Dispatch, type SetStateAction } from 'react';
 
 import { truncateTextLabel } from '../helpers';
 

--- a/packages/charts/src/components/BarChart/components/Axes.tsx
+++ b/packages/charts/src/components/BarChart/components/Axes.tsx
@@ -38,7 +38,7 @@ export const Axes = ({
     valueFormatter,
     labelFormatter,
 }: AxesProps) => {
-    const formatLabel = (label: string) => truncateTextLabel(labelFormatter(label).toString());
+    const formatLabel = (label: string | number) => truncateTextLabel(labelFormatter(label.toString()));
     const angle = useRotatedLabel(horizontal, updateMaxLabelHeight, updateFirstLabelOverflowsBy, formatLabel);
     const filteredTicks = useBandTicks(horizontal, updateBandScaleTicks);
     const textAnchor = getTextAnchorProp(horizontal, angle);
@@ -46,23 +46,23 @@ export const Axes = ({
     return (
         <>
             <VisxAxis
-                tickClassName={'tick'}
+                tickClassName="tick"
                 tickLength={4}
                 hideAxisLine={false}
-                stroke={'var(--fc-axis-y-color)'}
-                tickStroke={'var(--fc-tick-stroke-color)'}
+                stroke="var(--fc-axis-y-color)"
+                tickStroke="var(--fc-tick-stroke-color)"
                 numTicks={linearAxesTicks.length}
                 orientation={horizontal ? 'bottom' : 'left'}
                 tickValues={linearAxesTicks}
                 tickFormat={valueFormatter}
             />
             <VisxAxis
-                tickClassName={'tick'}
+                tickClassName="tick"
                 tickLength={4}
                 hideAxisLine={false}
                 orientation={horizontal ? 'left' : 'bottom'}
-                stroke={'var(--fc-axis-x-color)'}
-                tickStroke={'var(--fc-tick-stroke-color)'}
+                stroke="var(--fc-axis-x-color)"
+                tickStroke="var(--fc-tick-stroke-color)"
                 tickLabelProps={() => ({
                     angle,
                     textAnchor,

--- a/packages/charts/src/components/BarChart/components/Axes.tsx
+++ b/packages/charts/src/components/BarChart/components/Axes.tsx
@@ -1,11 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Axis as VisxAxis } from '@visx/xychart';
-import { type Dispatch, type SetStateAction } from 'react';
-
 import { useBandTicks } from '@components/BarChart/components/hooks/useBandTicks';
 import { useRotatedLabel } from '@components/BarChart/components/hooks/useRotatedLabel';
 import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
+import { Axis as VisxAxis } from '@visx/xychart';
+import { type Dispatch, type SetStateAction } from 'react';
 
 import { truncateTextLabel } from '../helpers';
 
@@ -38,7 +37,7 @@ export const Axes = ({
     valueFormatter,
     labelFormatter,
 }: AxesProps) => {
-    const formatLabel = (label: string) => truncateTextLabel(labelFormatter(label));
+    const formatLabel = (label: string) => truncateTextLabel(labelFormatter(label).toString());
     const angle = useRotatedLabel(horizontal, updateMaxLabelHeight, updateFirstLabelOverflowsBy, formatLabel);
     const filteredTicks = useBandTicks(horizontal, updateBandScaleTicks);
     const textAnchor = getTextAnchorProp(horizontal, angle);

--- a/packages/charts/src/components/BarChart/types.ts
+++ b/packages/charts/src/components/BarChart/types.ts
@@ -38,6 +38,7 @@ export type BarChartProps<DataPointDetails extends Record<string, any> | void = 
     legendPosition?: LegendPosition;
     valueFormatter?: ValueFormatter;
     labelFormatter?: LabelFormatter;
+    valueInfoBySeries?: string[];
     onBarClick?: (e: BarChartClickHandlerParams<DataPointDetails>) => void;
 };
 

--- a/packages/charts/src/components/BarChart/types.ts
+++ b/packages/charts/src/components/BarChart/types.ts
@@ -38,7 +38,7 @@ export type BarChartProps<DataPointDetails extends Record<string, any> | void = 
     legendPosition?: LegendPosition;
     valueFormatter?: ValueFormatter;
     labelFormatter?: LabelFormatter;
-    valueInfoBySeries?: string[];
+    valueContextBySeries?: string[];
     onBarClick?: (e: BarChartClickHandlerParams<DataPointDetails>) => void;
 };
 

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
@@ -56,7 +56,7 @@ describe('Tooltip', () => {
             glyphProps: [],
         });
         const { getByText } = render(
-            <Tooltip crossHairStyle="line" colorAccessor={(str) => str} valueInfoBySeries={['%', 'ºC', 'F']} />,
+            <Tooltip crossHairStyle="line" colorAccessor={(str) => str} valueContextBySeries={['%', 'ºC', 'F']} />,
         );
 
         expect(getByText(/10 %/i)).toBeDefined();

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
@@ -1,0 +1,66 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { render } from '@testing-library/react';
+import { useContext } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Tooltip } from './Tooltip';
+import { usePositions } from './hooks';
+
+vi.mock('react', async (importOriginal) => ({
+    ...(await importOriginal<typeof Object>()),
+    useContext: vi.fn(),
+}));
+
+vi.mock('./hooks/usePositions', async () => ({
+    usePositions: vi.fn(),
+}));
+
+describe('Tooltip', () => {
+    it('should render the value info by series', () => {
+        vi.mocked(useContext).mockReturnValue({
+            tooltipData: {
+                datumByKey: {
+                    test1: {
+                        datum: {
+                            label: 'test1',
+                            value: 10,
+                        },
+                        index: 1,
+                        key: 'test1',
+                    },
+
+                    test2: {
+                        datum: {
+                            label: 'test2',
+                            value: 20,
+                        },
+                        index: 2,
+                        key: 'test2',
+                    },
+
+                    test3: {
+                        datum: {
+                            label: 'test3',
+                            value: 30,
+                        },
+                        index: 3,
+                        key: 'test3',
+                    },
+                },
+            },
+            tooltipOpen: true,
+        });
+        vi.mocked(usePositions).mockReturnValue({
+            tooltipPosition: { tooltipLeft: 20, tooltipTop: 30 },
+            glyphProps: [],
+        });
+        const { getByText } = render(
+            <Tooltip crossHairStyle="line" colorAccessor={(str) => str} valueInfoBySeries={['%', 'ºC', 'F']} />,
+        );
+
+        expect(getByText(/10 %/i)).toBeDefined();
+        expect(getByText(/20 ºc/i)).toBeDefined();
+        expect(getByText(/30 f/i)).toBeDefined();
+    });
+});

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
@@ -55,9 +55,7 @@ describe('Tooltip', () => {
             tooltipPosition: { tooltipLeft: 20, tooltipTop: 30 },
             glyphProps: [],
         });
-        const { getByText } = render(
-            <Tooltip crossHairStyle="line" colorAccessor={(str) => str} valueContextBySeries={['%', 'ºC', 'F']} />,
-        );
+        const { getByText } = render(<Tooltip crossHairStyle="line" valueContextBySeries={['%', 'ºC', 'F']} />);
 
         expect(getByText(/10 %/i)).toBeDefined();
         expect(getByText(/20 ºc/i)).toBeDefined();

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -36,7 +36,7 @@ const TOOLTIP_NO_STYLE: CSSProperties = {
 export type TooltipCrossHairStyle = 'line' | 'bar';
 
 type TooltipPropsBase = {
-    colorAccessor: (key: string) => string | undefined;
+    colorAccessor?: (key: string) => string | undefined;
     missingValueLabel?: string;
     childSumLabel?: string;
     valueFormatter?: ValueFormatter;
@@ -70,7 +70,7 @@ export const Tooltip = ({
     missingValueLabel = MISSING_VALUE_LABEL,
     childSumLabel,
     scalePadding = 0,
-    colorAccessor,
+    colorAccessor = () => '',
     valueFormatter,
     valueContextBySeries,
     labelFormatter,
@@ -92,12 +92,10 @@ export const Tooltip = ({
         valueFormatter,
         tooltipContext.tooltipData?.datumByKey,
         childSumLabel,
+        valueContextBySeries,
     );
-    const entriesWithFormattedSeries = valueContextBySeries
-        ? entries.map((entry, index) => ({ ...entry, valueContextBySeries: valueContextBySeries[index] }))
-        : entries;
     const shouldReverseEntries = stackingGlyphs;
-    const sortedEntries = shouldReverseEntries ? [...entriesWithFormattedSeries].reverse() : entriesWithFormattedSeries;
+    const sortedEntries = shouldReverseEntries ? [...entries].reverse() : entries;
 
     return (
         <svg ref={containerRef} style={INVISIBLE_STYLES} key={wrapperKey}>

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -42,7 +42,7 @@ type TooltipPropsBase = {
     valueFormatter?: ValueFormatter;
     labelFormatter?: LabelFormatter;
     locale?: string;
-    valueInfoBySeries?: string[];
+    valueContextBySeries?: string[];
 };
 
 type TooltipBarProps = {
@@ -72,7 +72,7 @@ export const Tooltip = ({
     scalePadding = 0,
     colorAccessor,
     valueFormatter,
-    valueInfoBySeries,
+    valueContextBySeries,
     labelFormatter,
     locale,
     stackingGlyphs = false,
@@ -93,8 +93,8 @@ export const Tooltip = ({
         tooltipContext.tooltipData?.datumByKey,
         childSumLabel,
     );
-    const entriesWithFormattedSeries = valueInfoBySeries
-        ? entries.map((entry, index) => ({ ...entry, valueInfoBySeries: valueInfoBySeries[index] }))
+    const entriesWithFormattedSeries = valueContextBySeries
+        ? entries.map((entry, index) => ({ ...entry, valueContextBySeries: valueContextBySeries[index] }))
         : entries;
     const shouldReverseEntries = stackingGlyphs;
     const sortedEntries = shouldReverseEntries ? [...entriesWithFormattedSeries].reverse() : entriesWithFormattedSeries;

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -42,6 +42,7 @@ type TooltipPropsBase = {
     valueFormatter?: ValueFormatter;
     labelFormatter?: LabelFormatter;
     locale?: string;
+    valueInfoBySeries?: string[];
 };
 
 type TooltipBarProps = {
@@ -71,6 +72,7 @@ export const Tooltip = ({
     scalePadding = 0,
     colorAccessor,
     valueFormatter,
+    valueInfoBySeries,
     labelFormatter,
     locale,
     stackingGlyphs = false,
@@ -91,8 +93,11 @@ export const Tooltip = ({
         tooltipContext.tooltipData?.datumByKey,
         childSumLabel,
     );
+    const entriesWithFormattedSeries = valueInfoBySeries
+        ? entries.map((entry, index) => ({ ...entry, valueInfoBySeries: valueInfoBySeries[index] }))
+        : entries;
     const shouldReverseEntries = stackingGlyphs;
-    const sortedEntries = shouldReverseEntries ? [...entries].reverse() : entries;
+    const sortedEntries = shouldReverseEntries ? [...entriesWithFormattedSeries].reverse() : entriesWithFormattedSeries;
 
     return (
         <svg ref={containerRef} style={INVISIBLE_STYLES} key={wrapperKey}>

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -6,6 +6,7 @@ type TooltipEntry = {
     value: string | number;
     type?: string;
     typeByGrouping?: string;
+    valueInfoBySeries?: string;
 };
 
 type TooltipContentV2Props = {
@@ -42,6 +43,7 @@ export const TooltipContent = ({ title, description, entries }: TooltipContentV2
                     color={entry.color}
                     value={entry.value}
                     type={entry?.typeByGrouping}
+                    valueInfoBySeries={entry.valueInfoBySeries}
                 />
             ))}
         </div>
@@ -53,9 +55,10 @@ export type TooltipItemProps = {
     value: string | number;
     color?: string;
     type?: string;
+    valueInfoBySeries?: string;
 };
 
-const TooltipItem = ({ title, value, color, type }: TooltipItemProps) => {
+const TooltipItem = ({ title, value, color, type, valueInfoBySeries }: TooltipItemProps) => {
     return (
         <div key={`${title}-value`} className="tw-text-[var(--fc-base-color)] tw-text-sm tw-font-normal">
             {color && (
@@ -66,7 +69,8 @@ const TooltipItem = ({ title, value, color, type }: TooltipItemProps) => {
                     }}
                 />
             )}
-            {`${type || title}: ${value}`}
+            <span>{`${type || title}: `}</span>
+            <span className="tw-font-semibold">{`${value} ${valueInfoBySeries || ''}`}</span>
         </div>
     );
 };

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -6,7 +6,7 @@ type TooltipEntry = {
     value: string | number;
     type?: string;
     typeByGrouping?: string;
-    valueInfoBySeries?: string;
+    valueContextBySeries?: string;
 };
 
 type TooltipContentV2Props = {
@@ -43,7 +43,7 @@ export const TooltipContent = ({ title, description, entries }: TooltipContentV2
                     color={entry.color}
                     value={entry.value}
                     type={entry?.typeByGrouping}
-                    valueInfoBySeries={entry.valueInfoBySeries}
+                    valueContextBySeries={entry.valueContextBySeries}
                 />
             ))}
         </div>
@@ -55,10 +55,10 @@ export type TooltipItemProps = {
     value: string | number;
     color?: string;
     type?: string;
-    valueInfoBySeries?: string;
+    valueContextBySeries?: string;
 };
 
-const TooltipItem = ({ title, value, color, type, valueInfoBySeries }: TooltipItemProps) => {
+const TooltipItem = ({ title, value, color, type, valueContextBySeries }: TooltipItemProps) => {
     return (
         <div key={`${title}-value`} className="tw-text-[var(--fc-base-color)] tw-text-sm tw-font-normal">
             {color && (
@@ -70,7 +70,7 @@ const TooltipItem = ({ title, value, color, type, valueInfoBySeries }: TooltipIt
                 />
             )}
             <span>{`${type || title}: `}</span>
-            <span className="tw-font-semibold">{`${value} ${valueInfoBySeries || ''}`}</span>
+            <span className="tw-font-semibold">{`${value} ${valueContextBySeries || ''}`}</span>
         </div>
     );
 };

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.spec.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.spec.ts
@@ -83,4 +83,28 @@ describe('getTooltipEntries', () => {
         expect(valueFormatter).toHaveBeenCalledWith(100);
         expect(valueFormatter).toHaveBeenCalledWith(200);
     });
+
+    it('returns data with value context by series', () => {
+        const datumByKey = {
+            series1: {
+                datum: {
+                    label: 'foo',
+                    value: 100,
+                },
+            },
+            series2: {
+                datum: {
+                    label: 'bar',
+                    value: 200,
+                },
+            },
+        } as unknown as { [key: string]: TooltipDatum<LineChartDataPoint> };
+        const colorAccessor = vi.fn();
+        const valueFormatter = vi.fn().mockImplementation((value) => value);
+        const result = getTooltipEntries('No data', colorAccessor, valueFormatter, datumByKey, '', ['%', 'ºC']);
+        expect(result).toEqual([
+            { title: 'series1', value: 100, valueContextBySeries: '%' },
+            { title: 'series2', value: 200, valueContextBySeries: 'ºC' },
+        ]);
+    });
 });

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
@@ -16,23 +16,29 @@ export const getTooltipEntries = (
         [key: string]: TooltipDatum<LineChartDataPoint | BarChartDataPoint>;
     },
     childSumLabel?: string,
+    valueContextBySeries?: string[],
 ) => {
     const dataPoints = [];
     let sum = 0;
-    for (const key in datumByKey) {
-        if (isNoDataKey(key)) {
-            continue;
-        }
 
-        if (childSumLabel) {
-            sum += datumByKey[key]?.datum.value || 0;
-        }
+    if (datumByKey) {
+        for (const [index, key] of Object.keys(datumByKey).entries()) {
+            if (isNoDataKey(key)) {
+                continue;
+            }
 
-        dataPoints.push({
-            title: key,
-            value: getDataPointValue(missingValueLabel, datumByKey[key]?.datum.value, valueFormatter),
-            color: colorAccessor(key),
-        });
+            if (childSumLabel) {
+                sum += datumByKey[key]?.datum.value || 0;
+            }
+
+            dataPoints.push({
+                title: key,
+                value: getDataPointValue(missingValueLabel, datumByKey[key]?.datum.value, valueFormatter),
+                color: colorAccessor(key),
+
+                ...(valueContextBySeries?.[index] ? { valueContextBySeries: valueContextBySeries?.[index] } : {}),
+            });
+        }
     }
 
     if (childSumLabel) {


### PR DESCRIPTION
#### For the new guideline search page, we have a new requirement in the tooltip that requires individual formatting of the values(see design below) 
#### Also fixed an issue where toggling the horizontal field in the bar chart stories wasn't working

### Design
![image](https://github.com/user-attachments/assets/78408932-73c8-44a4-9fb2-9dbd0ffde94c)

### Strorybook
![image](https://github.com/user-attachments/assets/110d5c31-530a-4b0b-8543-e08419da9578)

#### Also fixed an issue where toggling the horizontal field in the bar chart stories wasn't working