### PR TITLE
feat: Add `disabled` property to color picker input

### DIFF
--- a/.changeset/smooth-hats-sleep.md
+++ b/.changeset/smooth-hats-sleep.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+Add `disabled` property to ColorPickerInput

--- a/packages/components/src/components/ColorPicker/ColorPickerInput.stories.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPickerInput.stories.tsx
@@ -34,3 +34,10 @@ export const Empty: Story = {
         return <ColorPicker.Input {...args} onClear={() => {}} />;
     },
 };
+
+export const Disabled: Story = {
+    args: {},
+    render: (args) => {
+        return <ColorPicker.Input {...args} disabled={true} onClear={() => {}} />;
+    },
+};

--- a/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
@@ -3,11 +3,11 @@
 import { IconCaretDown, IconCross, IconDroplet } from '@frontify/fondue-icons';
 import { type CSSProperties, type ForwardedRef, forwardRef } from 'react';
 
-import { type CommonAriaAttrs } from '#/utilities/types';
-
 import styles from './styles/colorInput.module.scss';
 import { type RgbaColor } from './types';
 import { colorToCss, getColorWithName } from './utils';
+
+import { type CommonAriaAttrs } from '#/utilities/types';
 
 type ColorPickerInputProps = {
     id?: string;
@@ -16,9 +16,13 @@ type ColorPickerInputProps = {
      */
     currentColor?: RgbaColor;
     /**
-     * The open state of the color picker used to dermine arrow state
+     * The open state of the color picker used to determine arrow state
      */
     isOpen?: boolean;
+    /**
+     * Whether the color picker input is disabled
+     */
+    disabled?: boolean;
     /**
      * callback for clearing the color
      */
@@ -38,6 +42,7 @@ export const ColorPickerInput = (
         id,
         currentColor,
         isOpen,
+        disabled = false,
         onClear,
         onClick,
         'data-test-id': dataTestId = 'color-picker-input',
@@ -48,7 +53,14 @@ export const ColorPickerInput = (
     const colorName = currentColor?.name ?? (currentColor ? getColorWithName(currentColor, 'RGBA').name : '');
     return (
         <div id={id} className={styles.root} ref={forwardedRef} data-test-id={dataTestId}>
-            <button className={styles.button} {...props} onClick={onClick} type="button" data-color-input-select>
+            <button
+                className={styles.button}
+                {...props}
+                disabled={disabled}
+                onClick={onClick}
+                type="button"
+                data-color-input-select
+            >
                 {currentColor?.red !== undefined ? (
                     <div
                         aria-hidden

--- a/packages/components/src/components/ColorPicker/__tests__/ColorPicker.ct.tsx
+++ b/packages/components/src/components/ColorPicker/__tests__/ColorPicker.ct.tsx
@@ -403,3 +403,22 @@ test('color picker input should render hex value without error', async ({ mount 
     await expect(component).toBeVisible();
     await expect(component).toHaveText('#ff0000');
 });
+
+test('color picker input should display a disabled button when disabled', async ({ mount }) => {
+    const component = await mount(
+        <ColorPicker.Input
+            aria-label="Color picker input"
+            currentColor={{
+                red: 255,
+                green: 0,
+                blue: 0,
+                alpha: 0.4,
+                name: '#ff0000',
+            }}
+            disabled={true}
+            onClear={() => {}}
+        />,
+    );
+    const button = component.locator('button').first();
+    await expect(button).toBeDisabled();
+});


### PR DESCRIPTION
Add a `disabled` property to the `ColorPickerInput` so color picker is not actionable for users with no permission.

**Why?**
For the backend library view sidebar, we need to "disable" all the fields for viewers.

TASK-14613