### PR TITLE
fix: define box sizing for Table Header Cell

### DIFF
--- a/.changeset/friendly-olives-drum.md
+++ b/.changeset/friendly-olives-drum.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: define box-sizing for Table Header Cell to avoid overflow

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -93,6 +93,7 @@
 }
 
 .cellContent {
+    box-sizing: border-box;
     display: inline-flex;
     width: 100%;
     text-align: inherit;


### PR DESCRIPTION
Explicitly set box sizing for header cell to avoid overflow.

If in the place of usage a parent selector for `box-sizing: content-box is present`, it currently causes a overflow issue


CU-8697wnkzm