### PR TITLE
refactor: tooltip value context approach [CU-8695b2cv6]

### DIFF
--- a/.changeset/friendly-pots-kiss.md
+++ b/.changeset/friendly-pots-kiss.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-charts": patch
+---
+
+Tooltip value context changes

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -143,12 +143,12 @@ const browserUsageData = ((): BarChartSeries[] => {
         firefoxSeries.dataPoints.push({
             label: entry.date,
             value: parseFloat(entry.Firefox),
-            valueContext: `(${Math.round(parseInt(entry['Google Chrome'], 10) / parseInt(entry.Firefox, 10))}%)`,
+            valueContext: `(% over Safari: ${Math.round(parseFloat(entry.Firefox) - parseFloat(entry.Safari))}%)`,
         });
         safariSeries.dataPoints.push({
             label: entry.date,
             value: parseFloat(entry.Safari),
-            valueContext: `(CTR ${Math.round(parseInt(entry.Firefox, 10) / parseInt(entry.Safari, 10))}%)`,
+            valueContext: `(% less than Chrome ${Math.round(parseFloat(entry['Google Chrome']) - parseFloat(entry.Safari))}%)`,
         });
     }
 

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -86,11 +86,6 @@ export default {
             description:
                 'An optional function to format the displayed labels both on the axis and in the tooltip. BarChart data requires unique labels to work well, which can lead to the necessity of enriching the labels so that they are unique, for example appending an id. This prop can be used to format the labels back to its original form.',
         },
-        valueContextBySeries: {
-            name: 'valueContextBySeries',
-            type: { name: 'other', value: 'string[]', required: false },
-            description: 'An optional function to individually add info after the formatted value.',
-        },
     },
 } as Meta<BarChartProps>;
 
@@ -148,10 +143,12 @@ const browserUsageData = ((): BarChartSeries[] => {
         firefoxSeries.dataPoints.push({
             label: entry.date,
             value: parseFloat(entry.Firefox),
+            valueContext: `(${Math.round(parseInt(entry['Google Chrome'], 10) / parseInt(entry.Firefox, 10))}%)`,
         });
         safariSeries.dataPoints.push({
             label: entry.date,
             value: parseFloat(entry.Safari),
+            valueContext: `(CTR ${Math.round(parseInt(entry.Firefox, 10) / parseInt(entry.Safari, 10))}%)`,
         });
     }
 
@@ -210,7 +207,6 @@ MultipleDataSets.args = {
     series: filterOnePointPerMonth(browserUsageData),
     width: 1000,
     height: 500,
-    valueContextBySeries: ['%', 'ºC', '...'],
 };
 
 export const MultipleDataSetsWithOnClick = TemplateWithUrl.bind({});

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -1,5 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { Grid, XYChart } from '@visx/xychart';
+import { useState } from 'react';
+
 import { BandwidthAdjuster } from '@components/BarChart/components/BandwidthAdjuster';
 import { getInitialBandTicks } from '@components/BarChart/helpers';
 import { Legend, Tooltip } from '@components/common/components';
@@ -9,8 +12,6 @@ import { useMargin } from '@components/common/hooks';
 import { type ValueFormatter } from '@components/common/types';
 import { BASE_COLORS } from '@theme/consts';
 import { createTheme } from '@theme/createTheme';
-import { Grid, XYChart } from '@visx/xychart';
-import { useState } from 'react';
 
 import { Axes, Bars } from './components';
 import { type BarChartProps } from './types';

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -1,8 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Grid, XYChart } from '@visx/xychart';
-import { useState } from 'react';
-
 import { BandwidthAdjuster } from '@components/BarChart/components/BandwidthAdjuster';
 import { getInitialBandTicks } from '@components/BarChart/helpers';
 import { Legend, Tooltip } from '@components/common/components';
@@ -12,6 +9,8 @@ import { useMargin } from '@components/common/hooks';
 import { type ValueFormatter } from '@components/common/types';
 import { BASE_COLORS } from '@theme/consts';
 import { createTheme } from '@theme/createTheme';
+import { Grid, XYChart } from '@visx/xychart';
+import { useState } from 'react';
 
 import { Axes, Bars } from './components';
 import { type BarChartProps } from './types';
@@ -31,7 +30,6 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
     legendPosition = 'top',
     valueFormatter = DEFAULT_VALUE_FORMATTER,
     labelFormatter = DEFAULT_LABEL_FORMATTER,
-    valueContextBySeries = undefined,
     onBarClick,
 }: BarChartProps<DataPointDetails>) => {
     const [maxLabelHeight, setMaxLabelHeight] = useState<number>(0);
@@ -103,7 +101,6 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
                             scalePadding={scalePadding}
                             valueFormatter={valueFormatter}
                             labelFormatter={labelFormatter}
-                            valueContextBySeries={valueContextBySeries}
                         />
                     </XYChart>
                 </span>

--- a/packages/charts/src/components/BarChart/types.ts
+++ b/packages/charts/src/components/BarChart/types.ts
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 import { type AxisScale, type EventHandlerParams } from '@visx/xychart';
 import { type ScaleBand } from 'd3-scale';
+
+import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 
 type BarChartDataPointBase = {
     label: string;

--- a/packages/charts/src/components/BarChart/types.ts
+++ b/packages/charts/src/components/BarChart/types.ts
@@ -1,14 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 import { type AxisScale, type EventHandlerParams } from '@visx/xychart';
 import { type ScaleBand } from 'd3-scale';
-
-import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 
 type BarChartDataPointBase = {
     label: string;
     value: number | null;
     description?: string;
+    valueContext?: string;
 };
 
 export type BarChartDataPoint<DataPointDetails extends Record<string, any> | void = void> =
@@ -38,7 +38,6 @@ export type BarChartProps<DataPointDetails extends Record<string, any> | void = 
     legendPosition?: LegendPosition;
     valueFormatter?: ValueFormatter;
     labelFormatter?: LabelFormatter;
-    valueContextBySeries?: string[];
     onBarClick?: (e: BarChartClickHandlerParams<DataPointDetails>) => void;
 };
 

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -1,9 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ChartHeading } from '@components/ChartHeading';
 import { type Meta, type StoryFn } from '@storybook/react';
 import { cityTemperature } from '@visx/mock-data';
-
-import { ChartHeading } from '@components/ChartHeading';
 
 import { IconRocket } from '../../utils/components/IconRocket';
 
@@ -147,10 +146,12 @@ const formattedTemperatureData = ((): LineChartSeries[] => {
         newYork.push({
             value: parseInt(obj['New York'], 10),
             timestamp: new Date(obj.date),
+            valueContext: `${Math.round(parseInt(obj['New York'], 10) / parseInt(obj.Austin, 10))}%`,
         });
         sanFrancisco.push({
             value: parseInt(obj['San Francisco'], 10),
             timestamp: new Date(obj.date),
+            valueContext: `(CTR ${Math.round(parseInt(obj['San Francisco'], 10) / parseInt(obj['New York'], 10))}%)`,
         });
     }
 

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -1,9 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ChartHeading } from '@components/ChartHeading';
 import { type Meta, type StoryFn } from '@storybook/react';
 import { cityTemperature } from '@visx/mock-data';
-
-import { ChartHeading } from '@components/ChartHeading';
 
 import { IconRocket } from '../../utils/components/IconRocket';
 
@@ -147,12 +146,12 @@ const formattedTemperatureData = ((): LineChartSeries[] => {
         newYork.push({
             value: parseInt(obj['New York'], 10),
             timestamp: new Date(obj.date),
-            valueContext: `${Math.round(parseInt(obj['New York'], 10) / parseInt(obj.Austin, 10))}%`,
+            valueContext: `Difference with Austin is ${Math.round(parseInt(obj['New York'], 10) - parseInt(obj.Austin, 10))}ºF`,
         });
         sanFrancisco.push({
             value: parseInt(obj['San Francisco'], 10),
             timestamp: new Date(obj.date),
-            valueContext: `(CTR ${Math.round(parseInt(obj['San Francisco'], 10) / parseInt(obj['New York'], 10))}%)`,
+            valueContext: `(Sum with NY is ${parseInt(obj['San Francisco'], 10) + parseInt(obj['New York'], 10)}ºF)`,
         });
     }
 

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ChartHeading } from '@components/ChartHeading';
 import { type Meta, type StoryFn } from '@storybook/react';
 import { cityTemperature } from '@visx/mock-data';
+
+import { ChartHeading } from '@components/ChartHeading';
 
 import { IconRocket } from '../../utils/components/IconRocket';
 

--- a/packages/charts/src/components/LineChart/types.ts
+++ b/packages/charts/src/components/LineChart/types.ts
@@ -6,6 +6,7 @@ export type LineChartDataPoint = {
     timestamp: Date;
     value: number | null;
     description?: string;
+    valueContext?: string;
 };
 
 export type LineChartSeries = {

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
@@ -17,7 +17,7 @@ vi.mock('./hooks/usePositions', async () => ({
 }));
 
 describe('Tooltip', () => {
-    it('should render the value info by series', () => {
+    it('should render the value context if it is present in datum', () => {
         vi.mocked(useContext).mockReturnValue({
             tooltipData: {
                 datumByKey: {
@@ -25,6 +25,7 @@ describe('Tooltip', () => {
                         datum: {
                             label: 'test1',
                             value: 10,
+                            valueContext: '5%',
                         },
                         index: 1,
                         key: 'test1',
@@ -34,6 +35,7 @@ describe('Tooltip', () => {
                         datum: {
                             label: 'test2',
                             value: 20,
+                            valueContext: '10%',
                         },
                         index: 2,
                         key: 'test2',
@@ -43,6 +45,7 @@ describe('Tooltip', () => {
                         datum: {
                             label: 'test3',
                             value: 30,
+                            valueContext: 'CTR 20%',
                         },
                         index: 3,
                         key: 'test3',
@@ -55,10 +58,10 @@ describe('Tooltip', () => {
             tooltipPosition: { tooltipLeft: 20, tooltipTop: 30 },
             glyphProps: [],
         });
-        const { getByText } = render(<Tooltip crossHairStyle="line" valueContextBySeries={['%', 'ºC', 'F']} />);
+        const { getByText } = render(<Tooltip crossHairStyle="line" />);
 
-        expect(getByText(/10 %/i)).toBeDefined();
-        expect(getByText(/20 ºc/i)).toBeDefined();
-        expect(getByText(/30 f/i)).toBeDefined();
+        expect(getByText(/5%/i)).toBeDefined();
+        expect(getByText(/10%/i)).toBeDefined();
+        expect(getByText(/ctr 20%/i)).toBeDefined();
     });
 });

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -1,15 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { GlyphDot } from '@visx/glyph';
+import { useTooltipInPortal } from '@visx/tooltip';
+import { TooltipContext, type TooltipContextType } from '@visx/xychart';
+import { type CSSProperties, useContext } from 'react';
+
 import { type BarChartDataPoint } from '@components/BarChart';
 import { type LineChartDataPoint } from '@components/LineChart';
 import { Crosshair } from '@components/common/components/Tooltip/Crosshair';
 import { TooltipContent } from '@components/common/components/Tooltip/TooltipContent';
 import { MISSING_VALUE_LABEL } from '@components/common/components/consts';
 import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
-import { GlyphDot } from '@visx/glyph';
-import { useTooltipInPortal } from '@visx/tooltip';
-import { TooltipContext, type TooltipContextType } from '@visx/xychart';
-import { type CSSProperties, useContext } from 'react';
 
 import { getHeadingFromDatum, getTooltipEntries, isNoDataKey } from './helpers';
 import { useKeyToForceRepaint, usePositions } from './hooks/';

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -1,16 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { GlyphDot } from '@visx/glyph';
-import { useTooltipInPortal } from '@visx/tooltip';
-import { TooltipContext, type TooltipContextType } from '@visx/xychart';
-import { type CSSProperties, useContext } from 'react';
-
 import { type BarChartDataPoint } from '@components/BarChart';
 import { type LineChartDataPoint } from '@components/LineChart';
 import { Crosshair } from '@components/common/components/Tooltip/Crosshair';
 import { TooltipContent } from '@components/common/components/Tooltip/TooltipContent';
 import { MISSING_VALUE_LABEL } from '@components/common/components/consts';
 import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
+import { GlyphDot } from '@visx/glyph';
+import { useTooltipInPortal } from '@visx/tooltip';
+import { TooltipContext, type TooltipContextType } from '@visx/xychart';
+import { type CSSProperties, useContext } from 'react';
 
 import { getHeadingFromDatum, getTooltipEntries, isNoDataKey } from './helpers';
 import { useKeyToForceRepaint, usePositions } from './hooks/';
@@ -42,7 +41,6 @@ type TooltipPropsBase = {
     valueFormatter?: ValueFormatter;
     labelFormatter?: LabelFormatter;
     locale?: string;
-    valueContextBySeries?: string[];
 };
 
 type TooltipBarProps = {
@@ -72,7 +70,6 @@ export const Tooltip = ({
     scalePadding = 0,
     colorAccessor = () => '',
     valueFormatter,
-    valueContextBySeries,
     labelFormatter,
     locale,
     stackingGlyphs = false,
@@ -92,7 +89,6 @@ export const Tooltip = ({
         valueFormatter,
         tooltipContext.tooltipData?.datumByKey,
         childSumLabel,
-        valueContextBySeries,
     );
     const shouldReverseEntries = stackingGlyphs;
     const sortedEntries = shouldReverseEntries ? [...entries].reverse() : entries;

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -4,9 +4,9 @@ type TooltipEntry = {
     title: string;
     color?: string;
     value: string | number;
+    valueContext?: string;
     type?: string;
     typeByGrouping?: string;
-    valueContextBySeries?: string;
 };
 
 type TooltipContentV2Props = {
@@ -43,7 +43,7 @@ export const TooltipContent = ({ title, description, entries }: TooltipContentV2
                     color={entry.color}
                     value={entry.value}
                     type={entry?.typeByGrouping}
-                    valueContextBySeries={entry.valueContextBySeries}
+                    valueContext={entry?.valueContext}
                 />
             ))}
         </div>
@@ -55,10 +55,10 @@ export type TooltipItemProps = {
     value: string | number;
     color?: string;
     type?: string;
-    valueContextBySeries?: string;
+    valueContext?: string;
 };
 
-const TooltipItem = ({ title, value, color, type, valueContextBySeries }: TooltipItemProps) => {
+const TooltipItem = ({ title, value, color, type, valueContext }: TooltipItemProps) => {
     return (
         <div key={`${title}-value`} className="tw-text-[var(--fc-base-color)] tw-text-sm tw-font-normal">
             {color && (
@@ -70,7 +70,7 @@ const TooltipItem = ({ title, value, color, type, valueContextBySeries }: Toolti
                 />
             )}
             <span>{`${type || title}: `}</span>
-            <span className="tw-font-semibold">{`${value} ${valueContextBySeries || ''}`}</span>
+            <span className="tw-font-semibold">{`${value} ${valueContext || ''}`}</span>
         </div>
     );
 };

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.spec.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.spec.ts
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type LineChartDataPoint } from '@components/LineChart';
 import { type TooltipDatum } from '@visx/xychart/lib/types/tooltip';
 import { describe, expect, it, vi } from 'vitest';
+
+import { type LineChartDataPoint } from '@components/LineChart';
 
 import { getTooltipEntries } from './getTooltipEntries';
 

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.spec.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.spec.ts
@@ -1,9 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type LineChartDataPoint } from '@components/LineChart';
 import { type TooltipDatum } from '@visx/xychart/lib/types/tooltip';
 import { describe, expect, it, vi } from 'vitest';
-
-import { type LineChartDataPoint } from '@components/LineChart';
 
 import { getTooltipEntries } from './getTooltipEntries';
 
@@ -84,27 +83,29 @@ describe('getTooltipEntries', () => {
         expect(valueFormatter).toHaveBeenCalledWith(200);
     });
 
-    it('returns data with value context by series', () => {
+    it('returns data with value context', () => {
         const datumByKey = {
             series1: {
                 datum: {
                     label: 'foo',
                     value: 100,
+                    valueContext: '10%',
                 },
             },
             series2: {
                 datum: {
                     label: 'bar',
                     value: 200,
+                    valueContext: '(CTR 20%)',
                 },
             },
         } as unknown as { [key: string]: TooltipDatum<LineChartDataPoint> };
         const colorAccessor = vi.fn();
         const valueFormatter = vi.fn().mockImplementation((value) => value);
-        const result = getTooltipEntries('No data', colorAccessor, valueFormatter, datumByKey, '', ['%', 'ºC']);
+        const result = getTooltipEntries('No data', colorAccessor, valueFormatter, datumByKey, '');
         expect(result).toEqual([
-            { title: 'series1', value: 100, valueContextBySeries: '%' },
-            { title: 'series2', value: 200, valueContextBySeries: 'ºC' },
+            { title: 'series1', value: 100, valueContext: '10%' },
+            { title: 'series2', value: 200, valueContext: '(CTR 20%)' },
         ]);
     });
 });

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
@@ -1,11 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type TooltipDatum } from '@visx/xychart/lib/types/tooltip';
+
 import { type BarChartDataPoint } from '@components/BarChart';
 import { type LineChartDataPoint } from '@components/LineChart';
 import { getDataPointValue } from '@components/common/components/Tooltip/helpers/getDataPointValue';
 import { isNoDataKey } from '@components/common/components/Tooltip/helpers/isNoDataKey';
 import { type ValueFormatter } from '@components/common/types';
-import { type TooltipDatum } from '@visx/xychart/lib/types/tooltip';
 
 export const getTooltipEntries = (
     missingValueLabel: string,

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
@@ -1,12 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type TooltipDatum } from '@visx/xychart/lib/types/tooltip';
-
 import { type BarChartDataPoint } from '@components/BarChart';
 import { type LineChartDataPoint } from '@components/LineChart';
 import { getDataPointValue } from '@components/common/components/Tooltip/helpers/getDataPointValue';
 import { isNoDataKey } from '@components/common/components/Tooltip/helpers/isNoDataKey';
 import { type ValueFormatter } from '@components/common/types';
+import { type TooltipDatum } from '@visx/xychart/lib/types/tooltip';
 
 export const getTooltipEntries = (
     missingValueLabel: string,
@@ -16,13 +15,12 @@ export const getTooltipEntries = (
         [key: string]: TooltipDatum<LineChartDataPoint | BarChartDataPoint>;
     },
     childSumLabel?: string,
-    valueContextBySeries?: string[],
 ) => {
     const dataPoints = [];
     let sum = 0;
 
     if (datumByKey) {
-        for (const [index, key] of Object.keys(datumByKey).entries()) {
+        for (const key of Object.keys(datumByKey)) {
             if (isNoDataKey(key)) {
                 continue;
             }
@@ -35,8 +33,7 @@ export const getTooltipEntries = (
                 title: key,
                 value: getDataPointValue(missingValueLabel, datumByKey[key]?.datum.value, valueFormatter),
                 color: colorAccessor(key),
-
-                ...(valueContextBySeries?.[index] ? { valueContextBySeries: valueContextBySeries?.[index] } : {}),
+                ...(datumByKey[key]?.datum.valueContext ? { valueContext: datumByKey[key]?.datum.valueContext } : {}),
             });
         }
     }

--- a/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
+++ b/packages/charts/src/components/common/components/Tooltip/helpers/getTooltipEntries.ts
@@ -34,7 +34,7 @@ export const getTooltipEntries = (
                 title: key,
                 value: getDataPointValue(missingValueLabel, datumByKey[key]?.datum.value, valueFormatter),
                 color: colorAccessor(key),
-                ...(datumByKey[key]?.datum.valueContext ? { valueContext: datumByKey[key]?.datum.valueContext } : {}),
+                valueContext: datumByKey[key]?.datum.valueContext,
             });
         }
     }


### PR DESCRIPTION
A more granular approach was needed to fill the requirements of the new tooltip, dropped the `valueContextBySeries` and passed the value along with the data point, which is rendered by the tooltip.

Examples: 
![image](https://github.com/user-attachments/assets/fc481faa-f343-4f43-b44a-62f2a9a9a80d)


Design: 
![image](https://github.com/user-attachments/assets/a6608eeb-360b-4007-809c-ae5ad8cc7c8f)
