### PR TITLE
fix: text input success/error icon margin if no decorator

### DIFF
--- a/.changeset/rotten-sheep-study.md
+++ b/.changeset/rotten-sheep-study.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: adding margin to TextInput's success/error icon if no decorator on the right

--- a/packages/components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/components/src/components/TextInput/TextInput.stories.tsx
@@ -9,6 +9,7 @@ import { Button } from '../Button/Button';
 import { Label } from '../Label/Label';
 
 import { TextFieldRoot, TextFieldSlot, TextInput } from './TextInput';
+import { Flex } from '../Flex/Flex';
 
 type Story = StoryObj<typeof meta>;
 const meta: Meta<typeof TextFieldRoot> = {
@@ -178,14 +179,17 @@ export const Success: Story = {
         status: 'success',
     },
     render: (args) => (
-        <TextInput.Root {...args}>
-            <TextInput.Slot name="left">
-                <IconPen size={16} />
-            </TextInput.Slot>
-            <TextInput.Slot name="right">
-                <IconIcon size={16} />
-            </TextInput.Slot>
-        </TextInput.Root>
+        <Flex gap={2} direction="column">
+            <TextInput {...args} />
+            <TextInput.Root {...args}>
+                <TextInput.Slot name="left">
+                    <IconPen size={16} />
+                </TextInput.Slot>
+                <TextInput.Slot name="right">
+                    <IconIcon size={16} />
+                </TextInput.Slot>
+            </TextInput.Root>
+        </Flex>
     ),
 };
 
@@ -194,14 +198,17 @@ export const Errored: Story = {
         status: 'error',
     },
     render: (args) => (
-        <TextInput.Root {...args}>
-            <TextInput.Slot name="left">
-                <IconPen size={16} />
-            </TextInput.Slot>
-            <TextInput.Slot name="right">
-                <IconIcon size={16} />
-            </TextInput.Slot>
-        </TextInput.Root>
+        <Flex gap={2} direction="column">
+            <TextInput {...args} />
+            <TextInput.Root {...args}>
+                <TextInput.Slot name="left">
+                    <IconPen size={16} />
+                </TextInput.Slot>
+                <TextInput.Slot name="right">
+                    <IconIcon size={16} />
+                </TextInput.Slot>
+            </TextInput.Root>
+        </Flex>
     ),
 };
 

--- a/packages/components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/components/src/components/TextInput/TextInput.stories.tsx
@@ -6,10 +6,10 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { type ComponentProps } from 'react';
 
 import { Button } from '../Button/Button';
+import { Flex } from '../Flex/Flex';
 import { Label } from '../Label/Label';
 
 import { TextFieldRoot, TextFieldSlot, TextInput } from './TextInput';
-import { Flex } from '../Flex/Flex';
 
 type Story = StoryObj<typeof meta>;
 const meta: Meta<typeof TextFieldRoot> = {

--- a/packages/components/src/components/TextInput/styles/text.module.scss
+++ b/packages/components/src/components/TextInput/styles/text.module.scss
@@ -71,7 +71,7 @@
 
     &:-moz-focusring {
         outline: 2px solid transparent;
-        outline-offset: 2px;;
+        outline-offset: 2px;
     }
 
     // Remove border-radius and text-indent/padding on the left if there’s a left-side slot
@@ -147,6 +147,7 @@
     align-items: center;
     height: 100%;
     margin-left: sizeToken(3);
+    margin-right: sizeToken(3);
     color: var(--text-color-positive);
 }
 
@@ -155,7 +156,14 @@
     align-items: center;
     height: 100%;
     margin-left: sizeToken(3);
+    margin-right: sizeToken(3);
     color: var(--text-color-negative);
+}
+
+// Icon with a right slot shouldn't have a margin right
+.iconSuccess:has(~ .slot[data-name='right']),
+.iconError:has(~ .slot[data-name='right']) {
+    margin-right: 0px;
 }
 
 .loadingStatus {


### PR DESCRIPTION
Before:
![Screenshot 2025-01-09 at 11 24 00](https://github.com/user-attachments/assets/0e90d892-50e8-48c7-9142-3babdc924fd5)



After:
![Screenshot 2025-01-09 at 11 22 48](https://github.com/user-attachments/assets/927d0e94-22f4-4bf7-b978-a5a68f0b5b20)
