### PR TITLE
fix: fix broken flyout width on mobile

### DIFF
--- a/.changeset/slow-poems-beg.md
+++ b/.changeset/slow-poems-beg.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: fix broken flyout width on mobile

--- a/packages/components/src/components/Flyout/styles/flyout.module.scss
+++ b/packages/components/src/components/Flyout/styles/flyout.module.scss
@@ -42,7 +42,7 @@
     }
 
     // Mobile view flyout -> dialog responsiveness
-    body > [data-radix-popper-content-wrapper]:has(&) {
+    body [data-radix-popper-content-wrapper]:has(&) {
         @include mediaQuery.max-sm {
             &:has([data-side='top']),
             &:has([data-side='bottom']) {


### PR DESCRIPTION
Adding the `ThemeProvider` makes this not be a direct child of the `body`