### PR TITLE
fix: remove tokens from the css bundles

### DIFF
--- a/.changeset/dry-days-rest.md
+++ b/.changeset/dry-days-rest.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-charts": minor
+"@frontify/fondue": minor
+---
+
+feat: remove tokens from css bundles

--- a/packages/charts/.storybook/preview.ts
+++ b/packages/charts/.storybook/preview.ts
@@ -1,6 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import '../src/index.css';
+import '@frontify/fondue-tokens/styles';
+import '@frontify/fondue-tokens/themes/theme.dark.css';
 import type { Preview } from '@storybook/react';
 import DocumentationTemplate from './DocumentationTemplate.mdx';
 

--- a/packages/charts/src/index.css
+++ b/packages/charts/src/index.css
@@ -1,5 +1,4 @@
-@import '@frontify/fondue-tokens/styles';
-@import '@frontify/fondue-tokens/themes/theme.dark.css';
+
 
 @tailwind base;
 @tailwind components;

--- a/packages/charts/src/index.css
+++ b/packages/charts/src/index.css
@@ -1,4 +1,4 @@
-
+/* (c) Copyright Frontify Ltd., all rights reserved. */
 
 @tailwind base;
 @tailwind components;

--- a/packages/fondue/.storybook/preview.tsx
+++ b/packages/fondue/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
+
 import '@frontify/fondue-tokens/styles';
 import '@frontify/fondue-tokens/themes/theme.dark.css';
 

--- a/packages/fondue/.storybook/preview.tsx
+++ b/packages/fondue/.storybook/preview.tsx
@@ -1,4 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
+import '@frontify/fondue-tokens/styles';
+import '@frontify/fondue-tokens/themes/theme.dark.css';
 
 import { Decorator } from '@storybook/react';
 import '../src/styles.css';

--- a/packages/fondue/cypress/support/component.ts
+++ b/packages/fondue/cypress/support/component.ts
@@ -20,3 +20,4 @@ declare global {
 
 import 'cypress-real-events/support';
 import '../../src/styles.css';
+import '@frontify/fondue-tokens/styles';

--- a/packages/fondue/src/styles.css
+++ b/packages/fondue/src/styles.css
@@ -1,8 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-@import '@frontify/fondue-tokens/styles';
-@import '@frontify/fondue-tokens/themes/theme.dark.css';
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
The tokens should not be bundled with the components.

They can be mad available by separately importing `import '@frontify/fondue-tokens/styles'` or wrapping in a `ThemeProvider` 