### PR TITLE
feat: split up assetInput types from ActionMenu Types

### DIFF
--- a/.changeset/common-spiders-heal.md
+++ b/.changeset/common-spiders-heal.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue": minor
+---
+
+feat: split up `AssetInput` types from ActionMenu  
+

--- a/packages/fondue/src/components/AssetInput/AssetInput.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.tsx
@@ -2,7 +2,7 @@
 
 import { type ChangeEvent, type ReactElement, useRef } from 'react';
 
-import { type ActionMenuProps } from '@components/ActionMenu/ActionMenu/ActionMenu';
+import { type ActionMenuProps } from '@components/ActionMenu/ActionMenu';
 import { Button, ButtonEmphasis, ButtonStyle } from '@components/Button';
 import IconArrowCircleUp from '@foundation/Icon/Generated/IconArrowCircleUp';
 import IconImageStack from '@foundation/Icon/Generated/IconImageStack';
@@ -12,6 +12,7 @@ import { merge } from '@utilities/merge';
 
 import { MultiAssetPreview } from './MultiAssetPreview';
 import { SelectedAsset } from './SingleAsset/SelectedAsset';
+import { type AssetInputMenuBlock } from './types';
 
 type BaseAsset = {
     name: string;
@@ -65,7 +66,7 @@ export type AssetInputProps = {
     assets?: AssetType[];
     size: AssetInputSize;
     numberOfLocations?: number;
-    actions?: ActionMenuProps['menuBlocks'];
+    actions?: ActionMenuProps['menuBlocks'] | AssetInputMenuBlock[];
     isLoading?: boolean;
     hideSize?: boolean;
     hideExtension?: boolean;

--- a/packages/fondue/src/components/AssetInput/index.ts
+++ b/packages/fondue/src/components/AssetInput/index.ts
@@ -1,3 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export * from './AssetInput';
+export * from './types';

--- a/packages/fondue/src/components/AssetInput/types.ts
+++ b/packages/fondue/src/components/AssetInput/types.ts
@@ -11,7 +11,6 @@ export enum AssetInputMenuItemContentSize {
 export type AssetInputMenuItemContentProps = {
     title?: ReactNode;
     decorator?: ReactElement;
-    switchComponent?: ReactElement;
     subtitle?: string;
     size?: AssetInputMenuItemContentSize;
     ariaProps?: HTMLAttributes<HTMLElement>;
@@ -47,9 +46,9 @@ export type AssetInputMenuItemProps = {
     onMouseLeave?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
     children?: ReactNode;
     'data-test-id'?: string;
-} & Omit<AssetInputMenuItemContentProps, 'iconSize'>;
+} & AssetInputMenuItemContentProps;
 
-export type AssetInputMenuItemType = Omit<AssetInputMenuItemProps, 'switchComponent'> & {
+export type AssetInputMenuItemType = AssetInputMenuItemProps & {
     id: string | number;
     link?: string;
 };

--- a/packages/fondue/src/components/AssetInput/types.ts
+++ b/packages/fondue/src/components/AssetInput/types.ts
@@ -1,0 +1,69 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type FocusEvent, type HTMLAttributes, type MouseEvent, type ReactElement, type ReactNode } from 'react';
+
+export enum AssetInputMenuItemContentSize {
+    XSmall = 'XSmall',
+    Small = 'Small',
+    Large = 'Large',
+}
+
+export type AssetInputMenuItemContentProps = {
+    title?: ReactNode;
+    decorator?: ReactElement;
+    switchComponent?: ReactElement;
+    subtitle?: string;
+    size?: AssetInputMenuItemContentSize;
+    ariaProps?: HTMLAttributes<HTMLElement>;
+    children?: ReactNode;
+};
+
+export enum AssetInputMenuItemStyle {
+    Primary = 'Primary',
+    Danger = 'Danger',
+    Warning = 'Warning',
+}
+
+export enum AssetInputSelectionIndicatorIcon {
+    Check = 'Check',
+    CaretRight = 'CaretRight',
+    None = 'None',
+}
+export type AssetInputMenuItemProps = {
+    style?: AssetInputMenuItemStyle;
+    disabled?: boolean;
+    active?: boolean;
+    checked?: boolean;
+    selectionIndicator?: AssetInputSelectionIndicatorIcon;
+    /** @deprecated this prop is not being used anymore */
+    type?: string;
+    link?: string;
+    onBlur?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: FocusEvent<T>) => void;
+    onClick?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
+    onFocus?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: FocusEvent<T>) => void;
+    onMouseEnter?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
+    onMouseOut?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
+    onMouseOver?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
+    onMouseLeave?: <T extends HTMLButtonElement | HTMLAnchorElement>(event: MouseEvent<T>) => void;
+    children?: ReactNode;
+    'data-test-id'?: string;
+} & Omit<AssetInputMenuItemContentProps, 'iconSize'>;
+
+export type AssetInputMenuItemType = Omit<AssetInputMenuItemProps, 'switchComponent'> & {
+    id: string | number;
+    link?: string;
+};
+
+export type AssetInputMenuDefaultItemType = AssetInputMenuItemType & { onClick: () => void };
+
+export type AssetInputMenuSwitchItemType = AssetInputMenuItemType & {
+    onClick: (switchValue: boolean) => void;
+    type: 'switch';
+    initialValue: boolean;
+};
+
+export type AssetInputMenuBlock = {
+    id: string;
+    menuItems: (AssetInputMenuDefaultItemType | AssetInputMenuSwitchItemType)[];
+    ariaLabel?: string;
+};


### PR DESCRIPTION
As in the next release the component `ActionMenu` will no longer be exported, the shared type is split up