### PR TITLE
fix: bump internal deps with changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
     "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
+    "updateInternalDependents": "always",
     "ignore": ["@frontify/fondue-storybook-docs"],
     "linked": [],
     "fixed": []


### PR DESCRIPTION
Bump the dependencies in any case: tokens package has a patch update, Fondue main package wasn't updated so we might have older version used.

<img width="833" height="393" alt="Screenshot 2025-08-28 at 14 36 15" src="https://github.com/user-attachments/assets/dea804eb-a921-46fb-ba4d-e9b682e46521" />
