### PR TITLE
fix: remove hover state when switch is disabled and toggled

### DIFF
--- a/.changeset/stupid-beers-travel.md
+++ b/.changeset/stupid-beers-travel.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: remove hover state when switch is disabled and toggled

--- a/packages/components/src/components/Switch/styles/switch.module.scss
+++ b/packages/components/src/components/Switch/styles/switch.module.scss
@@ -15,7 +15,7 @@
     background-color: var(--box-neutral-color);
     border: 1px solid var(--line-color-x-strong);
 
-    &:hover {
+    &:enabled:hover {
         background-color: var(--box-neutral-color-hover);
     }
 
@@ -38,11 +38,11 @@
         background-color: var(--text-color-weak);
 
         &:hover {
-            background: var(--box-neutral-strong-color-hover);
+            background-color: var(--box-neutral-strong-color-hover);
         }
     }
 
-    &[disabled] {
+    &:disabled {
         border-color: var(--line-color);
         background-color: var(--box-neutral-color);
 
@@ -51,6 +51,7 @@
         }
     }
 }
+
 .thumb {
     @include transition-transform;
 

--- a/packages/components/src/components/Switch/styles/switch.module.scss
+++ b/packages/components/src/components/Switch/styles/switch.module.scss
@@ -37,7 +37,7 @@
     &[data-state='checked'] {
         background-color: var(--text-color-weak);
 
-        &:hover {
+        &:enabled:hover {
             background-color: var(--box-neutral-strong-color-hover);
         }
     }


### PR DESCRIPTION
Props: disabled: `true`, value: `true`

Before:

https://github.com/user-attachments/assets/d45a83e4-9ffd-477b-a587-cfb889aac1df

After: 


https://github.com/user-attachments/assets/34e02dfe-28a3-4229-9fb5-e4dcaa4abd03

