### PR TITLE
fix: prevent global box sizing normalization from overriding fondue spacings

### DIFF
--- a/.changeset/afraid-eyes-visit.md
+++ b/.changeset/afraid-eyes-visit.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: prevent global box sizing normalization from overriding fondue spacings

--- a/packages/components/src/components/Dropdown/styles/dropdown.module.scss
+++ b/packages/components/src/components/Dropdown/styles/dropdown.module.scss
@@ -28,6 +28,7 @@
     line-height: var(--body-size-medium-line-height);
     color: var(--text-color-weak);
     outline-style: none;
+    box-sizing: border-box;
     &[data-state='open'] {
         background-color: var(--box-neutral-color);
         color: var(--text-color);

--- a/packages/components/src/components/Switch/styles/switch.module.scss
+++ b/packages/components/src/components/Switch/styles/switch.module.scss
@@ -10,7 +10,6 @@
 
     position: relative;
     container-type: size;
-    box-sizing: border-box;
     border-radius: 9999px;
 
     background-color: var(--box-neutral-color);
@@ -53,15 +52,19 @@
     }
 }
 .thumb {
+    @include transition-transform;
+
     display: block;
+    transform: translate(-1px, -1px);
+    will-change: transform;
+
+    box-sizing: border-box;
+    width: calc(100cqh + 2px);
+    height: calc(100cqh + 2px);
+
     background-color: var(--base-color);
     border-radius: 9999px;
     border: 1px solid var(--box-neutral-inverse-color);
-    transition: transform 100ms;
-    transform: translate(-1px, -1px);
-    will-change: transform;
-    width: calc(100cqh + 2px);
-    height: calc(100cqh + 2px);
 
     &[data-state='checked'] {
         transform: translate(calc(100cqw - 100% + 1px), -1px);

--- a/packages/components/src/utilities/transitions.module.scss
+++ b/packages/components/src/utilities/transitions.module.scss
@@ -32,3 +32,7 @@
 @mixin transition-box-shadow {
     @include transition(box-shadow);
 }
+
+@mixin transition-transform {
+    @include transition(transform);
+}


### PR DESCRIPTION
also applied our standard transition to the switch