### PR TITLE
fix: prevent button and link clicks inside <Table.Row> from triggering row click

### DIFF
--- a/.changeset/modern-rivers-strive.md
+++ b/.changeset/modern-rivers-strive.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+fix: prevent button and link clicks inside <Table.Row> from triggering row click

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -467,6 +467,7 @@ export const Interactive: Story = {
                     <Table.HeaderCell>Name</Table.HeaderCell>
                     <Table.HeaderCell>Invited by</Table.HeaderCell>
                     <Table.HeaderCell>Last seen</Table.HeaderCell>
+                    <Table.HeaderCell>Action</Table.HeaderCell>
                 </Table.Row>
             </Table.Header>
             <Table.Body>
@@ -482,6 +483,11 @@ export const Interactive: Story = {
                         </Table.RowCell>
                         <Table.RowCell>{user.invited}</Table.RowCell>
                         <Table.RowCell>{user.lastSeen}</Table.RowCell>
+                        <Table.RowCell>
+                            <Button onPress={() => alert('Button pressed — this does NOT trigger row click')}>
+                                Press me
+                            </Button>
+                        </Table.RowCell>
                     </Table.Row>
                 ))}
             </Table.Body>

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -485,7 +485,7 @@ export const Interactive: Story = {
                         <Table.RowCell>{user.lastSeen}</Table.RowCell>
                         <Table.RowCell>
                             <Button onPress={() => alert('Button pressed — this does NOT trigger row click')}>
-                                Press me
+                                <span>Press me</span>
                             </Button>
                         </Table.RowCell>
                     </Table.Row>

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -12,15 +12,15 @@ import {
     type ReactNode,
 } from 'react';
 
+import { useSyncRefs } from '#/hooks/useSyncRefs';
+import { useTextTruncation } from '#/hooks/useTextTruncation';
+import { type CommonAriaAttrs } from '#/utilities/types';
+
 import { Box } from '../Box/Box';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import styles from './styles/table.module.scss';
 import { handleKeyDown } from './utils';
-
-import { useSyncRefs } from '#/hooks/useSyncRefs';
-import { useTextTruncation } from '#/hooks/useTextTruncation';
-import { type CommonAriaAttrs } from '#/utilities/types';
 
 type TableRootProps = {
     /**
@@ -328,7 +328,7 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
             }
 
             const closestTd = event?.target instanceof Element && event.target.closest('td');
-            if (closestTd && closestTd.querySelector('button, a, [role="button"], [role="link"]')) {
+            if (closestTd?.querySelector('button, a, [role="button"], [role="link"]')) {
                 return;
             }
 

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -327,8 +327,8 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
                 return;
             }
 
-            const closestTd = event?.target instanceof Element && event.target.closest('td');
-            if (closestTd?.querySelector('button, a, [role="button"], [role="link"]')) {
+            const clickedCell = event?.target instanceof Element ? event.target.closest('td') : null;
+            if (clickedCell?.querySelector('button, a, [role="button"], [role="link"]')) {
                 return;
             }
 

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -7,19 +7,20 @@ import {
     useRef,
     type CSSProperties,
     type KeyboardEvent,
+    type MouseEvent,
     type ReactElement,
     type ReactNode,
 } from 'react';
-
-import { useSyncRefs } from '#/hooks/useSyncRefs';
-import { useTextTruncation } from '#/hooks/useTextTruncation';
-import { type CommonAriaAttrs } from '#/utilities/types';
 
 import { Box } from '../Box/Box';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import styles from './styles/table.module.scss';
 import { handleKeyDown } from './utils';
+
+import { useSyncRefs } from '#/hooks/useSyncRefs';
+import { useTextTruncation } from '#/hooks/useTextTruncation';
+import { type CommonAriaAttrs } from '#/utilities/types';
 
 type TableRootProps = {
     /**
@@ -321,8 +322,13 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
     ) => {
         const isInteractive = onClick !== undefined && !disabled;
 
-        const handleClick = () => {
+        const handleClick = (event?: MouseEvent<HTMLTableRowElement>) => {
             if (disabled) {
+                return;
+            }
+
+            const closestTd = event?.target instanceof Element && event.target.closest('td');
+            if (closestTd && closestTd.querySelector('button, a, [role="button"], [role="link"]')) {
                 return;
             }
 

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -12,15 +12,15 @@ import {
     type ReactNode,
 } from 'react';
 
+import { useSyncRefs } from '#/hooks/useSyncRefs';
+import { useTextTruncation } from '#/hooks/useTextTruncation';
+import { type CommonAriaAttrs } from '#/utilities/types';
+
 import { Box } from '../Box/Box';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import styles from './styles/table.module.scss';
 import { handleKeyDown, isEventFromInteractiveElement } from './utils';
-
-import { useSyncRefs } from '#/hooks/useSyncRefs';
-import { useTextTruncation } from '#/hooks/useTextTruncation';
-import { type CommonAriaAttrs } from '#/utilities/types';
 
 type TableRootProps = {
     /**

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -12,15 +12,15 @@ import {
     type ReactNode,
 } from 'react';
 
-import { useSyncRefs } from '#/hooks/useSyncRefs';
-import { useTextTruncation } from '#/hooks/useTextTruncation';
-import { type CommonAriaAttrs } from '#/utilities/types';
-
 import { Box } from '../Box/Box';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import styles from './styles/table.module.scss';
-import { handleKeyDown } from './utils';
+import { handleKeyDown, isEventFromInteractiveElement } from './utils';
+
+import { useSyncRefs } from '#/hooks/useSyncRefs';
+import { useTextTruncation } from '#/hooks/useTextTruncation';
+import { type CommonAriaAttrs } from '#/utilities/types';
 
 type TableRootProps = {
     /**
@@ -322,17 +322,12 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
     ) => {
         const isInteractive = onClick !== undefined && !disabled;
 
-        const handleClick = (event?: MouseEvent<HTMLTableRowElement>) => {
+        const handleClick = (event?: MouseEvent) => {
             if (disabled) {
                 return;
             }
 
-            const clickedCell = event?.target instanceof Element ? event.target.closest('td') : null;
-            if (clickedCell?.querySelector('button, a, [role="button"], [role="link"]')) {
-                return;
-            }
-
-            if (onClick) {
+            if (onClick && !isEventFromInteractiveElement(event)) {
                 onClick(selected);
             }
         };

--- a/packages/components/src/components/Table/__tests__/Table.ct.tsx
+++ b/packages/components/src/components/Table/__tests__/Table.ct.tsx
@@ -185,14 +185,29 @@ test('should handle all HeaderCell configurations', async ({ mount }) => {
 
 test('should handle all row states and interactions', async ({ mount }) => {
     const onClick = sinon.spy();
+    const onButtonClick = sinon.spy();
     const component = await mount(
         <Table.Root aria-label="Table">
             <Table.Body>
                 <Table.Row onClick={onClick} disabled={true} aria-label="Test Row">
                     <Table.RowCell>Test</Table.RowCell>
+                    <Table.RowCell>Test</Table.RowCell>
                 </Table.Row>
                 <Table.Row onClick={onClick} selected={true}>
                     <Table.RowCell>Test</Table.RowCell>
+                    <Table.RowCell>Test</Table.RowCell>
+                </Table.Row>
+                <Table.Row onClick={onClick}>
+                    <Table.RowCell>Test</Table.RowCell>
+                    <Table.RowCell>
+                        <button onClick={onButtonClick}>Test</button>
+                    </Table.RowCell>
+                </Table.Row>
+                <Table.Row onClick={onClick} disabled={true}>
+                    <Table.RowCell>Test</Table.RowCell>
+                    <Table.RowCell>
+                        <button onClick={onButtonClick}>Test</button>
+                    </Table.RowCell>
                 </Table.Row>
             </Table.Body>
         </Table.Root>,
@@ -207,6 +222,22 @@ test('should handle all row states and interactions', async ({ mount }) => {
     await expect(secondRow).toHaveAttribute('role', 'button');
     await secondRow.click();
     sinon.assert.calledOnce(onClick);
+
+    const thirdRow = component.locator('tr').nth(2);
+    const firstCellOfThirdRow = thirdRow.locator('td').nth(0);
+    const button = thirdRow.locator('button');
+
+    // Clicking the first cell of the third row should trigger the row's onClick again,
+    // but should NOT trigger the button's onClick
+    await firstCellOfThirdRow.click();
+    sinon.assert.calledTwice(onClick);
+    sinon.assert.notCalled(onButtonClick);
+
+    // Clicking the button inside the third row should trigger the button's onClick,
+    // but should NOT trigger the row's onClick again
+    await button.click();
+    sinon.assert.calledOnce(onButtonClick);
+    sinon.assert.calledTwice(onClick);
 });
 
 test('should handle all cell configurations', async ({ mount }) => {

--- a/packages/components/src/components/Table/utils.ts
+++ b/packages/components/src/components/Table/utils.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type KeyboardEvent } from 'react';
+import { type KeyboardEvent, type MouseEvent } from 'react';
 
 function getAdjacentRow(currentRow: HTMLElement, key: 'ArrowUp' | 'ArrowDown'): HTMLElement | null {
     const selector = 'tr[tabindex="0"]';
@@ -29,4 +29,26 @@ export function handleKeyDown(event: KeyboardEvent<HTMLTableElement>) {
         event.preventDefault();
         nextRow.focus();
     }
+}
+
+const INTERACTIVE_ELEMENTS_LIST = [HTMLButtonElement, HTMLAnchorElement];
+const INTERACTIVE_ROLES_LIST = ['button', 'link'];
+
+export function isEventFromInteractiveElement(event?: MouseEvent): boolean {
+    let node = event?.target instanceof Element ? event.target : null;
+
+    while (node && !(node instanceof HTMLTableRowElement)) {
+        if (INTERACTIVE_ELEMENTS_LIST.some((interactiveElement) => node instanceof interactiveElement)) {
+            return true;
+        }
+
+        const role = node.getAttribute('role');
+        if (role && INTERACTIVE_ROLES_LIST.includes(role)) {
+            return true;
+        }
+
+        node = node.parentElement;
+    }
+
+    return false;
 }


### PR DESCRIPTION
**What:**
This PR fixes how clicks work in the `<Table.Row>` component.
If the `click` prop is defined for <Table.Row>:
- clicking a button or link inside a cell will only trigger that button or link’s click
- clicking on a cell without a button or link will trigger the row’s click.

**Why:**
Previously, clicks on interactive elements like buttons or links inside a table row would also fire the row’s click handler.