### PR TITLE
fix(charts): crosshair overlap [CU-869a89rkf]

### DIFF
--- a/.changeset/new-poets-stay.md
+++ b/.changeset/new-poets-stay.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-charts": patch
+---
+
+Fix crosshair/glyphs overlapping

--- a/packages/charts/src/components/AreaStackChart/AreaStackChart.tsx
+++ b/packages/charts/src/components/AreaStackChart/AreaStackChart.tsx
@@ -50,7 +50,7 @@ export const AreaStackChart = ({
     });
 
     return (
-        <div className="tw-flex tw-flex-col tw-gap-6 tw-z-[1]">
+        <div className="tw-flex tw-flex-col tw-gap-6">
             {!hideLegend && legendPosition === LEGEND_POSITION_TOP && (
                 <Legend names={series.map((series) => series.name)} style="line" />
             )}

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -52,7 +52,7 @@ export const BarChart = <DataPointDetails extends Record<string, any> | void = v
     });
 
     return (
-        <div className="tw-flex tw-flex-col tw-gap-6 tw-z-[1]">
+        <div className="tw-flex tw-flex-col tw-gap-6">
             {!hideLegend && legendPosition === 'top' && (
                 <Legend style="rectangle" names={series.map((series) => series.name)} />
             )}

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -138,7 +138,7 @@ const TemplateWithContentOnTop: StoryFn<LineChartProps> = (args) => (
             description="The temperature of US cities over time"
             icon={<IconRocket />}
         />
-        <div className="tw-h-[200px] tw-w-[200px] tw-sticky tw-top-0 tw-p-5 tw-bg-[#cd2828] tw-z-[1]">
+        <div className="tw-h-[200px] tw-w-[200px] tw-sticky tw-top-0 tw-p-5 tw-bg-[#cd2828]">
             Content on top of chart
         </div>
         <LineChart {...args} />

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -131,18 +131,23 @@ const TemplateWithHeading: StoryFn<LineChartProps> = (args) => (
         <LineChart {...args} />
     </>
 );
+
 const TemplateWithContentOnTop: StoryFn<LineChartProps> = (args) => (
-    <div className="tw-h-[1000px] tw-overflow-auto tw-relative">
+    <div className="tw-h-screen tw-overflow-auto tw-relative">
         <ChartHeading
             title="US City Temperature"
             description="The temperature of US cities over time"
             icon={<IconRocket />}
         />
-        <div className="tw-h-[200px] tw-w-[200px] tw-sticky tw-top-0 tw-p-5 tw-bg-[#cd2828]">
+        <div className="tw-h-48 tw-w-screen tw-sticky tw-top-0 tw-p-5 tw-bg-box-neutral tw-flex tw-justify-center tw-items-center">
             Content on top of chart
         </div>
-        <LineChart {...args} />
-        <div className="tw-h-[600px] tw-w-[200px]">asdasdas </div>
+        <div className="tw-flex tw-justify-center">
+            <LineChart {...args} />
+        </div>
+        <div className="tw-h-96 tw-w-screen tw-border tw-border-line tw-flex tw-justify-center tw-items-center">
+            White space content
+        </div>
     </div>
 );
 

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -40,7 +40,7 @@ export const LineChart = ({
     });
 
     return (
-        <div className="tw-flex tw-flex-col tw-gap-6 tw-z-[1]">
+        <div className="tw-flex tw-flex-col tw-gap-6">
             {!hideLegend && legendPosition === 'top' && (
                 <Legend names={series.map((series) => series.name)} style={'line'} />
             )}

--- a/packages/charts/src/components/common/components/Tooltip/Crosshair.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Crosshair.tsx
@@ -1,30 +1,20 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type TooltipInPortalProps } from '@visx/tooltip/lib/hooks/useTooltipInPortal';
 import { DataContext } from '@visx/xychart';
-import { type CSSProperties, type FC, useContext } from 'react';
+import { useContext } from 'react';
 
 import { getCrosshairBarWidth } from '@components/common/components/Tooltip/helpers';
 
 import { type TooltipCrossHairStyle } from './Tooltip';
 
-/** fontSize + lineHeight from default styles break precise location of crosshair, etc. */
-const TOOLTIP_NO_STYLE: CSSProperties = {
-    position: 'absolute',
-    pointerEvents: 'none',
-    fontSize: 0,
-    lineHeight: 0,
-};
-
 type CrosshairProps = {
     style: TooltipCrossHairStyle;
     horizontal: boolean;
     scalePadding: number;
-    TooltipInPortal: FC<TooltipInPortalProps>;
     tooltipPosition: { tooltipLeft?: number; tooltipTop?: number };
 };
-export const Crosshair = ({ horizontal, TooltipInPortal, style, scalePadding, tooltipPosition }: CrosshairProps) => {
-    const { innerHeight, innerWidth, margin, xScale, yScale } = useContext(DataContext) || {};
+export const Crosshair = ({ horizontal, style, scalePadding, tooltipPosition }: CrosshairProps) => {
+    const { innerHeight, innerWidth, xScale, yScale } = useContext(DataContext) || {};
 
     const lineStyle = {
         strokeWidth: style === 'bar' ? getCrosshairBarWidth(horizontal, scalePadding, xScale, yScale) : 1,
@@ -39,46 +29,24 @@ export const Crosshair = ({ horizontal, TooltipInPortal, style, scalePadding, to
     return (
         <>
             {!horizontal && (
-                <TooltipInPortal
-                    left={style === 'bar' && tooltipLeft ? tooltipLeft - lineStyle.strokeWidth / 2 : tooltipLeft}
-                    top={margin?.top}
-                    offsetLeft={0}
-                    offsetTop={0}
-                    detectBounds={false}
-                    style={TOOLTIP_NO_STYLE}
-                >
-                    <svg width={lineStyle.strokeWidth} height={innerHeight} overflow="hidden">
-                        <line
-                            x1={style === 'bar' ? lineStyle.strokeWidth / 2 : 0}
-                            x2={style === 'bar' ? lineStyle.strokeWidth / 2 : 0}
-                            y1={0}
-                            y2={innerHeight}
-                            strokeWidth={lineStyle.strokeWidth}
-                            stroke={lineStyle.stroke}
-                        />
-                    </svg>
-                </TooltipInPortal>
+                <line
+                    x1={tooltipLeft}
+                    x2={tooltipLeft}
+                    y1={0}
+                    y2={Number(yScale?.range()[0] ?? innerHeight)}
+                    strokeWidth={lineStyle.strokeWidth}
+                    stroke={lineStyle.stroke}
+                />
             )}
             {horizontal && (
-                <TooltipInPortal
-                    left={margin?.left}
-                    top={style === 'bar' && tooltipTop ? tooltipTop - lineStyle.strokeWidth / 2 : tooltipTop}
-                    offsetLeft={0}
-                    offsetTop={0}
-                    detectBounds={false}
-                    style={TOOLTIP_NO_STYLE}
-                >
-                    <svg width={innerWidth} height={lineStyle.strokeWidth} overflow="hidden">
-                        <line
-                            x1={0}
-                            x2={innerWidth}
-                            y1={style === 'bar' ? lineStyle.strokeWidth / 2 : 0}
-                            y2={style === 'bar' ? lineStyle.strokeWidth / 2 : 0}
-                            strokeWidth={lineStyle.strokeWidth}
-                            stroke={lineStyle.stroke}
-                        />
-                    </svg>
-                </TooltipInPortal>
+                <line
+                    x1={0}
+                    x2={Number(xScale?.range()[1] || innerWidth)}
+                    y1={tooltipTop}
+                    y2={tooltipTop}
+                    strokeWidth={lineStyle.strokeWidth}
+                    stroke={lineStyle.stroke}
+                />
             )}
         </>
     );

--- a/packages/charts/src/components/common/components/Tooltip/Crosshair.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Crosshair.tsx
@@ -13,6 +13,9 @@ type CrosshairProps = {
     scalePadding: number;
     tooltipPosition: { tooltipLeft?: number; tooltipTop?: number };
 };
+
+const GLYPH_RADIUS = 3;
+
 export const Crosshair = ({ horizontal, style, scalePadding, tooltipPosition }: CrosshairProps) => {
     const { innerHeight, innerWidth, xScale, yScale } = useContext(DataContext) || {};
 
@@ -32,8 +35,9 @@ export const Crosshair = ({ horizontal, style, scalePadding, tooltipPosition }: 
                 <line
                     x1={tooltipLeft}
                     x2={tooltipLeft}
-                    y1={0}
-                    y2={Number(yScale?.range()[0] ?? innerHeight)}
+                    // *3 to account for the shift in the tooltip component, +1 to account for stroke width
+                    y1={GLYPH_RADIUS * 3 + 1}
+                    y2={Number(yScale?.range()[0] || innerHeight)}
                     strokeWidth={lineStyle.strokeWidth}
                     stroke={lineStyle.stroke}
                 />

--- a/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
+++ b/packages/charts/src/components/common/components/Tooltip/Tooltip.tsx
@@ -25,6 +25,8 @@ const INVISIBLE_STYLES: CSSProperties = {
     pointerEvents: 'none',
 };
 
+const GLYPH_RADIUS = 3;
+
 export type TooltipCrossHairStyle = 'line' | 'bar';
 
 type TooltipPropsBase = {
@@ -102,10 +104,11 @@ export const Tooltip = ({
                     <defs>
                         <clipPath id="chart-clip">
                             <rect
-                                x={margin?.left ?? 0}
-                                y={margin?.top ?? 0}
-                                width={innerWidth ?? '100%'}
-                                height={innerHeight ?? '100%'}
+                                // adjust the clip to glyphs on the edges
+                                x={margin?.left ? margin.left - GLYPH_RADIUS : 0}
+                                y={margin?.top ? margin?.top - GLYPH_RADIUS : 0}
+                                width={innerWidth ? innerWidth + GLYPH_RADIUS * 2 : '100%'}
+                                height={innerHeight ? innerHeight + GLYPH_RADIUS * 2 : '100%'}
                             />
                         </clipPath>
                     </defs>
@@ -123,7 +126,7 @@ export const Tooltip = ({
                                     key={glyph.key}
                                     cx={glyph.x}
                                     cy={glyph.y}
-                                    r={3}
+                                    r={GLYPH_RADIUS}
                                     fill={colorAccessor(glyph.key)}
                                     stroke={colorAccessor(glyph.key)}
                                 />


### PR DESCRIPTION
#### V2 of this fix, the issue stems from the crosshair and glyphs being rendered in a portal. Reverted the z-index change and refactored them in order to be rendered in the svg directly.

#### Superheroes
<img width="1863" height="458" alt="image" src="https://github.com/user-attachments/assets/4d58b721-ebd9-482c-80ee-b8b5c9c86026" />

#### Web app linked to this PR(issue solved)
<img width="1472" height="606" alt="image" src="https://github.com/user-attachments/assets/3375807e-0368-4e92-a8f5-1e1a21bd1130" />
