### PR TITLE
fix(CollapsibleWrap): overflow is kept hidden after expansion

### DIFF
--- a/.changeset/flat-windows-brake.md
+++ b/.changeset/flat-windows-brake.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix(CollapsibleWrap): overflow is kept hidden after expansion

--- a/packages/fondue/src/components/CollapsibleWrap/CollapsibleWrap.tsx
+++ b/packages/fondue/src/components/CollapsibleWrap/CollapsibleWrap.tsx
@@ -19,7 +19,14 @@ export const CollapsibleWrap = ({
                 animate={'open'}
                 exit={'collapsed'}
                 variants={{
-                    open: { height: 'auto', overflow: 'hidden', opacity: 1 },
+                    open: {
+                        height: 'auto',
+                        overflow: 'hidden',
+                        opacity: 1,
+                        transitionEnd: {
+                            overflow: 'visible',
+                        },
+                    },
                     collapsed: { height: 0, overflow: 'hidden', opacity: animateOpacity ? 0 : 1 },
                 }}
                 transition={{ type: 'tween' }}


### PR DESCRIPTION
To avoid scenarios like this I set the overflow to visible after the animation is done.

![image](https://github.com/user-attachments/assets/7d35a5ee-8d84-4e3d-b3ab-f5a7d2d2e4b1)
