### PR TITLE
fix: make ColorPicker inputs responsive based on container size

### DIFF
--- a/.changeset/little-experts-cheer.md
+++ b/.changeset/little-experts-cheer.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: make ColorPicker inputs responsive based on container size

--- a/packages/components/src/components/ColorPicker/styles/customColorPicker.module.scss
+++ b/packages/components/src/components/ColorPicker/styles/customColorPicker.module.scss
@@ -16,7 +16,7 @@
     grid-template-columns: 1fr;
     gap: sizeToken(2);
 
-    @container (min-width: 310px) {
+    @container (min-width: 19.5rem) {
         grid-template-columns: 100px 1fr 100px;
     }
 }
@@ -31,7 +31,7 @@
     flex-direction: column;
     gap: sizeToken(2);
 
-    @container (min-width: 310px) {
+    @container (min-width: 19.5rem) {
         flex-direction: row;
     }
 }
@@ -50,6 +50,7 @@
 
 //remove arrows from number inputs
 .valueInput {
+
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {
         -webkit-appearance: none;

--- a/packages/components/src/components/ColorPicker/styles/customColorPicker.module.scss
+++ b/packages/components/src/components/ColorPicker/styles/customColorPicker.module.scss
@@ -2,13 +2,13 @@
 
 @import '../../../utilities/sizeToken.module.scss';
 @import '../../../utilities/focusStyle.module.scss';
-@import '../../../utilities/mediaQuery.module.scss';
 
 .root {
     display: flex;
     flex-direction: column;
     gap: sizeToken(4);
     max-width: 700px;
+    container-type: inline-size;
 }
 
 .inputs {
@@ -16,7 +16,7 @@
     grid-template-columns: 1fr;
     gap: sizeToken(2);
 
-    @include sm {
+    @container (min-width: 310px) {
         grid-template-columns: 100px 1fr 100px;
     }
 }
@@ -31,7 +31,7 @@
     flex-direction: column;
     gap: sizeToken(2);
 
-    @include sm {
+    @container (min-width: 310px) {
         flex-direction: row;
     }
 }


### PR DESCRIPTION
Container width 310px:
![Screenshot 2025-01-15 at 09 27 25](https://github.com/user-attachments/assets/cfbd3863-0d05-4768-bea5-2461f4b7a255)

Container width <310px
![Screenshot 2025-01-15 at 09 27 37](https://github.com/user-attachments/assets/dda7a24d-e5cc-45c9-8782-e892fe49f920)
