### PR TITLE
fix(TextInput): update types

### DIFF
--- a/.changeset/shy-deers-enjoy.md
+++ b/.changeset/shy-deers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(`TextInput`): update focus and blur callback event types

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -2,6 +2,7 @@
 
 import { IconCheckMark, IconExclamationMarkTriangle } from '@frontify/fondue-icons';
 import {
+    type FocusEvent,
     forwardRef,
     useRef,
     type ChangeEvent,
@@ -82,11 +83,11 @@ export type TextInputProps = {
     /**
      * Event handler called when the text input is blurred
      */
-    onBlur?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
     /**
      * Event handler called when the text input is focused
      */
-    onFocus?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
     /**
      * Event handler called when a key is pressed
      */


### PR DESCRIPTION
Noticed a type issue when migrating the common text input component and I believe it is a genuine bug with our text input stemming from incorrect types on these callbacks