### PR TITLE
feat: set tooltip description word-break property to 'all'

### DIFF
--- a/.changeset/silver-chicken-whisper.md
+++ b/.changeset/silver-chicken-whisper.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-charts": patch
+---
+
+set tooltip description word-break to all

--- a/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/TooltipContent.tsx
@@ -21,7 +21,7 @@ export const TooltipContent = ({ title, description, imageUrl, entries }: Toolti
     const dataPoint = entries[1];
 
     return (
-        <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border tw-max-w-[260px]">
+        <div className="tw-bg-[var(--text-color)] tw-p-3 tw-rounded tw-border tw-border-button-border tw-max-w-[260px] tw-break-all">
             {imageUrl && (
                 <div className="tw--m-1">
                     <img src={imageUrl} alt={description} className="tw-h-28 tw-object-cover tw-mb-5 tw-w-full" />


### PR DESCRIPTION
Set tooltip description word-break property to 'all'. See [this PR](https://github.com/Frontify/fondue/pull/2115) for additional context.