### PR TITLE
fix(Dialog): dialog height grows too much on safari

### DIFF
--- a/.changeset/young-plants-exist.md
+++ b/.changeset/young-plants-exist.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+fix(Dialog): dialog height grows too much on safari

--- a/packages/components/src/components/Dialog/styles/dialog.module.scss
+++ b/packages/components/src/components/Dialog/styles/dialog.module.scss
@@ -17,7 +17,6 @@
     border: var(--line-width) solid var(--line-color);
     z-index: 1;
     max-width: var(--dialog-max-width);
-    height: fit-content;
     min-height: var(--dialog-min-height);
     max-height: calc(100dvh - 10rem);
     overflow: hidden;


### PR DESCRIPTION
Before:
![Screenshot 2025-02-28 at 08 18 03](https://github.com/user-attachments/assets/08600929-0870-4762-be90-7cc52434de71)

After:
![Screenshot 2025-02-28 at 08 18 30](https://github.com/user-attachments/assets/4cb793ff-3546-4588-85d2-5ec504db12d2)

CU-86984ebd9