### PR TITLE
feat: add generic type support to `SegmentedControl` component

### DIFF
--- a/.changeset/mighty-news-unite.md
+++ b/.changeset/mighty-news-unite.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat: add generic type support to SegmentedControl component

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -3,26 +3,26 @@
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { forwardRef, type ForwardedRef, type ReactNode } from 'react';
 
-import { useControllableState } from '#/hooks/useControllableState';
-
 import styles from './styles/segmentedControl.module.scss';
 
-export type SegmentedControlRootProps = {
+import { useControllableState } from '#/hooks/useControllableState';
+
+export type SegmentedControlRootProps<TValue extends string = string> = {
     id?: string;
     children: ReactNode;
     /**
      * The default value of the segmented control
      * Used for uncontrolled components
      */
-    defaultValue: string;
+    defaultValue: TValue;
     /**
      * The controlled value of the segmented control
      */
-    value?: string;
+    value?: TValue;
     /**
      * Event handler called when the value changes
      */
-    onValueChange?: (value: string) => void;
+    onValueChange?: (value: TValue) => void;
     /**
      * Disable the segmented control
      * @default false
@@ -35,7 +35,7 @@ export type SegmentedControlRootProps = {
     hugWidth?: boolean;
 };
 
-export const SegmentedControlRoot = (
+export const SegmentedControlRoot = <TValue extends string = string>(
     {
         children,
         value: propsValue,
@@ -43,7 +43,7 @@ export const SegmentedControlRoot = (
         onValueChange,
         hugWidth = true,
         ...rootProps
-    }: SegmentedControlRootProps,
+    }: SegmentedControlRootProps<TValue>,
     ref: ForwardedRef<HTMLDivElement>,
 ) => {
     const [value, setValue] = useControllableState({
@@ -59,7 +59,7 @@ export const SegmentedControlRoot = (
             className={styles.root}
             onValueChange={(value) => {
                 if (value) {
-                    setValue(value);
+                    setValue(value as TValue);
                 }
             }}
             value={value}
@@ -100,6 +100,8 @@ export const SegmentedControlItem = (
 SegmentedControlItem.displayName = 'SegmentedControl.Item';
 
 export const SegmentedControl = {
-    Root: forwardRef<HTMLDivElement, SegmentedControlRootProps>(SegmentedControlRoot),
-    Item: forwardRef<HTMLButtonElement, SegmentedControlItemProps>(SegmentedControlItem),
+    Root: forwardRef(SegmentedControlRoot) as <TValue extends string = string>(
+        props: SegmentedControlRootProps<TValue> & { ref?: ForwardedRef<HTMLDivElement> },
+    ) => JSX.Element,
+    Item: forwardRef(SegmentedControlItem),
 };

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -3,9 +3,9 @@
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { forwardRef, type ForwardedRef, type ReactNode } from 'react';
 
-import styles from './styles/segmentedControl.module.scss';
-
 import { useControllableState } from '#/hooks/useControllableState';
+
+import styles from './styles/segmentedControl.module.scss';
 
 export type SegmentedControlRootProps<TValue extends string = string> = {
     id?: string;

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
-import { forwardRef, type ForwardedRef, type ReactNode } from 'react';
+import { forwardRef, type ForwardedRef, type ReactElement, type ReactNode } from 'react';
 
 import { useControllableState } from '#/hooks/useControllableState';
 
@@ -102,6 +102,6 @@ SegmentedControlItem.displayName = 'SegmentedControl.Item';
 export const SegmentedControl = {
     Root: forwardRef(SegmentedControlRoot) as <TValue extends string = string>(
         props: SegmentedControlRootProps<TValue> & { ref?: ForwardedRef<HTMLDivElement> },
-    ) => JSX.Element,
+    ) => ReactElement,
     Item: forwardRef(SegmentedControlItem),
 };

--- a/packages/components/src/components/SegmentedControl/__tests__/SegmentedControl.ct.tsx
+++ b/packages/components/src/components/SegmentedControl/__tests__/SegmentedControl.ct.tsx
@@ -130,3 +130,39 @@ test('should render full width', async ({ mount }) => {
     const boundingBox = await component.getByTestId(SEGMENTED_CONTROL_TEST_ID).boundingBox();
     expect(boundingBox?.width).toBe(550);
 });
+
+test('should work with enum values', async ({ mount }) => {
+    // Define an enum for testing generic type functionality
+    const enum TabOptions {
+        First = 'first',
+        Second = 'second',
+        Third = 'third',
+    }
+
+    const onValueChange = sinon.spy();
+
+    const component = await mount(
+        <SegmentedControl.Root<TabOptions>
+            data-test-id={SEGMENTED_CONTROL_TEST_ID}
+            defaultValue={TabOptions.First}
+            onValueChange={onValueChange}
+        >
+            <SegmentedControl.Item value={TabOptions.First}>First</SegmentedControl.Item>
+            <SegmentedControl.Item value={TabOptions.Second}>Second</SegmentedControl.Item>
+            <SegmentedControl.Item value={TabOptions.Third}>Third</SegmentedControl.Item>
+        </SegmentedControl.Root>,
+    );
+
+    // Check initial state
+    await expect(component.getByRole('radio').locator('nth=0')).toHaveAttribute('aria-checked', 'true');
+
+    // Click second option
+    await component.getByRole('radio').locator('nth=1').click();
+
+    // Verify callback was called with the enum value
+    expect(onValueChange.calledOnce).toBe(true);
+    expect(onValueChange.firstCall.args[0]).toBe(TabOptions.Second);
+
+    // Check the UI updates correctly
+    await expect(component.getByRole('radio').locator('nth=1')).toHaveAttribute('aria-checked', 'true');
+});


### PR DESCRIPTION
This PR adds type generic capabilities to the SegmentedControl component, allowing for stronger type safety when working with enum values and string literal types.


before
```tsx
<SegmentedControl.Root
  value={visibility}
  defaultValue={VisibilityKind.Visible}
  onValueChange={_value => {
    const value = _value as VisibilityKind; // Type assertion needed 😢
    // ...
  }}
>
  {/* ... */}
</SegmentedControl.Root>
        
```

after

```tsx

<SegmentedControl.Root<VisibilityKind> // passing the generic is optional
  value={visibility}
  defaultValue={VisibilityKind.Visible}
  onValueChange={value => {
    // TypeScript knows 'value' is VisibilityKind! 🎉
    // ...
  }}
>
  {/* ... */}
</SegmentedControl.Root>

```

This component enhancement maintains full backward compatibility. You can continue using <SegmentedControl.Root> without specifying any generic type parameter, and it will work exactly as before with the default string type.