### PR TITLE
fix: improve handling of focus outline on flyout

### DIFF
--- a/.changeset/tough-suns-lick.md
+++ b/.changeset/tough-suns-lick.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: improve focus outline for flyout

--- a/packages/components/src/components/Flyout/styles/flyout.module.scss
+++ b/packages/components/src/components/Flyout/styles/flyout.module.scss
@@ -3,8 +3,10 @@
 @import '../../../utilities/mediaQuery.module.scss';
 @import '../../../utilities/sizeToken.module.scss';
 @import '../../../utilities/shadow.module.scss';
+@import '../../../utilities/focusStyle.module.scss';
 
 .root {
+
     display: block;
     background-color: var(--base-color);
     border: var(--line-width) solid var(--line-color);
@@ -47,6 +49,8 @@
             min-width: 0 !important;
         }
     }
+
+    @include focus-outline;
 }
 
 // Responsive dialog background element
@@ -137,5 +141,6 @@
 }
 
 .close {
+    @include focus-outline;
     cursor: pointer;
 }

--- a/packages/components/src/utilities/focusStyle.module.scss
+++ b/packages/components/src/utilities/focusStyle.module.scss
@@ -13,7 +13,7 @@
 @mixin focus-outline {
     &:focus-visible,
     &:focus-visible:hover,
-    &:has([data-show-focus-ring='true']) {
+    &:has(>[data-show-focus-ring='true']) {
         @include focus-outline-styles;
     }
 }


### PR DESCRIPTION
- use custom outline on flyout
- adjust focus-outline mixin to only appear when a direct child is focused