### PR TITLE
fix: accordion col width

### DIFF
--- a/.changeset/tricky-bees-visit.md
+++ b/.changeset/tricky-bees-visit.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: adress issue with accordion caret width

--- a/packages/components/src/components/Accordion/styles/accordion.module.scss
+++ b/packages/components/src/components/Accordion/styles/accordion.module.scss
@@ -43,7 +43,7 @@
     position: relative;
     min-width: fit-content;
     display: grid;
-    grid-template-columns: 1fr min-content 60px;
+    grid-template-columns: 1fr min-content max-content;
     gap: 1rem;
 
     & > .accordionSlot {


### PR DESCRIPTION
Fix accordion grid column width


Before:
<img width="537" height="270" alt="Screenshot 2025-09-09 at 08 52 07" src="https://github.com/user-attachments/assets/a5a20942-18d8-43ad-a05d-d42309175a17" />


After:
<img width="562" height="204" alt="Screenshot 2025-09-09 at 08 52 26" src="https://github.com/user-attachments/assets/15c79e13-977d-4829-aef5-4e61aa46c205" />

