### PR TITLE
feat: add button type property to prevent form submission

### DIFF
--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -50,7 +50,7 @@ export const TooltipTrigger = (
     ref: ForwardedRef<HTMLButtonElement>,
 ) => {
     return (
-        <RadixTooltip.Trigger data-test-id={dataTestId} asChild={asChild} ref={ref}>
+        <RadixTooltip.Trigger data-test-id={dataTestId} type="button" asChild={asChild} ref={ref}>
             {children}
         </RadixTooltip.Trigger>
     );


### PR DESCRIPTION
Added `type="button"` to the TooltipTrigger to ensure it never triggers form submissions by default.