### PR TITLE
fix: add outline inset to dropdown and select

### DIFF
--- a/.changeset/wicked-spies-pay.md
+++ b/.changeset/wicked-spies-pay.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: add outline inset option and apply it

--- a/packages/components/src/components/Dropdown/styles/dropdown.module.scss
+++ b/packages/components/src/components/Dropdown/styles/dropdown.module.scss
@@ -51,7 +51,7 @@
     }
 
     &:not(:hover) {
-        @include focus-outline;
+        @include focus-outline(-4px);
     }
 }
 

--- a/packages/components/src/components/Select/styles/select.module.scss
+++ b/packages/components/src/components/Select/styles/select.module.scss
@@ -202,6 +202,9 @@
 
     &[data-highlighted='true'] {
         background-color: var(--box-neutral-color-hover);
+        &:not(:hover) {
+            @include focus-outline-styles(-4px);
+        }
     }
 }
 

--- a/packages/components/src/utilities/focusStyle.module.scss
+++ b/packages/components/src/utilities/focusStyle.module.scss
@@ -1,11 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-@mixin focus-outline {
+@mixin focus-outline-styles($offset: 2px) {
+    outline-style: solid;
+    outline-width: 4px;
+    outline-offset: $offset;
+    outline-color: #4196fb;
+}
+
+@mixin focus-outline($offset: 2px) {
     &:focus-visible,
     &:has([data-show-focus-ring='true']) {
-        outline-style: solid;
-        outline-width: 4px;
-        outline-offset: 2px;
-        outline-color: #4196fb;
+        @include focus-outline-styles($offset);
     }
 }

--- a/packages/components/src/utilities/focusStyle.module.scss
+++ b/packages/components/src/utilities/focusStyle.module.scss
@@ -1,15 +1,20 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-@mixin focus-outline-styles($offset: 2px) {
-    outline-style: solid;
+@mixin focus-outline-base($offset: 2px) {
     outline-width: 4px;
     outline-offset: $offset;
     outline-color: #4196fb;
 }
 
+@mixin focus-outline-styles($offset: 2px) {
+    outline-style: solid;
+    @include focus-outline-styles($offset);
+}
+
 @mixin focus-outline($offset: 2px) {
+    @include focus-outline-base($offset);
     &:focus-visible,
     &:has([data-show-focus-ring='true']) {
-        @include focus-outline-styles($offset);
+        outline-style: solid;
     }
 }


### PR DESCRIPTION
for some reason the jobs are failing because of insufficient memory, locally there are no errors