### PR TITLE
fix: prevent `hugWidth` from being spread on the `button`

### DIFF
--- a/.changeset/nasty-icons-work.md
+++ b/.changeset/nasty-icons-work.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: prevent `hugWidth` from being spread on the `button`

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -77,6 +77,7 @@ export const Button = forwardRef<HTMLButtonElement | null, ButtonProps>(
             'data-test-id': dataTestId = 'fondue-button',
             className = '',
             onPress = () => {},
+            hugWidth = true,
             ...props
         }: ButtonProps,
         ref: ForwardedRef<HTMLButtonElement | null>,
@@ -88,7 +89,7 @@ export const Button = forwardRef<HTMLButtonElement | null, ButtonProps>(
                 form={form}
                 data-test-id={dataTestId}
                 className={cn(
-                    buttonStyles({ size, variant, ...props }),
+                    buttonStyles({ size, variant, hugWidth, ...props }),
                     textStyles({ variant, ...props }),
                     iconStyles({ variant, ...props }),
                     className,


### PR DESCRIPTION
Prevents this warning
![Screenshot 2025-01-23 at 15 50 01](https://github.com/user-attachments/assets/27ae6732-82a3-421e-add6-eee8c7026d16)
