### PR TITLE
fix: issues with table alignment + focus rings

### DIFF
--- a/.changeset/early-avocados-heal.md
+++ b/.changeset/early-avocados-heal.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: fix issue aligning content in table cells when sorting was available

--- a/.changeset/five-moons-remember.md
+++ b/.changeset/five-moons-remember.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: fix issue where a second focus outline appeared on firefox

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -179,21 +179,27 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
                 aria-sort={onSortChange ? sortDirection || 'none' : undefined}
             >
                 {onSortChange ? (
-                    <button
-                        className={styles.sortButton}
-                        aria-label={sortLabel}
-                        data-active={!!sortDirection}
-                        onClick={handleSortChange}
-                    >
-                        {children}
-                        {sortDirection === 'ascending' ? (
-                            <IconArrowUp size="12" />
-                        ) : sortDirection === 'descending' ? (
-                            <IconArrowDown size="12" />
-                        ) : (
-                            <IconArrowBidirectional className={styles.sortIndicator} size="12" />
-                        )}
-                    </button>
+                    <div className={styles.cellContent}>
+                        <button
+                            className={styles.sortButton}
+                            aria-label={sortLabel}
+                            data-active={!!sortDirection}
+                            onClick={handleSortChange}
+                        >
+                            {typeof children === 'string' && truncate ? (
+                                <span className={styles.buttonText}>{children}</span>
+                            ) : (
+                                children
+                            )}
+                            {sortDirection === 'ascending' ? (
+                                <IconArrowUp size="12" />
+                            ) : sortDirection === 'descending' ? (
+                                <IconArrowDown size="12" />
+                            ) : (
+                                <IconArrowBidirectional className={styles.sortIndicator} size="12" />
+                            )}
+                        </button>
+                    </div>
                 ) : (
                     children
                 )}

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -102,6 +102,10 @@
         color: var(--text-color);
     }
 
+    .buttonText {
+        flex: 1;
+    }
+
     &:focus-visible {
         @include focus-outline;
     }
@@ -159,19 +163,32 @@
 
 .headerCell,
 .rowCell {
+
     &[data-align='left'] {
         text-align: left;
+
+        .sortButton {
+            justify-content: flex-start;
+        }
     }
 
     &[data-align='center'] {
         text-align: center;
+
+        .sortButton {
+            justify-content: center;
+        }
     }
 
     &[data-align='right'] {
         text-align: right;
+
+        .sortButton {
+            justify-content: flex-end;
+        }
     }
 
-    &[data-truncate='true'] {
+    &[data-truncate='true'], &[data-truncate='true'] .buttonText {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/packages/components/src/components/TextInput/styles/text.module.scss
+++ b/packages/components/src/components/TextInput/styles/text.module.scss
@@ -69,6 +69,11 @@
         color: var(--text-color-x-weak);
     }
 
+    &:-moz-focusring {
+        outline: 2px solid transparent;
+        outline-offset: 2px;;
+    }
+
     // Remove border-radius and text-indent/padding on the left if there’s a left-side slot
     &:has(~ div:not([data-name='right'])) {
         text-indent: 0px;


### PR DESCRIPTION
- make sure `:-moz-focusring` is overridden to avoid double outlines
- fix aligning content in table cells when sorting is present
- fix text truncation when sorting is present

CU-86970tv1f
CU-86971xjcy