### PR TITLE
refactor: add data attributes to all fondue components

### DIFF
--- a/.changeset/sixty-colts-check.md
+++ b/.changeset/sixty-colts-check.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat: add data attr to all fondue components

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -31,7 +31,13 @@ export const Box = ({
     ...props
 }: BoxProps) => {
     return (
-        <Component className={styles.root} data-test-id={dataTestId} {...props} style={propsToCssVariables(props)}>
+        <Component
+            data-fondue-component="Box"
+            className={styles.root}
+            data-test-id={dataTestId}
+            {...props}
+            style={propsToCssVariables(props)}
+        >
             {children}
         </Component>
     );

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -81,6 +81,7 @@ export const Button = forwardRef<HTMLButtonElement | null, ButtonProps>(
     ) => {
         return (
             <button
+                data-fondue-component="Button"
                 ref={ref}
                 type={type}
                 data-test-id={dataTestId}

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -79,6 +79,7 @@ export const CheckboxComponent = (
 ) => {
     return (
         <CheckboxPrimitive.Root
+            data-fondue-component="Checkbox"
             ref={ref}
             checked={value}
             defaultChecked={defaultValue}

--- a/packages/components/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPicker.tsx
@@ -48,7 +48,13 @@ export const ColorPickerRoot = (
     const [currentFormat, setCurrentFormat] = useState<ColorFormat>(defaultFormat);
 
     return (
-        <div className={styles.root} data-picker-type="custom-color" data-test-id={dataTestId} ref={forwardedRef}>
+        <div
+            data-fondue-component="ColorPicker"
+            className={styles.root}
+            data-picker-type="custom-color"
+            data-test-id={dataTestId}
+            ref={forwardedRef}
+        >
             {Children.map(children, (child) => (
                 <ColorPickerSlot
                     {...props}

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -106,7 +106,9 @@ const DialogContext = createContext<DialogContextType>({ isModal: false });
 export const DialogRoot = ({ children, ...props }: DialogRootProps) => {
     return (
         <DialogContext.Provider value={{ isModal: props.modal ?? false }}>
-            <RadixDialog.Root {...props}>{children}</RadixDialog.Root>
+            <RadixDialog.Root data-fondue-component="Dialog" {...props}>
+                {children}
+            </RadixDialog.Root>
         </DialogContext.Provider>
     );
 };

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -49,6 +49,7 @@ export const DividerComponent = (
 ): ReactElement => {
     return (
         <Separator.Root
+            data-fondue-component="Divider"
             ref={ref}
             className={cn(
                 dividerStyles({

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -29,7 +29,12 @@ export const DropdownRoot = ({
     'data-test-id': dataTestId = 'fondue-dropdown',
 }: DropdownRootProps) => {
     return (
-        <RadixDropdown.Root open={open} onOpenChange={onOpenChange} data-test-id={dataTestId}>
+        <RadixDropdown.Root
+            data-fondue-component="Dropdown"
+            open={open}
+            onOpenChange={onOpenChange}
+            data-test-id={dataTestId}
+        >
             {children}
         </RadixDropdown.Root>
     );

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -61,6 +61,7 @@ export const Flex = ({
 }: FlexProps) => {
     return (
         <Component
+            data-fondue-component="Flex"
             className={styles.root}
             data-test-id={dataTestId}
             style={propsToCssVariables(props, { justify: 'justify-content' })}

--- a/packages/components/src/components/Flyout/Flyout.tsx
+++ b/packages/components/src/components/Flyout/Flyout.tsx
@@ -110,6 +110,7 @@ export const FlyoutContent = (
     return (
         <RadixPopover.Portal>
             <RadixPopover.Content
+                data-fondue-component="Flyout"
                 style={
                     {
                         '--flyout-max-width': maxWidth,

--- a/packages/components/src/components/Grid/Grid.tsx
+++ b/packages/components/src/components/Grid/Grid.tsx
@@ -65,6 +65,7 @@ export const Grid = ({
 }: GridProps) => {
     return (
         <Component
+            data-fondue-component="Grid"
             className={styles.root}
             data-test-id={dataTestId}
             style={propsToCssVariables(props, { justify: 'justify-items' })}

--- a/packages/components/src/components/Label/Label.tsx
+++ b/packages/components/src/components/Label/Label.tsx
@@ -27,6 +27,7 @@ export const LabelComponent = (
 ) => {
     return (
         <LabelPrimitive.Root
+            data-fondue-component="Label"
             ref={ref}
             data-required={props.required}
             className={cn(

--- a/packages/components/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/components/src/components/LoadingBar/LoadingBar.tsx
@@ -56,6 +56,7 @@ export const LoadingBar = forwardRef<ElementRef<typeof ProgressRadixPrimitive.Ro
     ) => {
         return (
             <ProgressRadixPrimitive.Root
+                data-fondue-component="LoadingBar"
                 ref={ref}
                 data-test-id={dataTestId}
                 className={loadingBarContainerStyles({ rounded, size, variant })}

--- a/packages/components/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.tsx
@@ -40,6 +40,7 @@ const ScrollAreaComponent = (
 ): ReactElement => {
     return (
         <RadixScrollArea.Root
+            data-fondue-component="ScrollArea"
             type={type}
             className={styles.root}
             style={{ maxWidth }}

--- a/packages/components/src/components/Section/Section.tsx
+++ b/packages/components/src/components/Section/Section.tsx
@@ -21,7 +21,12 @@ export type SectionProps = LayoutComponentProps & {
 
 export const Section = ({ 'data-test-id': dataTestId = 'fondue-section', children, ...props }: SectionProps) => {
     return (
-        <section className={styles.root} data-test-id={dataTestId} style={propsToCssVariables(props)}>
+        <section
+            data-fondue-component="Section"
+            className={styles.root}
+            data-test-id={dataTestId}
+            style={propsToCssVariables(props)}
+        >
             {children}
         </section>
     );

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -42,6 +42,7 @@ export const SegmentedControlRoot = (
 
     return (
         <ToggleGroupPrimitive.Root
+            data-fondue-component="SegmentedControl"
             ref={ref}
             {...rootProps}
             className={styles.root}

--- a/packages/components/src/components/Select/Combobox.tsx
+++ b/packages/components/src/components/Select/Combobox.tsx
@@ -131,7 +131,7 @@ export const SelectCombobox = (
     };
 
     return (
-        <RadixPopover.Root open={isOpen}>
+        <RadixPopover.Root data-fondue-component="Select" open={isOpen}>
             <RadixPopover.Anchor asChild>
                 <div ref={forwardedRef} className={styles.root} data-status={valueInvalid ? 'error' : status}>
                     <input

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -100,7 +100,7 @@ export const SelectInput = (
         });
 
     return (
-        <RadixPopover.Root open={isOpen}>
+        <RadixPopover.Root data-fondue-component="Select" open={isOpen}>
             <RadixPopover.Anchor
                 asChild
                 onMouseDown={(mouseEvent) => {

--- a/packages/components/src/components/Slider/Slider.tsx
+++ b/packages/components/src/components/Slider/Slider.tsx
@@ -65,6 +65,7 @@ const SliderComponent = (
     const sliderThumbRef = useRef<HTMLSpanElement | null>(null);
     return (
         <RadixSlider.Root
+            data-fondue-component="Slider"
             ref={ref}
             className={styles.root}
             value={value}

--- a/packages/components/src/components/Switch/Switch.tsx
+++ b/packages/components/src/components/Switch/Switch.tsx
@@ -67,6 +67,7 @@ const SwitchComponent = (
     ref: ForwardedRef<HTMLButtonElement>,
 ) => (
     <RadixSwitch.Root
+        data-fondue-component="Switch"
         ref={ref}
         checked={value}
         defaultChecked={defaultValue}

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -118,7 +118,12 @@ export const TextFieldRoot = (
     const wasClicked = useRef(false);
 
     return (
-        <div className={cn(styles.root, className)} data-status={status} data-test-id={dataTestId}>
+        <div
+            data-fondue-component="TextInput"
+            className={cn(styles.root, className)}
+            data-status={status}
+            data-test-id={dataTestId}
+        >
             {status === 'loading' ? (
                 <div className={styles.loadingStatus} data-test-id={`${dataTestId}-loader`} />
             ) : null}

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -27,7 +27,12 @@ export type TooltipRootProps = {
 export const TooltipRoot = ({ children, enterDelay = 700, open, onOpenChange }: TooltipRootProps) => {
     return (
         <RadixTooltip.Provider>
-            <RadixTooltip.Root delayDuration={enterDelay} open={open} onOpenChange={onOpenChange}>
+            <RadixTooltip.Root
+                data-fondue-component="Tooltip"
+                delayDuration={enterDelay}
+                open={open}
+                onOpenChange={onOpenChange}
+            >
                 {children}
             </RadixTooltip.Root>
         </RadixTooltip.Provider>


### PR DESCRIPTION
This is one possible way for excluding fondue from the global styles in the web app. We can also use these in conjunction with the removal of the className prop. People can use the data attr to create specific styles but it'll become so cumbersome and hacky to do so, they will think twice before they do.