### PR TITLE
fix: add legacy export for dark theme

### DIFF
--- a/.changeset/smooth-hounds-relax.md
+++ b/.changeset/smooth-hounds-relax.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+feat: Add missing dark theme in legacy token export

--- a/packages/fondue/src/subpackages/tokens.js
+++ b/packages/fondue/src/subpackages/tokens.js
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import '@frontify/fondue-tokens/styles';
+import '@frontify/fondue-tokens/themes/all.css';
+import '@frontify/fondue-tokens/themes/theme.dark.css';
 
 export * from '@frontify/fondue-tokens';


### PR DESCRIPTION
FIX: Solves issue of dark theme not working inside of terrific components

Add the dark theme to the legacy style export used by some terrific components

CU-8697vk44j