### PR TITLE
fix: Clicking outside flyout not triggering other elements

### DIFF
--- a/.changeset/upset-glasses-rule.md
+++ b/.changeset/upset-glasses-rule.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+fix(color picker): click Outside Flyout no longer propogated when closing Flyout

--- a/packages/components/src/components/Flyout/Flyout.tsx
+++ b/packages/components/src/components/Flyout/Flyout.tsx
@@ -4,11 +4,11 @@ import { IconCross } from '@frontify/fondue-icons';
 import * as RadixPopover from '@radix-ui/react-popover';
 import { forwardRef, type CSSProperties, type ForwardedRef, type ReactNode } from 'react';
 
-import { addAutoFocusAttribute, addShowFocusRing } from '#/utilities/domUtilities';
-
 import { ThemeProvider, useFondueTheme } from '../ThemeProvider/ThemeProvider';
 
 import styles from './styles/flyout.module.scss';
+
+import { addAutoFocusAttribute, addShowFocusRing } from '#/utilities/domUtilities';
 
 export type FlyoutRootProps = {
     /**
@@ -146,7 +146,7 @@ export const FlyoutContent = (
     return (
         <RadixPopover.Portal>
             <ThemeProvider theme={theme}>
-                <div className={styles.overlay} />
+                <div data-test-id="fondue-flyout-overlay" className={styles.overlay} />
                 <RadixPopover.Content
                     style={
                         {

--- a/packages/components/src/components/Flyout/Flyout.tsx
+++ b/packages/components/src/components/Flyout/Flyout.tsx
@@ -4,11 +4,11 @@ import { IconCross } from '@frontify/fondue-icons';
 import * as RadixPopover from '@radix-ui/react-popover';
 import { forwardRef, type CSSProperties, type ForwardedRef, type ReactNode } from 'react';
 
+import { addAutoFocusAttribute, addShowFocusRing } from '#/utilities/domUtilities';
+
 import { ThemeProvider, useFondueTheme } from '../ThemeProvider/ThemeProvider';
 
 import styles from './styles/flyout.module.scss';
-
-import { addAutoFocusAttribute, addShowFocusRing } from '#/utilities/domUtilities';
 
 export type FlyoutRootProps = {
     /**

--- a/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
+++ b/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
@@ -3,14 +3,15 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import sinon from 'sinon';
 
-import { Flyout } from '../Flyout';
-
 import { Button } from '#/components/Button/Button';
 import { TextInput } from '#/components/TextInput/TextInput';
 import { FOCUS_BORDER_CSS, FOCUS_OUTLINE_CSS } from '#/helpers/constants';
 
+import { Flyout } from '../Flyout';
+
 const FLYOUT_TRIGGER_TEST_ID = 'fondue-flyout-trigger';
 const FLYOUT_CONTENT_TEST_ID = 'fondue-flyout-content';
+const FLY_OUT_OVERLAY_TEST_ID = 'fondue-flyout-overlay';
 const FLYOUT_TRIGGER_TEXT = 'Flyout Trigger';
 const FLYOUT_BODY_TEST_ID = 'fondue-flyout-body';
 const FLYOUT_BODY_TEXT = 'Flyout Body';
@@ -112,7 +113,7 @@ test('should close on click on overlay', async ({ mount, page }) => {
     );
     const tooltipTrigger = page.getByTestId(FLYOUT_TRIGGER_TEST_ID);
     const flyoutContent = page.getByTestId(FLYOUT_CONTENT_TEST_ID);
-    const overlay = page.getByTestId('fondue-flyout-overlay');
+    const overlay = page.getByTestId(FLY_OUT_OVERLAY_TEST_ID);
     await tooltipTrigger.click();
     await expect(flyoutContent).toBeVisible();
     await overlay.click();

--- a/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
+++ b/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
@@ -3,11 +3,11 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import sinon from 'sinon';
 
+import { Flyout } from '../Flyout';
+
 import { Button } from '#/components/Button/Button';
 import { TextInput } from '#/components/TextInput/TextInput';
 import { FOCUS_BORDER_CSS, FOCUS_OUTLINE_CSS } from '#/helpers/constants';
-
-import { Flyout } from '../Flyout';
 
 const FLYOUT_TRIGGER_TEST_ID = 'fondue-flyout-trigger';
 const FLYOUT_CONTENT_TEST_ID = 'fondue-flyout-content';
@@ -93,13 +93,9 @@ test('should close on click outside', async ({ mount, page }) => {
     await expect(flyoutContent).not.toBeVisible();
 });
 
-test('should close on click outside and not trigger anything else', async ({ mount, page }) => {
-    const clickfn = sinon.spy();
+test('should close on click on overlay', async ({ mount, page }) => {
     await mount(
         <div>
-            <button data-test-id="outside" onClick={clickfn}>
-                outside
-            </button>
             <Flyout.Root>
                 <Flyout.Trigger>
                     <Button>{FLYOUT_TRIGGER_TEXT}</Button>
@@ -116,12 +112,11 @@ test('should close on click outside and not trigger anything else', async ({ mou
     );
     const tooltipTrigger = page.getByTestId(FLYOUT_TRIGGER_TEST_ID);
     const flyoutContent = page.getByTestId(FLYOUT_CONTENT_TEST_ID);
-    const outsideButton = page.getByTestId('outside');
+    const overlay = page.getByTestId('fondue-flyout-overlay');
     await tooltipTrigger.click();
     await expect(flyoutContent).toBeVisible();
-    await outsideButton.click();
+    await overlay.click();
     await expect(flyoutContent).not.toBeVisible();
-    expect(clickfn.called).toBe(false);
 });
 
 test('should close on cross button click', async ({ mount, page }) => {

--- a/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
+++ b/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
@@ -3,11 +3,11 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import sinon from 'sinon';
 
-import { Flyout } from '../Flyout';
-
 import { Button } from '#/components/Button/Button';
 import { TextInput } from '#/components/TextInput/TextInput';
 import { FOCUS_BORDER_CSS, FOCUS_OUTLINE_CSS } from '#/helpers/constants';
+
+import { Flyout } from '../Flyout';
 
 const FLYOUT_TRIGGER_TEST_ID = 'fondue-flyout-trigger';
 const FLYOUT_CONTENT_TEST_ID = 'fondue-flyout-content';
@@ -93,10 +93,13 @@ test('should close on click outside', async ({ mount, page }) => {
     await expect(flyoutContent).not.toBeVisible();
 });
 
-test('click outside should not register when closing', async ({ mount, page }) => {
+test('should close on click outside and not trigger anything else', async ({ mount, page }) => {
     const clickfn = sinon.spy();
     await mount(
         <div>
+            <button data-test-id="outside" onClick={clickfn}>
+                outside
+            </button>
             <Flyout.Root>
                 <Flyout.Trigger>
                     <Button>{FLYOUT_TRIGGER_TEXT}</Button>
@@ -109,9 +112,6 @@ test('click outside should not register when closing', async ({ mount, page }) =
                     </Flyout.Footer>
                 </Flyout.Content>
             </Flyout.Root>
-            <button data-test-id="outside" onClick={clickfn}>
-                outside
-            </button>
         </div>,
     );
     const tooltipTrigger = page.getByTestId(FLYOUT_TRIGGER_TEST_ID);

--- a/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
+++ b/packages/components/src/components/Flyout/__tests__/Flyout.ct.tsx
@@ -3,11 +3,11 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import sinon from 'sinon';
 
+import { Flyout } from '../Flyout';
+
 import { Button } from '#/components/Button/Button';
 import { TextInput } from '#/components/TextInput/TextInput';
 import { FOCUS_BORDER_CSS, FOCUS_OUTLINE_CSS } from '#/helpers/constants';
-
-import { Flyout } from '../Flyout';
 
 const FLYOUT_TRIGGER_TEST_ID = 'fondue-flyout-trigger';
 const FLYOUT_CONTENT_TEST_ID = 'fondue-flyout-content';
@@ -91,6 +91,37 @@ test('should close on click outside', async ({ mount, page }) => {
     await expect(flyoutContent).toBeVisible();
     await page.click('body');
     await expect(flyoutContent).not.toBeVisible();
+});
+
+test('click outside should not register when closing', async ({ mount, page }) => {
+    const clickfn = sinon.spy();
+    await mount(
+        <div>
+            <Flyout.Root>
+                <Flyout.Trigger>
+                    <Button>{FLYOUT_TRIGGER_TEXT}</Button>
+                </Flyout.Trigger>
+                <Flyout.Content>
+                    <Flyout.Header showCloseButton>{FLYOUT_HEADER_TEXT}</Flyout.Header>
+                    <Flyout.Body>{FLYOUT_BODY_TEXT}</Flyout.Body>
+                    <Flyout.Footer>
+                        <Button>{FLYOUT_FOOTER_TEXT}</Button>
+                    </Flyout.Footer>
+                </Flyout.Content>
+            </Flyout.Root>
+            <button data-test-id="outside" onClick={clickfn}>
+                outside
+            </button>
+        </div>,
+    );
+    const tooltipTrigger = page.getByTestId(FLYOUT_TRIGGER_TEST_ID);
+    const flyoutContent = page.getByTestId(FLYOUT_CONTENT_TEST_ID);
+    const outsideButton = page.getByTestId('outside');
+    await tooltipTrigger.click();
+    await expect(flyoutContent).toBeVisible();
+    await outsideButton.click();
+    await expect(flyoutContent).not.toBeVisible();
+    expect(clickfn.called).toBe(false);
 });
 
 test('should close on cross button click', async ({ mount, page }) => {

--- a/packages/components/src/components/Flyout/styles/flyout.module.scss
+++ b/packages/components/src/components/Flyout/styles/flyout.module.scss
@@ -66,7 +66,6 @@
     height: 100dvh;
     background-color: var(--box-positive-strong-inverse-color);
     opacity: 0.3;
-    pointer-events: none;
 
     & {
         @include mediaQuery.sm {

--- a/packages/components/src/components/Flyout/styles/flyout.module.scss
+++ b/packages/components/src/components/Flyout/styles/flyout.module.scss
@@ -69,7 +69,7 @@
 
     & {
         @include mediaQuery.sm {
-            display: none;
+            opacity: 0;
         }
     }
 }


### PR DESCRIPTION
CU-86994t2ye

bug reported in LibraryList

Clicking outside the Flyout should not trigger things outside, instead it should only close the Flyout. 

(having this issue right now in Library list.)