### PR TITLE
feat(ScrollArea): add padding options

### DIFF
--- a/.changeset/hungry-jokes-search.md
+++ b/.changeset/hungry-jokes-search.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat(`ScrollArea`): add padding options

--- a/packages/components/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -185,3 +185,99 @@ export const WithShadow: Story = {
         );
     },
 };
+
+export const WithTightPadding: Story = {
+    render: () => {
+        return (
+            <ScrollArea type="scroll" maxHeight={200} maxWidth={300} padding="tight">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec dui in nunc ultricies ornare.
+                    Quisque auctor, nunc nec aliquam fermentum, odio turpis ultricies elit, in ultricies nunc justo
+                    vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies
+                    nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo,
+                    vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero
+                    posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt,
+                    odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies
+                    tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero
+                    in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer
+                    auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae
+                    purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc
+                    justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel
+                    ultricies nunc justo vitae purus.
+                </p>
+            </ScrollArea>
+        );
+    },
+};
+
+export const WithCompactPadding: Story = {
+    render: () => {
+        return (
+            <ScrollArea type="scroll" maxHeight={200} maxWidth={300} padding="compact">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec dui in nunc ultricies ornare.
+                    Quisque auctor, nunc nec aliquam fermentum, odio turpis ultricies elit, in ultricies nunc justo
+                    vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies
+                    nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo,
+                    vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero
+                    posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt,
+                    odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies
+                    tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero
+                    in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer
+                    auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae
+                    purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc
+                    justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel
+                    ultricies nunc justo vitae purus.
+                </p>
+            </ScrollArea>
+        );
+    },
+};
+
+export const WithComfortablePadding: Story = {
+    render: () => {
+        return (
+            <ScrollArea type="scroll" maxHeight={200} maxWidth={300} padding="comfortable">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec dui in nunc ultricies ornare.
+                    Quisque auctor, nunc nec aliquam fermentum, odio turpis ultricies elit, in ultricies nunc justo
+                    vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies
+                    nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo,
+                    vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero
+                    posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt,
+                    odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies
+                    tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero
+                    in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer
+                    auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae
+                    purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc
+                    justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel
+                    ultricies nunc justo vitae purus.
+                </p>
+            </ScrollArea>
+        );
+    },
+};
+
+export const WithSpaciousPadding: Story = {
+    render: () => {
+        return (
+            <ScrollArea type="scroll" maxHeight={200} maxWidth={300} padding="spacious">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec dui in nunc ultricies ornare.
+                    Quisque auctor, nunc nec aliquam fermentum, odio turpis ultricies elit, in ultricies nunc justo
+                    vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies
+                    nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo,
+                    vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero
+                    posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies tincidunt,
+                    odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero in ultricies
+                    tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer auctor, libero
+                    in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae purus. Integer
+                    auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc justo vitae
+                    purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel ultricies nunc
+                    justo vitae purus. Integer auctor, libero in ultricies tincidunt, odio libero posuere justo, vel
+                    ultricies nunc justo vitae purus.
+                </p>
+            </ScrollArea>
+        );
+    },
+};

--- a/packages/components/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.tsx
@@ -25,7 +25,7 @@ export type ScrollAreaProps = {
      */
     maxWidth?: string | number;
     /**
-     * Define the padding of the dialog
+     * Define the padding of the scroll area
      * @default "compact"
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';

--- a/packages/components/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.tsx
@@ -25,6 +25,11 @@ export type ScrollAreaProps = {
      */
     maxWidth?: string | number;
     /**
+     * Define the padding of the dialog
+     * @default "compact"
+     */
+    padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
+    /**
      * Determines if a inset shadow should be shown the edge of the component
      */
     showShadow?: boolean;
@@ -38,6 +43,7 @@ const ScrollAreaComponent = (
         maxHeight = '100%',
         maxWidth = '100%',
         showShadow = false,
+        padding,
         children,
         'data-test-id': dataTestId = 'fondue-scroll-area',
     }: ScrollAreaProps,
@@ -54,8 +60,9 @@ const ScrollAreaComponent = (
             <RadixScrollArea.Viewport
                 className={styles.viewport}
                 style={{ maxHeight }}
-                data-test-id={`${dataTestId}-viewport`}
+                data-scroll-padding={padding}
                 data-show-shadow={showShadow}
+                data-test-id={`${dataTestId}-viewport`}
             >
                 {children}
             </RadixScrollArea.Viewport>

--- a/packages/components/src/components/ScrollArea/__tests__/ScrollArea.ct.tsx
+++ b/packages/components/src/components/ScrollArea/__tests__/ScrollArea.ct.tsx
@@ -4,6 +4,10 @@ import { expect, test } from '@playwright/experimental-ct-react';
 
 import { ScrollArea } from '../ScrollArea';
 
+const SCROLLAREA_VIEWPORT_TEST_ID = 'fondue-scroll-area-viewport';
+const SCROLLAREA_SCROLLBAR_VERTICAL_TEST_ID = 'fondue-scroll-area-vertical-scrollbar';
+const SCROLLAREA_SCROLLBAR_HORIZONTAL_TEST_ID = 'fondue-scroll-area-horizontal-scrollbar';
+
 test('renders with default props', async ({ mount }) => {
     const component = await mount(
         <ScrollArea>
@@ -14,7 +18,7 @@ test('renders with default props', async ({ mount }) => {
     await expect(component).toBeVisible();
     await expect(component).toHaveCSS('max-width', '100%');
 
-    const viewport = component.getByTestId('fondue-scroll-area-viewport');
+    const viewport = component.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID);
 
     await expect(viewport).toBeVisible();
     await expect(viewport).toHaveCSS('max-height', '100%');
@@ -30,7 +34,7 @@ test('renders with custom maxHeight and maxWidth', async ({ mount }) => {
     await expect(component).toBeVisible();
     await expect(component).toHaveCSS('max-width', '800px');
 
-    const viewport = component.locator('data-test-id=fondue-scroll-area-viewport');
+    const viewport = component.locator(`data-test-id=${SCROLLAREA_VIEWPORT_TEST_ID}`);
 
     await expect(viewport).toBeVisible();
     await expect(viewport).toHaveCSS('max-height', '500px');
@@ -43,8 +47,8 @@ test('renders scrollbars on hover', async ({ mount }) => {
         </ScrollArea>,
     );
 
-    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_VERTICAL_TEST_ID);
+    const horizontalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_HORIZONTAL_TEST_ID);
 
     await expect(verticalScrollbar).not.toBeVisible();
     await expect(horizontalScrollbar).not.toBeVisible();
@@ -58,8 +62,8 @@ test('renders scrollbars on hover', async ({ mount }) => {
 test('renders scrollbars always', async ({ mount }) => {
     const component = await mount(<ScrollArea type="always">Scrollable content</ScrollArea>);
 
-    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_VERTICAL_TEST_ID);
+    const horizontalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_HORIZONTAL_TEST_ID);
 
     await expect(verticalScrollbar).toBeVisible();
     await expect(horizontalScrollbar).toBeVisible();
@@ -72,8 +76,8 @@ test('renders scrollbars only when content overflows (and it does not)', async (
         </ScrollArea>,
     );
 
-    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_VERTICAL_TEST_ID);
+    const horizontalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_HORIZONTAL_TEST_ID);
 
     await expect(verticalScrollbar).not.toBeVisible();
     await expect(horizontalScrollbar).not.toBeVisible();
@@ -86,8 +90,8 @@ test('renders scrollbars only when content overflows (and it does)', async ({ mo
         </ScrollArea>,
     );
 
-    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_VERTICAL_TEST_ID);
+    const horizontalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_HORIZONTAL_TEST_ID);
 
     await expect(verticalScrollbar).toBeVisible();
     await expect(horizontalScrollbar).toBeVisible();
@@ -100,8 +104,8 @@ test('renders scrollbars only when scrolling', async ({ mount }) => {
         </ScrollArea>,
     );
 
-    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_VERTICAL_TEST_ID);
+    const horizontalScrollbar = component.getByTestId(SCROLLAREA_SCROLLBAR_HORIZONTAL_TEST_ID);
 
     await expect(verticalScrollbar).not.toBeVisible();
     await expect(horizontalScrollbar).not.toBeVisible();
@@ -211,7 +215,7 @@ test('should render no padding', async ({ mount, page }) => {
         </ScrollArea>,
     );
 
-    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '0px');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '0px');
 });
 
 test('should render tight padding', async ({ mount, page }) => {
@@ -221,7 +225,7 @@ test('should render tight padding', async ({ mount, page }) => {
         </ScrollArea>,
     );
 
-    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '8px');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '8px');
 });
 
 test('should render compact padding', async ({ mount, page }) => {
@@ -230,7 +234,7 @@ test('should render compact padding', async ({ mount, page }) => {
             <div />
         </ScrollArea>,
     );
-    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '16px');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '16px');
 });
 
 test('should render comfortable padding', async ({ mount, page }) => {
@@ -239,7 +243,7 @@ test('should render comfortable padding', async ({ mount, page }) => {
             <div />
         </ScrollArea>,
     );
-    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '16px 24px');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '16px 24px');
 });
 
 test('should render spacious padding', async ({ mount, page }) => {
@@ -248,5 +252,5 @@ test('should render spacious padding', async ({ mount, page }) => {
             <div />
         </ScrollArea>,
     );
-    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '24px 40p');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '24px 40p');
 });

--- a/packages/components/src/components/ScrollArea/__tests__/ScrollArea.ct.tsx
+++ b/packages/components/src/components/ScrollArea/__tests__/ScrollArea.ct.tsx
@@ -215,7 +215,7 @@ test('should render no padding', async ({ mount, page }) => {
         </ScrollArea>,
     );
 
-    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '0px');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '0px 10px 0px 0px');
 });
 
 test('should render tight padding', async ({ mount, page }) => {
@@ -234,7 +234,7 @@ test('should render compact padding', async ({ mount, page }) => {
             <div />
         </ScrollArea>,
     );
-    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '16px');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '8px 16px');
 });
 
 test('should render comfortable padding', async ({ mount, page }) => {
@@ -252,5 +252,5 @@ test('should render spacious padding', async ({ mount, page }) => {
             <div />
         </ScrollArea>,
     );
-    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '24px 40p');
+    await expect(page.getByTestId(SCROLLAREA_VIEWPORT_TEST_ID)).toHaveCSS('padding', '24px 40px');
 });

--- a/packages/components/src/components/ScrollArea/__tests__/ScrollArea.ct.tsx
+++ b/packages/components/src/components/ScrollArea/__tests__/ScrollArea.ct.tsx
@@ -4,205 +4,249 @@ import { expect, test } from '@playwright/experimental-ct-react';
 
 import { ScrollArea } from '../ScrollArea';
 
-test.describe('ScrollArea Component', () => {
-    test('renders with default props', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea>
-                <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
-            </ScrollArea>,
-        );
+test('renders with default props', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea>
+            <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
+        </ScrollArea>,
+    );
 
-        await expect(component).toBeVisible();
-        await expect(component).toHaveCSS('max-width', '100%');
+    await expect(component).toBeVisible();
+    await expect(component).toHaveCSS('max-width', '100%');
 
-        const viewport = component.getByTestId('fondue-scroll-area-viewport');
+    const viewport = component.getByTestId('fondue-scroll-area-viewport');
 
-        await expect(viewport).toBeVisible();
-        await expect(viewport).toHaveCSS('max-height', '100%');
-    });
+    await expect(viewport).toBeVisible();
+    await expect(viewport).toHaveCSS('max-height', '100%');
+});
 
-    test('renders with custom maxHeight and maxWidth', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea maxHeight="500px" maxWidth="800px">
-                <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
-            </ScrollArea>,
-        );
+test('renders with custom maxHeight and maxWidth', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea maxHeight="500px" maxWidth="800px">
+            <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
+        </ScrollArea>,
+    );
 
-        await expect(component).toBeVisible();
-        await expect(component).toHaveCSS('max-width', '800px');
+    await expect(component).toBeVisible();
+    await expect(component).toHaveCSS('max-width', '800px');
 
-        const viewport = component.locator('data-test-id=fondue-scroll-area-viewport');
+    const viewport = component.locator('data-test-id=fondue-scroll-area-viewport');
 
-        await expect(viewport).toBeVisible();
-        await expect(viewport).toHaveCSS('max-height', '500px');
-    });
+    await expect(viewport).toBeVisible();
+    await expect(viewport).toHaveCSS('max-height', '500px');
+});
 
-    test('renders scrollbars on hover', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea maxHeight="300px" maxWidth="300px">
-                <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
-            </ScrollArea>,
-        );
+test('renders scrollbars on hover', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea maxHeight="300px" maxWidth="300px">
+            <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
+        </ScrollArea>,
+    );
 
-        const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-        const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
+    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
 
-        await expect(verticalScrollbar).not.toBeVisible();
-        await expect(horizontalScrollbar).not.toBeVisible();
+    await expect(verticalScrollbar).not.toBeVisible();
+    await expect(horizontalScrollbar).not.toBeVisible();
 
-        await component.hover();
+    await component.hover();
 
-        await expect(verticalScrollbar).toBeVisible();
-        await expect(horizontalScrollbar).toBeVisible();
-    });
+    await expect(verticalScrollbar).toBeVisible();
+    await expect(horizontalScrollbar).toBeVisible();
+});
 
-    test('renders scrollbars always', async ({ mount }) => {
-        const component = await mount(<ScrollArea type="always">Scrollable content</ScrollArea>);
+test('renders scrollbars always', async ({ mount }) => {
+    const component = await mount(<ScrollArea type="always">Scrollable content</ScrollArea>);
 
-        const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-        const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
+    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
 
-        await expect(verticalScrollbar).toBeVisible();
-        await expect(horizontalScrollbar).toBeVisible();
-    });
+    await expect(verticalScrollbar).toBeVisible();
+    await expect(horizontalScrollbar).toBeVisible();
+});
 
-    test('renders scrollbars only when content overflows (and it does not)', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea type="auto" maxHeight="300px" maxWidth="300px">
-                Scrollable content
-            </ScrollArea>,
-        );
+test('renders scrollbars only when content overflows (and it does not)', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea type="auto" maxHeight="300px" maxWidth="300px">
+            Scrollable content
+        </ScrollArea>,
+    );
 
-        const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-        const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
+    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
 
-        await expect(verticalScrollbar).not.toBeVisible();
-        await expect(horizontalScrollbar).not.toBeVisible();
-    });
+    await expect(verticalScrollbar).not.toBeVisible();
+    await expect(horizontalScrollbar).not.toBeVisible();
+});
 
-    test('renders scrollbars only when content overflows (and it does)', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea type="auto" maxHeight="300px" maxWidth="300px">
-                <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
-            </ScrollArea>,
-        );
+test('renders scrollbars only when content overflows (and it does)', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea type="auto" maxHeight="300px" maxWidth="300px">
+            <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
+        </ScrollArea>,
+    );
 
-        const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-        const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
+    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
 
-        await expect(verticalScrollbar).toBeVisible();
-        await expect(horizontalScrollbar).toBeVisible();
-    });
+    await expect(verticalScrollbar).toBeVisible();
+    await expect(horizontalScrollbar).toBeVisible();
+});
 
-    test('renders scrollbars only when scrolling', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea type="scroll" maxHeight="300px" maxWidth="300px">
-                <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
-            </ScrollArea>,
-        );
+test('renders scrollbars only when scrolling', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea type="scroll" maxHeight="300px" maxWidth="300px">
+            <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
+        </ScrollArea>,
+    );
 
-        const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
-        const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
+    const verticalScrollbar = component.getByTestId('fondue-scroll-area-vertical-scrollbar');
+    const horizontalScrollbar = component.getByTestId('fondue-scroll-area-horizontal-scrollbar');
 
-        await expect(verticalScrollbar).not.toBeVisible();
-        await expect(horizontalScrollbar).not.toBeVisible();
+    await expect(verticalScrollbar).not.toBeVisible();
+    await expect(horizontalScrollbar).not.toBeVisible();
 
-        await component.hover();
-        await component.click();
+    await component.hover();
+    await component.click();
 
-        await component.press('ArrowDown');
-        await expect(verticalScrollbar).toBeVisible();
+    await component.press('ArrowDown');
+    await expect(verticalScrollbar).toBeVisible();
 
-        await component.press('ArrowRight');
-        await expect(horizontalScrollbar).toBeVisible();
-    });
+    await component.press('ArrowRight');
+    await expect(horizontalScrollbar).toBeVisible();
+});
 
-    test('scrolls content vertically by dragging the scrollbar thumb', async ({ mount, page }) => {
-        const component = await mount(
-            <ScrollArea maxHeight="300px" maxWidth="300px">
-                <div style={{ height: '1000px', width: '100%' }}>
-                    {Array.from({ length: 20 }, (_, i) => (
-                        <p key={i} data-test-id={`paragraph-${i}`}>
-                            Paragraph {i + 1}
-                        </p>
-                    ))}
-                </div>
-            </ScrollArea>,
-        );
-
-        await component.hover();
-
-        const verticalScrollbarThumb = component.getByTestId('fondue-scroll-area-vertical-scrollbar-thumb');
-
-        await expect(verticalScrollbarThumb).toBeVisible();
-
-        const firstParagraph = component.getByTestId('paragraph-0');
-        const initialFirstParagraphBox = await firstParagraph.boundingBox();
-        const thumbBox = await verticalScrollbarThumb.boundingBox();
-
-        if (!thumbBox) {
-            throw new Error("Couldn't get thumb bounding box");
-        }
-
-        const thumbXPos = thumbBox.x + thumbBox.width / 2;
-
-        await page.mouse.move(thumbXPos, thumbBox.y + 100);
-        await page.mouse.down();
-        await page.mouse.move(thumbXPos, thumbBox.y + 100, { steps: 10 });
-        await page.mouse.up();
-
-        const newFirstParagraphBox = await firstParagraph.boundingBox();
-
-        expect(newFirstParagraphBox?.y).toBeLessThan(initialFirstParagraphBox?.y || 0);
-    });
-
-    test('scrolls content horizontally by dragging the scrollbar thumb', async ({ mount, page }) => {
-        const component = await mount(
-            <ScrollArea maxHeight="300px" maxWidth="300px">
-                <div style={{ height: '100%', width: '1000px' }}>
-                    <p style={{ whiteSpace: 'nowrap' }} data-test-id="long-text">
-                        {Array.from({ length: 50 }, (_, i) => `Word${i} `).join('')}
+test('scrolls content vertically by dragging the scrollbar thumb', async ({ mount, page }) => {
+    const component = await mount(
+        <ScrollArea maxHeight="300px" maxWidth="300px">
+            <div style={{ height: '1000px', width: '100%' }}>
+                {Array.from({ length: 20 }, (_, i) => (
+                    <p key={i} data-test-id={`paragraph-${i}`}>
+                        Paragraph {i + 1}
                     </p>
-                </div>
-            </ScrollArea>,
-        );
+                ))}
+            </div>
+        </ScrollArea>,
+    );
 
-        await component.hover();
+    await component.hover();
 
-        const horizontalScrollbarThumb = component.getByTestId('fondue-scroll-area-horizontal-scrollbar-thumb');
+    const verticalScrollbarThumb = component.getByTestId('fondue-scroll-area-vertical-scrollbar-thumb');
 
-        await expect(horizontalScrollbarThumb).toBeVisible();
+    await expect(verticalScrollbarThumb).toBeVisible();
 
-        const longText = component.getByTestId('long-text');
-        const initialTextBox = await longText.boundingBox();
-        const thumbBox = await horizontalScrollbarThumb.boundingBox();
+    const firstParagraph = component.getByTestId('paragraph-0');
+    const initialFirstParagraphBox = await firstParagraph.boundingBox();
+    const thumbBox = await verticalScrollbarThumb.boundingBox();
 
-        if (!thumbBox) {
-            throw new Error("Couldn't get thumb bounding box");
-        }
+    if (!thumbBox) {
+        throw new Error("Couldn't get thumb bounding box");
+    }
 
-        const thumbYPos = thumbBox.y + thumbBox.height / 2;
+    const thumbXPos = thumbBox.x + thumbBox.width / 2;
 
-        await page.mouse.move(thumbBox.x + 100, thumbYPos);
-        await page.mouse.down();
-        await page.mouse.move(thumbBox.x + 100, thumbYPos, { steps: 10 });
-        await page.mouse.up();
+    await page.mouse.move(thumbXPos, thumbBox.y + 100);
+    await page.mouse.down();
+    await page.mouse.move(thumbXPos, thumbBox.y + 100, { steps: 10 });
+    await page.mouse.up();
 
-        const newTextBox = await longText.boundingBox();
-        expect(newTextBox?.x).toBeLessThan(initialTextBox?.x || 0);
-    });
+    const newFirstParagraphBox = await firstParagraph.boundingBox();
 
-    test('renders corner when both scrollbars are visible', async ({ mount }) => {
-        const component = await mount(
-            <ScrollArea maxHeight="300px" maxWidth="300px">
-                <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
-            </ScrollArea>,
-        );
+    expect(newFirstParagraphBox?.y).toBeLessThan(initialFirstParagraphBox?.y || 0);
+});
 
-        await component.hover();
+test('scrolls content horizontally by dragging the scrollbar thumb', async ({ mount, page }) => {
+    const component = await mount(
+        <ScrollArea maxHeight="300px" maxWidth="300px">
+            <div style={{ height: '100%', width: '1000px' }}>
+                <p style={{ whiteSpace: 'nowrap' }} data-test-id="long-text">
+                    {Array.from({ length: 50 }, (_, i) => `Word${i} `).join('')}
+                </p>
+            </div>
+        </ScrollArea>,
+    );
 
-        const corner = component.getByTestId('fondue-scroll-area-corner');
+    await component.hover();
 
-        await expect(corner).toBeVisible();
-    });
+    const horizontalScrollbarThumb = component.getByTestId('fondue-scroll-area-horizontal-scrollbar-thumb');
+
+    await expect(horizontalScrollbarThumb).toBeVisible();
+
+    const longText = component.getByTestId('long-text');
+    const initialTextBox = await longText.boundingBox();
+    const thumbBox = await horizontalScrollbarThumb.boundingBox();
+
+    if (!thumbBox) {
+        throw new Error("Couldn't get thumb bounding box");
+    }
+
+    const thumbYPos = thumbBox.y + thumbBox.height / 2;
+
+    await page.mouse.move(thumbBox.x + 100, thumbYPos);
+    await page.mouse.down();
+    await page.mouse.move(thumbBox.x + 100, thumbYPos, { steps: 10 });
+    await page.mouse.up();
+
+    const newTextBox = await longText.boundingBox();
+    expect(newTextBox?.x).toBeLessThan(initialTextBox?.x || 0);
+});
+
+test('renders corner when both scrollbars are visible', async ({ mount }) => {
+    const component = await mount(
+        <ScrollArea maxHeight="300px" maxWidth="300px">
+            <div style={{ height: '1000px', width: '1000px' }}>Scrollable content</div>
+        </ScrollArea>,
+    );
+
+    await component.hover();
+
+    const corner = component.getByTestId('fondue-scroll-area-corner');
+
+    await expect(corner).toBeVisible();
+});
+test('should render no padding', async ({ mount, page }) => {
+    await mount(
+        <ScrollArea>
+            <div />
+        </ScrollArea>,
+    );
+
+    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '0px');
+});
+
+test('should render tight padding', async ({ mount, page }) => {
+    await mount(
+        <ScrollArea padding="tight">
+            <div />
+        </ScrollArea>,
+    );
+
+    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '8px');
+});
+
+test('should render compact padding', async ({ mount, page }) => {
+    await mount(
+        <ScrollArea padding="compact">
+            <div />
+        </ScrollArea>,
+    );
+    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '16px');
+});
+
+test('should render comfortable padding', async ({ mount, page }) => {
+    await mount(
+        <ScrollArea padding="comfortable">
+            <div />
+        </ScrollArea>,
+    );
+    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '16px 24px');
+});
+
+test('should render spacious padding', async ({ mount, page }) => {
+    await mount(
+        <ScrollArea padding="spacious">
+            <div />
+        </ScrollArea>,
+    );
+    await expect(page.getByTestId('fondue-scroll-area-viewport')).toHaveCSS('padding', '24px 40p');
 });

--- a/packages/components/src/components/ScrollArea/styles/scrollArea.module.scss
+++ b/packages/components/src/components/ScrollArea/styles/scrollArea.module.scss
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 @use '../../../utilities/transitions.module.scss';
+@use '../../../utilities/sizeToken.module.scss';
 
 .root {
     height: 100%;
@@ -13,6 +14,22 @@
     width: 100%;
     height: 100%;
     padding-right: var(--scrollbar-size);
+
+    &[data-scroll-padding='tight'] {
+        padding: sizeToken.get(2);
+    }
+
+    &[data-scroll-padding='compact'] {
+        padding: sizeToken.get(2) sizeToken.get(4);
+    }
+
+    &[data-scroll-padding='comfortable'] {
+        padding: sizeToken.get(4) sizeToken.get(6);
+    }
+
+    &[data-scroll-padding='spacious'] {
+        padding: sizeToken.get(6) sizeToken.get(10);
+    }
 
     &[data-show-shadow='true'] {
         box-shadow: inset 0 -15px 8px -10px var(--box-neutral-color);


### PR DESCRIPTION
CU-8697y5qxd

It can be rather annoying using scroll areas inside elements like Dialogs because you have to cancel the padding on the dialog and then use tailwind to recreate it. This way we get some convenience while not sacrificing on composibility