### PR TITLE
fix(Select): Increase select portal z index

### DIFF
--- a/.changeset/empty-worms-repair.md
+++ b/.changeset/empty-worms-repair.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+fix(Select): increase Selects portal z-index

--- a/packages/components/src/components/Select/styles/select.module.scss
+++ b/packages/components/src/components/Select/styles/select.module.scss
@@ -253,7 +253,7 @@
 }
 
 .portal {
-    z-index: 30;
+    z-index: 120000;
 
     &[data-side='bottom'] {
         margin-top: sizeToken.get(2);


### PR DESCRIPTION
The old Dropdowns used a z-index of 120000 to make sure it is above any modal that might contain it. 30 was way too low and opens behind most modals.

"Old" Dropdown:
![Screenshot 2025-02-28 at 14 48 45](https://github.com/user-attachments/assets/c07cefb6-d3a2-437d-8011-09c2ec5f3fd4)

CU-86982zvzh
