### PR TITLE
fix: chart labels overlap [CU-TASK-13738]

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -62,8 +62,7 @@
         "@visx/text": "^3.12.0",
         "@visx/tooltip": "^3.12.0",
         "@visx/xychart": "^3.12.0",
-        "lodash-es": "^4.17.21",
-        "use-font-face-observer": "^1.3.0"
+        "lodash-es": "^4.17.21"
     },
     "devDependencies": {
         "@babel/core": "^7.26.10",

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -89,6 +89,39 @@ export default {
     },
 } as Meta<BarChartProps>;
 
+const brandData = {
+    name: 'Top Global Brands',
+    dataPoints: [
+        { label: 'Apple', value: 200 },
+        { label: 'Microsoft', value: 180 },
+        { label: 'Amazon', value: 170 },
+        { label: 'Google', value: 165 },
+        { label: 'Samsung', value: 150 },
+        { label: 'Toyota', value: 130 },
+        { label: 'Coca-Cola', value: 125 },
+        { label: 'Nike', value: 120 },
+        { label: 'Mercedes-Benz', value: 115 },
+        { label: 'Disney', value: 110 },
+        { label: 'BMW', value: 105 },
+        { label: 'Intel', value: 100 },
+        { label: 'Facebook', value: 95 },
+        { label: 'Tesla', value: 90 },
+        { label: 'Visa', value: 85 },
+        { label: 'Mastercard', value: 80 },
+        { label: 'Pepsi', value: 75 },
+        { label: 'Netflix', value: 70 },
+        { label: 'Adobe', value: 65 },
+        { label: 'Honda', value: 60 },
+        { label: 'McDonald’s', value: 58 },
+        { label: 'Starbucks', value: 55 },
+        { label: 'YouTube', value: 53 },
+        { label: 'Sony', value: 50 },
+        { label: 'eBay', value: 45 },
+        { label: 'LG', value: 43 },
+        { label: 'Nvidia', value: 40 },
+    ],
+};
+
 const planetsRadiusData = (() => {
     const formattedData = planets.map((item) => {
         return {
@@ -210,6 +243,13 @@ const Template: StoryFn<BarChartProps> = (args) => <BarChart {...args} />;
 export const SingleDataSet = Template.bind({});
 SingleDataSet.args = {
     series: planetsRadiusData,
+    width: 1000,
+    height: 500,
+};
+
+export const SingleDataSetWithRotatedLabels = Template.bind({});
+SingleDataSetWithRotatedLabels.args = {
+    series: [brandData],
     width: 1000,
     height: 500,
 };

--- a/packages/charts/src/components/BarChart/components/hooks/useRotatedLabel.spec.tsx
+++ b/packages/charts/src/components/BarChart/components/hooks/useRotatedLabel.spec.tsx
@@ -1,14 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { useRotatedLabel } from '@components/BarChart/components/hooks/useRotatedLabel';
 import { renderHook } from '@testing-library/react';
 import { type AxisScale } from '@visx/axis';
 import { DataContext, type DataContextType } from '@visx/xychart';
 import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
-import { type Mock, type MockedFunction, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { useRotatedLabel } from '@components/BarChart/components/hooks/useRotatedLabel';
-
-import type useFontFaceObserver from 'use-font-face-observer';
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type DataProviderProps = {
     children: ReactNode;
@@ -30,10 +27,6 @@ const mockData = (bandWidth: number, paddingInner: number) => {
     } as unknown as DataContextType<AxisScale, AxisScale, Record<string, unknown>>;
 };
 
-vi.mock('use-font-face-observer', () => ({
-    default: vi.fn(),
-}));
-
 vi.mock('@components/common/helpers', () => ({
     getSVGTextDimensions: vi.fn(),
 }));
@@ -42,14 +35,9 @@ const updateMaxLabelHeightMock: Mock<(prevState: number) => number> = vi.fn();
 const updateFirstLabelOverflowsByMock: Mock<(prevState: number) => number> = vi.fn();
 
 describe('useRotatedLabel', () => {
-    let useFontFaceObserverMock: MockedFunction<typeof useFontFaceObserver>;
-
     beforeEach(async () => {
-        const { default: useFontFaceObserver } = await import('use-font-face-observer');
         const { getSVGTextDimensions } = await import('@components/common/helpers');
-        vi.mocked(useFontFaceObserver).mockReturnValue(true);
         vi.mocked(getSVGTextDimensions).mockReturnValue({ width: 100, height: 100 });
-        useFontFaceObserverMock = vi.mocked(useFontFaceObserver);
     });
 
     afterEach(() => {
@@ -121,39 +109,6 @@ describe('useRotatedLabel', () => {
                 ),
             { wrapper },
         );
-
-        expect(result.current).toEqual(315);
-        expect(updateMaxLabelHeightMock).toHaveBeenCalledTimes(1);
-        expect(updateFirstLabelOverflowsByMock).toHaveBeenCalledTimes(1);
-        expect(updateMaxLabelHeightMock).toHaveBeenCalledWith(100);
-        expect(updateFirstLabelOverflowsByMock).toHaveBeenCalledWith(85);
-    });
-
-    it('returns 0 until font is loaded, then 315', () => {
-        useFontFaceObserverMock.mockReturnValue(false);
-
-        const dataContext = mockData(20, 0.5);
-        const wrapper = ({ children }: { children: ReactNode }) => (
-            <DataProvider dataContext={dataContext}>{children}</DataProvider>
-        );
-
-        const { result, rerender } = renderHook(
-            () =>
-                useRotatedLabel(
-                    false,
-                    updateMaxLabelHeightMock as Dispatch<SetStateAction<number>>,
-                    updateFirstLabelOverflowsByMock as Dispatch<SetStateAction<number>>,
-                    (label) => label,
-                ),
-            { wrapper },
-        );
-
-        expect(result.current).toEqual(0);
-        expect(updateMaxLabelHeightMock).not.toHaveBeenCalled();
-        expect(updateFirstLabelOverflowsByMock).not.toHaveBeenCalled();
-
-        useFontFaceObserverMock.mockReturnValue(true);
-        rerender();
 
         expect(result.current).toEqual(315);
         expect(updateMaxLabelHeightMock).toHaveBeenCalledTimes(1);

--- a/packages/charts/src/components/BarChart/components/hooks/useRotatedLabel.ts
+++ b/packages/charts/src/components/BarChart/components/hooks/useRotatedLabel.ts
@@ -1,14 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { DataContext } from '@visx/xychart';
-import { useContext, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
-import useFontFaceObserver from 'use-font-face-observer';
-
 import { getBandScaleColumnWidth } from '@components/BarChart/components/helpers';
 import { getSVGTextDimensions } from '@components/common/helpers';
 import { type LabelFormatter } from '@components/common/types';
-import { BODY_FONT_FAMILY, TICK_LABEL_WEIGHT } from '@theme/consts';
 import { TICK_LABEL_STYLE } from '@theme/createTheme';
+import { DataContext } from '@visx/xychart';
+import { useContext, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 
 const getRotationAngleAndMaxHeight = (ticks: string[], columnWidth: number) => {
     const style = TICK_LABEL_STYLE;
@@ -44,19 +41,13 @@ export const useRotatedLabel = (
     const [angle, setAngle] = useState(0);
     const dataContext = useContext(DataContext);
     const { xScale } = dataContext;
-    const isFontLoaded = useFontFaceObserver([
-        {
-            family: getComputedStyle(document.documentElement).getPropertyValue(BODY_FONT_FAMILY).trim(),
-            weight: TICK_LABEL_WEIGHT,
-        },
-    ]);
     const scale = horizontal ? undefined : xScale;
     const formattedTicks = scale ? scale.domain().map((tick) => labelFormatter(tick)) : null;
     const ticksJSON = scale ? JSON.stringify(formattedTicks) : null;
     const columnWidth = Math.round(getBandScaleColumnWidth(scale));
 
     useEffect(() => {
-        if (isFontLoaded && columnWidth > 0 && ticksJSON) {
+        if (columnWidth > 0 && ticksJSON) {
             const ticks: string[] = JSON.parse(ticksJSON);
 
             const { rotationAngle, maxHeight, firstItemWidth } = getRotationAngleAndMaxHeight(ticks, columnWidth);
@@ -67,7 +58,7 @@ export const useRotatedLabel = (
         } else {
             setAngle(0);
         }
-    }, [isFontLoaded, columnWidth, ticksJSON, updateMaxLabelHeight, updateFirstLabelOverflowsBy]);
+    }, [columnWidth, ticksJSON, updateMaxLabelHeight, updateFirstLabelOverflowsBy]);
 
     return angle;
 };

--- a/packages/charts/src/components/PieChart/components/consts.ts
+++ b/packages/charts/src/components/PieChart/components/consts.ts
@@ -22,4 +22,4 @@ export const LABEL_PERCENTAGE_STYLE = {
     ...LABEL_VALUE_STYLE,
     fill: 'var(--fc-font-color-x-weak)',
 };
-export const LABEL_PADDING_X = 5;
+export const LABEL_PADDING_X = 10;

--- a/packages/charts/src/components/PieChart/hooks/useTextWidths.spec.ts
+++ b/packages/charts/src/components/PieChart/hooks/useTextWidths.spec.ts
@@ -1,29 +1,20 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { useTextWidths } from '@components/PieChart/hooks/useTextWidths';
+import { type getSVGTextDimensions } from '@components/common/helpers';
 import { renderHook } from '@testing-library/react';
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { useTextWidths } from '@components/PieChart/hooks/useTextWidths';
-import { getSVGTextDimensions } from '@components/common/helpers';
-
-vi.mock('use-font-face-observer', () => ({
-    default: vi.fn(),
-}));
 
 vi.mock('@components/common/helpers', () => ({
     getSVGTextDimensions: vi.fn(),
 }));
 
 describe('useTextWidths', () => {
-    let useFontFaceObserverMock: Mock<() => boolean>;
     let getSVGTextDimensionsMock: Mock<typeof getSVGTextDimensions>;
 
     beforeEach(async () => {
-        const { default: useFontFaceObserver } = await import('use-font-face-observer');
         const { getSVGTextDimensions } = await import('@components/common/helpers');
-        vi.mocked(useFontFaceObserver).mockReturnValue(true);
         vi.mocked(getSVGTextDimensions).mockImplementation((value: string) => ({ width: value.length, height: 0 }));
-        useFontFaceObserverMock = vi.mocked(useFontFaceObserver);
         getSVGTextDimensionsMock = vi.mocked(getSVGTextDimensions);
     });
 
@@ -39,30 +30,6 @@ describe('useTextWidths', () => {
             valueWidth: 9,
             percentageWidth: 10,
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalled();
         expect(getSVGTextDimensionsMock).toHaveBeenCalledTimes(3);
-    });
-
-    it('should return the correct widths when font is not loaded and update once it is loaded', () => {
-        useFontFaceObserverMock.mockReturnValue(false);
-        const { result, rerender } = renderHook(() => useTextWidths('label', 'someValue', 'percentage'));
-
-        expect(result.current).toEqual({
-            labelWidth: 0,
-            valueWidth: 0,
-            percentageWidth: 0,
-        });
-        expect(useFontFaceObserverMock).toHaveBeenCalled();
-        expect(getSVGTextDimensionsMock).toHaveBeenCalledTimes(0);
-
-        useFontFaceObserverMock.mockReturnValue(true);
-        rerender();
-
-        expect(result.current).toEqual({
-            labelWidth: 5,
-            valueWidth: 9,
-            percentageWidth: 10,
-        });
-        expect(getSVGTextDimensions).toHaveBeenCalledTimes(3);
     });
 });

--- a/packages/charts/src/components/PieChart/hooks/useTextWidths.ts
+++ b/packages/charts/src/components/PieChart/hooks/useTextWidths.ts
@@ -1,11 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useEffect, useState } from 'react';
-import useFontFaceObserver from 'use-font-face-observer';
-
 import { LABEL_PERCENTAGE_STYLE, LABEL_TITLE_STYLE, LABEL_VALUE_STYLE } from '@components/PieChart/components/consts';
 import { getSVGTextDimensions } from '@components/common/helpers';
-import { BODY_FONT_FAMILY, TICK_LABEL_WEIGHT } from '@theme/consts';
+import { useEffect, useState } from 'react';
 
 type Widths = {
     labelWidth: number;
@@ -15,21 +12,13 @@ type Widths = {
 
 export const useTextWidths = (label: string, value: string, percentage: string) => {
     const [widths, setWidths] = useState<Widths>({ labelWidth: 0, valueWidth: 0, percentageWidth: 0 });
-    const isFontLoaded = useFontFaceObserver([
-        {
-            family: getComputedStyle(document.documentElement).getPropertyValue(BODY_FONT_FAMILY).trim(),
-            weight: TICK_LABEL_WEIGHT,
-        },
-    ]);
 
     useEffect(() => {
-        if (isFontLoaded) {
-            const labelWidth = getSVGTextDimensions(label, LABEL_TITLE_STYLE).width ?? 0;
-            const valueWidth = getSVGTextDimensions(value, LABEL_VALUE_STYLE).width ?? 0;
-            const percentageWidth = getSVGTextDimensions(percentage, LABEL_PERCENTAGE_STYLE).width ?? 0;
-            setWidths({ labelWidth, valueWidth, percentageWidth });
-        }
-    }, [label, value, percentage, isFontLoaded]);
+        const labelWidth = getSVGTextDimensions(label, LABEL_TITLE_STYLE).width ?? 0;
+        const valueWidth = getSVGTextDimensions(value, LABEL_VALUE_STYLE).width ?? 0;
+        const percentageWidth = getSVGTextDimensions(percentage, LABEL_PERCENTAGE_STYLE).width ?? 0;
+        setWidths({ labelWidth, valueWidth, percentageWidth });
+    }, [label, value, percentage]);
 
     return widths;
 };

--- a/packages/charts/src/components/common/hooks/useMargin.spec.tsx
+++ b/packages/charts/src/components/common/hooks/useMargin.spec.tsx
@@ -1,11 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { renderHook } from '@testing-library/react';
-import { type TextProps } from '@visx/text';
-import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { truncateTextLabel } from '@components/BarChart/helpers';
 import { useMargin } from '@components/common/hooks/useMargin';
+import { renderHook } from '@testing-library/react';
+import { type TextProps } from '@visx/text';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const TICK_LENGTH = 4;
 const VALUE_FORMATTER = (value: number | string) => `${value}°C`;
@@ -31,12 +30,6 @@ const BASE_MARGIN = {
     left: 0,
 };
 
-const DEFAULT_MARGIN = { bottom: 24, left: 52.265625, right: 20, top: 10 };
-
-vi.mock('use-font-face-observer', () => ({
-    default: vi.fn(),
-}));
-
 vi.mock('@components/LineChart/helpers', () => ({
     getSVGTextDimensions: vi.fn((text: string) => ({
         width: text.length,
@@ -44,13 +37,6 @@ vi.mock('@components/LineChart/helpers', () => ({
 }));
 
 describe('useMargin', () => {
-    let useFontFaceObserverMock: Mock<() => boolean>;
-    beforeEach(async () => {
-        const { default: useFontFaceObserver } = await import('use-font-face-observer');
-        vi.mocked(useFontFaceObserver).mockReturnValue(true);
-        useFontFaceObserverMock = vi.mocked(useFontFaceObserver);
-    });
-
     afterEach(() => {
         vi.restoreAllMocks();
     });
@@ -72,7 +58,6 @@ describe('useMargin', () => {
                 TICK_LENGTH +
                 Math.abs(TICK_LABEL_STYLE.dx as number),
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
     });
 
     it('returns correct margin for unformatted numeric ticks', () => {
@@ -87,7 +72,6 @@ describe('useMargin', () => {
                 TICK_LENGTH +
                 Math.abs(TICK_LABEL_STYLE.dx as number),
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
     });
 
     it('returns correct margin for string ticks', () => {
@@ -100,7 +84,6 @@ describe('useMargin', () => {
                 // @ts-expect-error Wrong typing in the original code
                 BASE_MARGIN.left + STRING_TICKS_LONGEST.length + TICK_LENGTH + Math.abs(TICK_LABEL_STYLE.dx as number),
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
     });
 
     it('returns correct margin for with maxLabelHeight and firstLabelOverflowsBy', () => {
@@ -118,7 +101,6 @@ describe('useMargin', () => {
             bottom: 63,
             left: 30,
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
     });
 
     it('returns correct margin for with maxLabelHeight and firstLabelOverflowsBy < tickLabelOffset', () => {
@@ -136,34 +118,6 @@ describe('useMargin', () => {
             bottom: 63,
             left: 15,
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
-    });
-
-    it('returns default margin when font is not loaded', () => {
-        useFontFaceObserverMock.mockReturnValue(false);
-        const { result, rerender } = renderHook(() =>
-            useMargin({
-                ticks: NUMERIC_TICKS,
-                tickLabelStyle: TICK_LABEL_STYLE,
-                valueFormatter: VALUE_FORMATTER,
-                tickLength: TICK_LENGTH,
-            }),
-        );
-        expect(result.current).toEqual(DEFAULT_MARGIN);
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(1);
-
-        useFontFaceObserverMock.mockReturnValue(true);
-        rerender();
-
-        expect(result.current).toEqual({
-            ...BASE_MARGIN,
-            left:
-                BASE_MARGIN.left +
-                NUMERIC_TICKS_LONGEST_FORMATTED.length +
-                TICK_LENGTH +
-                Math.abs(TICK_LABEL_STYLE.dx as number),
-        });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(3);
     });
 
     it('updated value formatter updates results', () => {
@@ -184,7 +138,6 @@ describe('useMargin', () => {
                 TICK_LENGTH +
                 Math.abs(TICK_LABEL_STYLE.dx as number),
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
 
         valueFormatter = (value: number | string) => `${value}°F`;
         rerender();
@@ -198,7 +151,6 @@ describe('useMargin', () => {
                 TICK_LENGTH +
                 Math.abs(TICK_LABEL_STYLE.dx as number),
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(4);
     });
 
     it('long tick labels are truncated and truncation reflected in calculated margin', () => {
@@ -220,6 +172,5 @@ describe('useMargin', () => {
                 TICK_LENGTH +
                 Math.abs(TICK_LABEL_STYLE.dx as number),
         });
-        expect(useFontFaceObserverMock).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/charts/src/components/common/hooks/useMargin.ts
+++ b/packages/charts/src/components/common/hooks/useMargin.ts
@@ -1,14 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type TextProps } from '@visx/text';
-import { type Margin } from '@visx/xychart';
-import { useEffect, useState } from 'react';
-import useFontFaceObserver from 'use-font-face-observer';
-
 import { truncateTextLabel } from '@components/BarChart/helpers';
 import { getSVGTextDimensions } from '@components/LineChart/helpers';
 import { type ValueFormatter } from '@components/common/types';
-import { BODY_FONT_FAMILY, TICK_LABEL_WEIGHT } from '@theme/consts';
+import { type TextProps } from '@visx/text';
+import { type Margin } from '@visx/xychart';
+import { useEffect, useState } from 'react';
 
 type TickType<T> = T extends undefined ? string | number : number;
 type UseMarginProps = {
@@ -41,12 +38,6 @@ const getTickLabelOffset = ({ tickLabelStyle, tickLength }: Pick<UseMarginProps,
 export const useMargin = (props: UseMarginProps) => {
     const { tickLabelStyle, ticks, valueFormatter, tickLength, maxLabelHeight = 6, firstLabelOverflowsBy = 0 } = props;
     const [margin, setMargin] = useState<Margin>(DEFAULT_MARGIN);
-    const isFontLoaded = useFontFaceObserver([
-        {
-            family: getComputedStyle(document.documentElement).getPropertyValue(BODY_FONT_FAMILY).trim(),
-            weight: TICK_LABEL_WEIGHT,
-        },
-    ]);
 
     const tickLabelOffset = getTickLabelOffset({ tickLabelStyle, tickLength });
     const ticksJSON = JSON.stringify(ticks);
@@ -55,25 +46,24 @@ export const useMargin = (props: UseMarginProps) => {
     useEffect(() => {
         const ticks = JSON.parse(ticksJSON);
         const style = JSON.parse(styleJSON);
-        if (isFontLoaded) {
-            const longestFormattedValue = findLongestFormattedTickValue({
-                ticks,
-                tickLabelStyle: style as TextProps,
-                tickLength: ticks.length,
-                valueFormatter,
-            });
-            let marginLeft = longestFormattedValue + tickLabelOffset;
-            if (firstLabelOverflowsBy > marginLeft) {
-                marginLeft = firstLabelOverflowsBy;
-            }
-            setMargin({
-                top: 10,
-                right: 20,
-                bottom: maxLabelHeight + 18,
-                left: marginLeft,
-            });
+
+        const longestFormattedValue = findLongestFormattedTickValue({
+            ticks,
+            tickLabelStyle: style as TextProps,
+            tickLength: ticks.length,
+            valueFormatter,
+        });
+        let marginLeft = longestFormattedValue + tickLabelOffset;
+        if (firstLabelOverflowsBy > marginLeft) {
+            marginLeft = firstLabelOverflowsBy;
         }
-    }, [ticksJSON, isFontLoaded, styleJSON, valueFormatter, maxLabelHeight, firstLabelOverflowsBy, tickLabelOffset]);
+        setMargin({
+            top: 10,
+            right: 20,
+            bottom: maxLabelHeight + 18,
+            left: marginLeft,
+        });
+    }, [ticksJSON, styleJSON, valueFormatter, maxLabelHeight, firstLabelOverflowsBy, tickLabelOffset]);
 
     return margin;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
-      use-font-face-observer:
-        specifier: ^1.3.0
-        version: 1.3.0(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.26.10
@@ -6592,9 +6589,6 @@ packages:
       debug:
         optional: true
 
-  fontfaceobserver@2.1.0:
-    resolution: {integrity: sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==}
-
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -9732,11 +9726,6 @@ packages:
     resolution: {integrity: sha512-JTnOZAr0fq1ix6CQ4XANoWIh03xAiMFlP/lVAYDdAOZwur6nqBSdATn1/Q9PLIGIW+C7xmFZBCcaA4KLDcQJtg==}
     peerDependencies:
       react: '>=16.8.0'
-
-  use-font-face-observer@1.3.0:
-    resolution: {integrity: sha512-gS5UoSPcOoCF+JMbw2By1E3FtXl6ZPxgFo8MW4shpM15lf+MNyzEfjsLJFJ3T/mHLdGTBhQgZYSAXEzubr6v5Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   use-isomorphic-layout-effect@1.1.2:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
@@ -17365,8 +17354,6 @@ snapshots:
 
   follow-redirects@1.15.9: {}
 
-  fontfaceobserver@2.1.0: {}
-
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -21082,11 +21069,6 @@ snapshots:
   use-deep-compare@1.2.1(react@18.3.1):
     dependencies:
       dequal: 2.0.3
-      react: 18.3.1
-
-  use-font-face-observer@1.3.0(react@18.3.1):
-    dependencies:
-      fontfaceobserver: 2.1.0
       react: 18.3.1
 
   use-isomorphic-layout-effect@1.1.2(@types/react@18.3.20)(react@18.3.1):


### PR DESCRIPTION
### Bar chart and pie chart labels were acting up. Found the reason to be the `use-font-face-observer` package that was not working as intended. Per my tests, it seems it wasn't really doing anything so I just removed it.

#### Pie chart storybook

![image](https://github.com/user-attachments/assets/494c8bc6-5f8e-4df6-91e8-b371b389d010)

#### Pie chart web app with linked fondue build

![image](https://github.com/user-attachments/assets/afa515fc-ac16-4bc4-87a5-2b4c1ca835e6)

#### Superheroes 

![image](https://github.com/user-attachments/assets/03ff1af8-3fcc-4990-8d93-3e4d58482f68)

#### Bar chart storybook

![image](https://github.com/user-attachments/assets/43b392ea-5cad-4b7a-9f82-69141e94ca4d)

#### Bar chart web app with linked fondue build

![image](https://github.com/user-attachments/assets/828d81ec-5957-4a1b-9e8d-2476fe016957)

#### Superheroes 

![image](https://github.com/user-attachments/assets/42b45c53-3edd-4ad8-a68f-266c270bafe6)
