### PR TITLE
feat(Button): add `form` prop 

### DIFF
--- a/.changeset/cuddly-rice-kneel.md
+++ b/.changeset/cuddly-rice-kneel.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat(`Button`): add form prop

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -59,6 +59,7 @@ export type ButtonProps = {
     hugWidth?: boolean;
     children?: ReactNode;
     onPress?: (event?: MouseEvent<HTMLButtonElement>) => void;
+    form?: string;
     'aria-label'?: string;
     'aria-describedby'?: string;
     'data-test-id'?: string;
@@ -72,6 +73,7 @@ export const Button = forwardRef<HTMLButtonElement | null, ButtonProps>(
             type = 'button',
             variant,
             size = 'medium',
+            form,
             'data-test-id': dataTestId = 'fondue-button',
             className = '',
             onPress = () => {},
@@ -83,6 +85,7 @@ export const Button = forwardRef<HTMLButtonElement | null, ButtonProps>(
             <button
                 ref={ref}
                 type={type}
+                form={form}
                 data-test-id={dataTestId}
                 className={cn(
                     buttonStyles({ size, variant, ...props }),


### PR DESCRIPTION
If the button is outside of a form, devs won't be able to make it submit that form. 