### PR TITLE
feat: add max-width and adjust styling of tooltip image and description text

### DIFF
--- a/.changeset/honest-hounds-work.md
+++ b/.changeset/honest-hounds-work.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-charts": patch
+---
+
+adjust chart tooltip styling to accomodate very long titles used in combination with tooltip preview images

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -24,7 +24,7 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
         <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border tw-max-w-[260px]">
             {imageUrl && (
                 <div className="tw--m-1">
-                    <img className="tw-w-full" src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-5 tw-w-full" />
+                    <img src={imageUrl} alt={description} className="tw-h-28 tw-object-cover tw-mb-5 tw-w-full" />
                 </div>
             )}
             <div className={title ? 'tw-pb-3' : ''}>

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -21,10 +21,10 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
     const dataPoint = entries[1];
 
     return (
-        <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border">
+        <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border tw-max-w-[260px]">
             {imageUrl && (
                 <div className="tw--m-1">
-                    <img src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-5" />
+                    <img className="tw-w-full" src={imageUrl} alt={description} className="tw-w-48 tw-h-28 tw-object-cover tw-mb-5 tw-w-full" />
                 </div>
             )}
             <div className={title ? 'tw-pb-3' : ''}>
@@ -37,7 +37,9 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
                 {descriptionLines.length > 0 && (
                     <div className="tw-text-base tw-text-xs">
                         {descriptionLines.map((line) => (
-                            <div key={line}>{line}</div>
+                            <div key={line} className="tw-truncate">
+                                {line}
+                            </div>
                         ))}
                     </div>
                 )}


### PR DESCRIPTION
Tooltips with long, single word (with dashes or underscores) titles look strange when the template preview image is shown. (_See the image below for an example from Superheroes_).
This PR fixes the issue by adding a max-width, and setting the image to full width. It also includes an update to truncate the description lines (in this case Brand, Project, etc.) as requested by our team's designer.

Before:
<img width="457" alt="Screenshot 2024-11-26 at 11 20 23" src="https://github.com/user-attachments/assets/03ac86a5-3534-4ba1-b481-dacaf0346df9">


After:
<img width="332" alt="Screenshot 2024-11-26 at 11 24 16" src="https://github.com/user-attachments/assets/efa357d5-1b72-498e-a343-041979968fbf">
