### PR TITLE
feat(charts): add support for image rendering inside tooltip

### DIFF
--- a/.changeset/late-mirrors-kiss.md
+++ b/.changeset/late-mirrors-kiss.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-charts": patch
+---
+
+add support for image rendering inside tooltips

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -165,6 +165,18 @@ const filterOnePointPerMonth = (series: BarChartSeries[]): BarChartSeries[] => {
     return filteredSeries;
 };
 
+const planetImagesMap: Record<string, string> = {
+    Mercury:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Mercury_in_true_color.jpg/800px-Mercury_in_true_color.jpg',
+    Venus: 'https://cdn.mos.cms.futurecdn.net/RifjtkFLBEFgzkZqWEh69P-1200-80.jpg',
+    Earth: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/97/The_Earth_seen_from_Apollo_17.jpg/1200px-The_Earth_seen_from_Apollo_17.jpg',
+    Mars: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Mars_-_August_30_2021_-_Flickr_-_Kevin_M._Gill.png/800px-Mars_-_August_30_2021_-_Flickr_-_Kevin_M._Gill.png',
+    Jupiter: 'https://upload.wikimedia.org/wikipedia/commons/2/2b/Jupiter_and_its_shrunken_Great_Red_Spot.jpg',
+    Saturn: 'https://cdn.mos.cms.futurecdn.net/TWpr5dTCno77m2J2aFgLxD-1200-80.jpg',
+    Uranus: 'https://ychef.files.bbci.co.uk/1280x720/p0257vk5.jpg',
+    Neptune: 'https://c.tadst.com/gfx/600x337/neptune.jpg?1',
+};
+
 const addDetailsWithUrl = (series: BarChartSeries[]): BarChartSeries<{ url: string }>[] => {
     const seriesWithDetails = [];
     for (const item of series) {
@@ -175,6 +187,21 @@ const addDetailsWithUrl = (series: BarChartSeries[]): BarChartSeries<{ url: stri
     }
 
     return seriesWithDetails;
+};
+
+const addImageUrlToDataPoints = (series: BarChartSeries[]) => {
+    const seriesWithImageUrls = [];
+    for (const item of series) {
+        const dataPointsWithDetails = item.dataPoints.map((dataPoint) => {
+            return {
+                ...dataPoint,
+                imageUrl: planetImagesMap[dataPoint.label],
+            };
+        });
+        seriesWithImageUrls.push({ ...item, dataPoints: dataPointsWithDetails });
+    }
+
+    return seriesWithImageUrls;
 };
 
 const TemplateWithUrl: StoryFn<BarChartProps<{ url: string }>> = (args) => <BarChart<{ url: string }> {...args} />;
@@ -193,6 +220,13 @@ SingleDataSetWithOnClick.args = {
     width: 1000,
     height: 500,
     onBarClick: (e) => alert(e.datum.details.url),
+};
+
+export const SingleDataSetWithTooltipImages = Template.bind({});
+SingleDataSetWithTooltipImages.args = {
+    series: addImageUrlToDataPoints(planetsRadiusData),
+    width: 1000,
+    height: 500,
 };
 
 export const SingleDataSetWith100Points = Template.bind({});

--- a/packages/charts/src/components/BarChart/types.ts
+++ b/packages/charts/src/components/BarChart/types.ts
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 import { type AxisScale, type EventHandlerParams } from '@visx/xychart';
 import { type ScaleBand } from 'd3-scale';
+
+import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 
 type BarChartDataPointBase = {
     label: string;

--- a/packages/charts/src/components/BarChart/types.ts
+++ b/packages/charts/src/components/BarChart/types.ts
@@ -1,15 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 import { type AxisScale, type EventHandlerParams } from '@visx/xychart';
 import { type ScaleBand } from 'd3-scale';
-
-import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 
 type BarChartDataPointBase = {
     label: string;
     value: number | null;
     description?: string;
     valueContext?: string;
+    imageUrl?: string;
 };
 
 export type BarChartDataPoint<DataPointDetails extends Record<string, any> | void = void> =

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.spec.tsx
@@ -20,6 +20,11 @@ describe('Tooltip', () => {
     it('should render the value context if it is present in datum', () => {
         vi.mocked(useContext).mockReturnValue({
             tooltipData: {
+                nearestDatum: {
+                    datum: {
+                        imageUrl: '/image.png',
+                    },
+                },
                 datumByKey: {
                     test1: {
                         datum: {
@@ -58,10 +63,11 @@ describe('Tooltip', () => {
             tooltipPosition: { tooltipLeft: 20, tooltipTop: 30 },
             glyphProps: [],
         });
-        const { getByText } = render(<Tooltip crossHairStyle="line" />);
+        const { getByText, getByRole } = render(<Tooltip crossHairStyle="line" />);
 
         expect(getByText(/5%/i)).toBeDefined();
         expect(getByText(/10%/i)).toBeDefined();
         expect(getByText(/ctr 20%/i)).toBeDefined();
+        expect(getByRole('img')).toBeDefined();
     });
 });

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -1,14 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { GlyphDot } from '@visx/glyph';
+import { useTooltipInPortal } from '@visx/tooltip';
+import { TooltipContext, type TooltipContextType } from '@visx/xychart';
+import { type CSSProperties, useContext } from 'react';
+
 import { type BarChartDataPoint } from '@components/BarChart';
 import { type LineChartDataPoint } from '@components/LineChart';
 import { Crosshair } from '@components/common/components/Tooltip/Crosshair';
 import { MISSING_VALUE_LABEL } from '@components/common/components/consts';
 import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
-import { GlyphDot } from '@visx/glyph';
-import { useTooltipInPortal } from '@visx/tooltip';
-import { TooltipContext, type TooltipContextType } from '@visx/xychart';
-import { type CSSProperties, useContext } from 'react';
 
 import { TooltipContent } from './TooltipContent';
 import { getHeadingFromDatum, getTooltipEntries, isNoDataKey } from './helpers';

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -1,17 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type BarChartDataPoint } from '@components/BarChart';
+import { type LineChartDataPoint } from '@components/LineChart';
+import { Crosshair } from '@components/common/components/Tooltip/Crosshair';
+import { MISSING_VALUE_LABEL } from '@components/common/components/consts';
+import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
 import { GlyphDot } from '@visx/glyph';
 import { useTooltipInPortal } from '@visx/tooltip';
 import { TooltipContext, type TooltipContextType } from '@visx/xychart';
 import { type CSSProperties, useContext } from 'react';
 
-import { type BarChartDataPoint } from '@components/BarChart';
-import { type LineChartDataPoint } from '@components/LineChart';
-import { Crosshair } from '@components/common/components/Tooltip/Crosshair';
-import { TooltipContent } from '@components/common/components/Tooltip/TooltipContent';
-import { MISSING_VALUE_LABEL } from '@components/common/components/consts';
-import { type LabelFormatter, type ValueFormatter } from '@components/common/types';
-
+import { TooltipContent } from './TooltipContent';
 import { getHeadingFromDatum, getTooltipEntries, isNoDataKey } from './helpers';
 import { useKeyToForceRepaint, usePositions } from './hooks/';
 
@@ -93,6 +92,7 @@ export const Tooltip = ({
     );
     const shouldReverseEntries = stackingGlyphs;
     const sortedEntries = shouldReverseEntries ? [...entries].reverse() : entries;
+    const imageUrl = (tooltipContext.tooltipData?.nearestDatum?.datum as BarChartDataPoint)?.imageUrl;
 
     return (
         <svg ref={containerRef} style={INVISIBLE_STYLES} key={wrapperKey}>
@@ -134,8 +134,9 @@ export const Tooltip = ({
                                 locale,
                                 labelFormatter,
                             )}
-                            entries={sortedEntries}
                             description={tooltipContext.tooltipData.nearestDatum?.datum?.description}
+                            imageUrl={imageUrl}
+                            entries={sortedEntries}
                         />
                     </TooltipInPortal>
                 </>

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -22,7 +22,11 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
 
     return (
         <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border">
-            {imageUrl && <img src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-3" />}
+            {imageUrl && (
+                <div className="tw--m-1">
+                    <img src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-3" />
+                </div>
+            )}
             <div className={title ? 'tw-pb-3' : ''}>
                 <div className="tw-text-sm tw-leading-5 tw-text-base-alt tw-font-bold">{title}</div>
                 {dataPoint?.type && (

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -24,7 +24,7 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
         <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border">
             {imageUrl && (
                 <div className="tw--m-1">
-                    <img src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-3" />
+                    <img src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-5" />
                 </div>
             )}
             <div className={title ? 'tw-pb-3' : ''}>

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -28,9 +28,9 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
                 </div>
             )}
             <div className={title ? 'tw-pb-3' : ''}>
-                <div className="tw-text-sm tw-leading-5 tw-text-base-alt tw-font-bold">{title}</div>
+                <div className="tw-text-body-small tw-text-base tw-font-bold">{title}</div>
                 {dataPoint?.type && (
-                    <div className="tw-text-sm tw-text-base-alt tw-pb-2">
+                    <div className="tw-text-body-small tw-text-base tw-pb-2">
                         {dataPoint.type}: {dataPoint.title}
                     </div>
                 )}
@@ -66,7 +66,7 @@ export type TooltipItemProps = {
 
 const TooltipItem = ({ title, value, color, type, valueContext }: TooltipItemProps) => {
     return (
-        <div key={`${title}-value`} className="tw-text-[var(--fc-base-color)] tw-text-sm tw-font-normal">
+        <div key={`${title}-value`} className="tw-text-body-small tw-text-base">
             {color && (
                 <span
                     className="tw-inline-block tw-w-2 tw-h-2 tw-rounded-full tw-mr-1"
@@ -76,7 +76,7 @@ const TooltipItem = ({ title, value, color, type, valueContext }: TooltipItemPro
                 />
             )}
             <span>{`${type || title}: `}</span>
-            <span className="tw-font-semibold">{`${value} ${valueContext || ''}`}</span>
+            <span className="tw-text-body-small tw-font-bold">{`${value} ${valueContext || ''}`}</span>
         </div>
     );
 };

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -13,14 +13,16 @@ type TooltipContentV2Props = {
     entries: TooltipEntry[];
     title?: string;
     description?: string;
+    imageUrl?: string;
 };
 
-export const TooltipContent = ({ title, description, entries }: TooltipContentV2Props) => {
+export const TooltipContent = ({ title, description, imageUrl, entries }: TooltipContentV2Props) => {
     const descriptionLines = description?.split('\n') ?? [];
     const dataPoint = entries[1];
 
     return (
         <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border">
+            {imageUrl && <img src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-3" />}
             <div className={title ? 'tw-pb-3' : ''}>
                 <div className="tw-text-sm tw-leading-5 tw-text-base-alt tw-font-bold">{title}</div>
                 {dataPoint?.type && (


### PR DESCRIPTION
### As part of new requirements for template usage chart

#### Example story
![image](https://github.com/user-attachments/assets/04eabf49-07c2-47ef-8f9d-cb41483d455b)

#### Design
![image](https://github.com/user-attachments/assets/d85b003a-3678-4973-a3d9-d02e5d7034e8)
