### PR TITLE
fix: prevent clicks inside a <Dialog> opened from a <Table.Row> from triggering the row click event.

### DIFF
--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -20,7 +20,7 @@ import { Box } from '../Box/Box';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import styles from './styles/table.module.scss';
-import { handleKeyDown, isEventFromInteractiveElement } from './utils';
+import { handleKeyDown, shouldIgnoreRowClick } from './utils';
 
 type TableRootProps = {
     /**
@@ -327,7 +327,11 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
                 return;
             }
 
-            if (onClick && !isEventFromInteractiveElement(event)) {
+            if (shouldIgnoreRowClick(event)) {
+                return;
+            }
+
+            if (onClick) {
                 onClick(selected);
             }
         };

--- a/packages/components/src/components/Table/__tests__/utils.spec.ts
+++ b/packages/components/src/components/Table/__tests__/utils.spec.ts
@@ -3,7 +3,7 @@
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { describe, it, expect, vi, beforeEach, test } from 'vitest';
 
-import { handleKeyDown, isEventFromInteractiveElement } from '../utils';
+import { handleKeyDown, shouldIgnoreRowClick } from '../utils';
 
 describe('handleKeyDown', () => {
     beforeEach(() => {
@@ -154,7 +154,7 @@ describe('handleKeyDown', () => {
     });
 });
 
-describe('isEventFromInteractiveElement', () => {
+describe('shouldIgnoreRowClick', () => {
     beforeEach(() => {
         document.body.innerHTML = `
             <table>
@@ -190,6 +190,7 @@ describe('isEventFromInteractiveElement', () => {
                     </tr>
                 </tbody>
             </table>
+            <div id="dialog">Modal dialog content</div>
         `;
     });
 
@@ -198,7 +199,7 @@ describe('isEventFromInteractiveElement', () => {
             target.addEventListener(
                 'click',
                 (event) => {
-                    const result = isEventFromInteractiveElement(event as unknown as MouseEvent);
+                    const result = shouldIgnoreRowClick(event as unknown as MouseEvent);
                     resolve(result);
                 },
                 { once: true },
@@ -254,4 +255,19 @@ describe('isEventFromInteractiveElement', () => {
             expect(await clickOnElement(document.getElementById(elementId)!)).toBe(expected);
         },
     );
+
+    test('should return true when clicking outside the row element', () => {
+        const row = document.querySelector('tr')!;
+        const dialog = document.getElementById('dialog')!;
+
+        // simulates a click event inside a dialog that was opened using a dialog trigger button located within the row
+        const fakeEvent = {
+            target: dialog,
+            currentTarget: row,
+        } as unknown as MouseEvent;
+
+        const result = shouldIgnoreRowClick(fakeEvent);
+
+        expect(result).toBe(true);
+    });
 });

--- a/packages/components/src/components/Table/utils.ts
+++ b/packages/components/src/components/Table/utils.ts
@@ -34,20 +34,30 @@ export function handleKeyDown(event: KeyboardEvent<HTMLTableElement>) {
 const INTERACTIVE_ELEMENTS_LIST = [HTMLButtonElement, HTMLAnchorElement];
 const INTERACTIVE_ROLES_LIST = ['button', 'link'];
 
-export function isEventFromInteractiveElement(event?: MouseEvent): boolean {
-    let node = event?.target instanceof Element ? event.target : null;
+export function shouldIgnoreRowClick(event?: MouseEvent): boolean {
+    if (!event) {
+        return false;
+    }
 
-    while (node && !(node instanceof HTMLTableRowElement)) {
-        if (INTERACTIVE_ELEMENTS_LIST.some((interactiveElement) => node instanceof interactiveElement)) {
+    const { target, currentTarget } = event;
+
+    let element = target instanceof Element ? target : null;
+
+    if (!currentTarget.contains(element)) {
+        return true;
+    }
+
+    while (element && !(element instanceof HTMLTableRowElement)) {
+        if (INTERACTIVE_ELEMENTS_LIST.some((interactiveElement) => element instanceof interactiveElement)) {
             return true;
         }
 
-        const role = node.getAttribute('role');
+        const role = element.getAttribute('role');
         if (role && INTERACTIVE_ROLES_LIST.includes(role)) {
             return true;
         }
 
-        node = node.parentElement;
+        element = element.parentElement;
     }
 
     return false;


### PR DESCRIPTION
**What**
This PR completes the previous [one](https://github.com/Frontify/fondue/pull/2334).

It prevents the row click from being triggered when a user clicks inside a <Dialog> opened from a <Dialog.Trigger> within that specific <Table.Row>.

**Why**
When a <Dialog> is opened from a button inside a table row, clicking inside the modal triggers the row’s click handler.
This happens even though the dialog’s DOM elements are rendered outside the table.

**How**
We check whether the clicked element (`target`) is contained within the table row (`currentTarget`).
If not, the click happened outside the row and should not trigger the row’s click handler.

https://github.com/user-attachments/assets/4bf4c55f-b5b8-4747-9c89-d0d07b720a30

Related task : [CU-8699v81gz](https://app.clickup.com/t/8699v81gz)

