### PR TITLE
fix(Table): make sure focus ring on table is always on top

### DIFF
--- a/.changeset/khaki-donuts-behave.md
+++ b/.changeset/khaki-donuts-behave.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(Table): make sure focus ring on table is always on top

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -132,7 +132,7 @@
 
     &:focus-visible {
         @include focusStyle.focus-outline;
-        z-index: 1;
+        z-index: 3;
     }
 
     &[data-selected='true'] {


### PR DESCRIPTION
Before:
![2025-03-13 13 31 19](https://github.com/user-attachments/assets/d4fceac7-2320-4e9f-99d5-25e5a55d7fa3)

After:
![2025-03-13 13 31 47](https://github.com/user-attachments/assets/d1952246-10ff-4942-a1ed-652ee3b84daa)
