### PR TITLE
fix: adress color picker issues

### DIFF
--- a/.changeset/old-ways-roll.md
+++ b/.changeset/old-ways-roll.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: adress a11y issues and improve handing of transparency in the ColorPicker Input

--- a/packages/components/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -90,6 +90,7 @@ export const InFlyout: Story = {
     render: (args) => {
         const [savedColor, setSavedColor] = useState(args.currentColor);
         const [currentColor, setCurrentColor] = useState(args.currentColor);
+        const [currentFormat, setCurrentFormat] = useState(args.currentFormat);
         const [isOpen, setIsOpen] = useState(true);
         return (
             <Flyout.Root open={isOpen} onOpenChange={setIsOpen}>
@@ -106,9 +107,10 @@ export const InFlyout: Story = {
                     <Flyout.Body>
                         <div className="tw-p-2 md:tw-w-[450px]">
                             <ColorPicker.Root
-                                defaultFormat="RGBA"
+                                currentFormat={currentFormat}
                                 currentColor={currentColor}
                                 onColorChange={setCurrentColor}
+                                onFormatChange={setCurrentFormat}
                             >
                                 <ColorPicker.Values />
                                 <ColorPicker.Gradient />

--- a/packages/components/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPicker.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Slot as RadixSlot } from '@radix-ui/react-slot';
-import { Children, forwardRef, useState, type ForwardedRef, type ReactNode } from 'react';
+import { Children, forwardRef, useMemo, useState, type ForwardedRef, type ReactNode } from 'react';
 
 import { ForwardedRefColorGradientInput } from './ColorGradientInput';
 import { ForwardedRefColorPickerInput } from './ColorPickerInput';
@@ -24,7 +24,15 @@ type ColorPickerProps = {
      */
     onColorChange?: (color: RgbaColor) => void;
     /**
-     * The default format to use for the color input
+     * The active color format in the color picker
+     */
+    currentFormat?: ColorFormat;
+    /**
+     * Event handler called when the color format changes
+     */
+    onFormatChange?: (format: ColorFormat) => void;
+    /**
+     * The default format to use for the color input when not controlled externally
      * @default "HEX"
      */
     defaultFormat?: ColorFormat;
@@ -39,13 +47,16 @@ export const ColorPickerRoot = (
         children,
         currentColor = DEFAULT_COLOR,
         onColorChange = () => {},
+        currentFormat,
+        onFormatChange = () => {},
         defaultFormat = DEFAULT_FORMAT,
         'data-test-id': dataTestId = 'color-picker-input',
         ...props
     }: ColorPickerProps,
     forwardedRef: ForwardedRef<HTMLDivElement>,
 ) => {
-    const [currentFormat, setCurrentFormat] = useState<ColorFormat>(defaultFormat);
+    const [managedFormat, setManagedFormat] = useState<ColorFormat>(defaultFormat);
+    const activeFormat = useMemo(() => currentFormat ?? managedFormat, [currentFormat, managedFormat]);
 
     return (
         <div className={styles.root} data-picker-type="custom-color" data-test-id={dataTestId} ref={forwardedRef}>
@@ -53,12 +64,13 @@ export const ColorPickerRoot = (
                 <ColorPickerSlot
                     {...props}
                     onColorChange={(color: RgbaColor) => {
-                        onColorChange(getColorWithName(color, currentFormat));
+                        onColorChange(getColorWithName(color, activeFormat));
                     }}
                     currentColor={currentColor}
-                    currentFormat={currentFormat}
+                    currentFormat={activeFormat}
                     setCurrentFormat={(currentFormat: ColorFormat) => {
-                        setCurrentFormat(currentFormat);
+                        setManagedFormat(currentFormat);
+                        onFormatChange(currentFormat);
                         onColorChange(getColorWithName(currentColor, currentFormat));
                     }}
                 >

--- a/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
@@ -46,8 +46,8 @@ export const ColorPickerInput = (
     forwardedRef: ForwardedRef<HTMLDivElement>,
 ) => {
     return (
-        <div id={id} className={styles.root} {...props} ref={forwardedRef} data-test-id={dataTestId}>
-            <button className={styles.button} onClick={onClick} type="button" data-color-input-select>
+        <div id={id} className={styles.root} ref={forwardedRef} data-test-id={dataTestId}>
+            <button className={styles.button} {...props} onClick={onClick} type="button" data-color-input-select>
                 {currentColor?.red !== undefined ? (
                     <div
                         aria-hidden

--- a/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
@@ -7,7 +7,7 @@ import { type CommonAriaAttrs } from '#/utilities/types';
 
 import styles from './styles/colorInput.module.scss';
 import { type RgbaColor } from './types';
-import { colorToCss } from './utils';
+import { colorToCss, getColorWithName } from './utils';
 
 type ColorPickerInputProps = {
     id?: string;
@@ -45,6 +45,7 @@ export const ColorPickerInput = (
     }: ColorPickerInputProps,
     forwardedRef: ForwardedRef<HTMLDivElement>,
 ) => {
+    const colorName = currentColor?.name ?? (currentColor ? getColorWithName(currentColor, 'RGBA').name : '');
     return (
         <div id={id} className={styles.root} ref={forwardedRef} data-test-id={dataTestId}>
             <button className={styles.button} {...props} onClick={onClick} type="button" data-color-input-select>
@@ -61,7 +62,7 @@ export const ColorPickerInput = (
                     </>
                 )}
 
-                <span className={styles.colorName}>{currentColor?.name}</span>
+                <span className={styles.colorName}>{colorName}</span>
             </button>
             <div className={styles.actions}>
                 {onClear && (

--- a/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconCaretDown, IconCross, IconDroplet } from '@frontify/fondue-icons';
-import { type ForwardedRef, forwardRef } from 'react';
+import { type CSSProperties, type ForwardedRef, forwardRef } from 'react';
 
 import { type CommonAriaAttrs } from '#/utilities/types';
 
@@ -52,7 +52,7 @@ export const ColorPickerInput = (
                     <div
                         aria-hidden
                         className={styles.colorIndicator}
-                        style={{ backgroundColor: colorToCss(currentColor) }}
+                        style={{ '--active-color': colorToCss(currentColor) } as CSSProperties}
                     />
                 ) : (
                     <>

--- a/packages/components/src/components/ColorPicker/styles/colorInput.module.scss
+++ b/packages/components/src/components/ColorPicker/styles/colorInput.module.scss
@@ -3,6 +3,7 @@
 @use '../../../utilities/focusStyle.module.scss';
 @use '../../../utilities/transitions.module.scss';
 
+
 .root {
     width: 100%;
     position: relative;
@@ -69,10 +70,23 @@
 }
 
 .colorIndicator {
+    position: relative;
+    overflow: hidden;
     width: sizeToken.get(4);
     height: sizeToken.get(4);
     border-radius: sizeToken.get(1);
     border: 1px solid var(--line-color-x-strong);
+    background-clip: padding-box;
+    background-image: repeating-conic-gradient(white 0% 25%, var(--line-color-strong) 0% 50%);
+    background-size: 6px 6px;
+    background-position: -0.5px -0.5px;
+
+    &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--active-color);
+    }
 }
 
 .actions {

--- a/packages/components/src/components/ColorPicker/utils.ts
+++ b/packages/components/src/components/ColorPicker/utils.ts
@@ -20,7 +20,7 @@ export const colorToCss = (color?: RgbaColor) => {
     if (!color) {
         return undefined;
     }
-    return `rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha || 1})`;
+    return `rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha ?? 1})`;
 };
 
 /**
@@ -118,7 +118,7 @@ export const getColorWithName = (color: RgbaColor, currentFormat: ColorFormat) =
     }
     return {
         ...color,
-        name: `rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha || 1})`,
+        name: `rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha ?? 1})`,
     };
 };
 


### PR DESCRIPTION
- pass slot props from flyout to button instead of div to resolve a11y issues
- fix issue where opacity 0 was transformed into opacity 1
- added functionality to control the format externally
- added check pattern background for the color preview in the input to make transparency more visible
- display rgba value when no name is passed for the coolor

CU-8698kmet7
CU-8698j7gdf