### PR TITLE
fix: prevent tooltip focus when opening dialogs

### DIFF
--- a/.changeset/little-cobras-join.md
+++ b/.changeset/little-cobras-join.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: prevent tooltip focus which would open the tooltip when opening dialogs

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -146,18 +146,21 @@ type DialogContextType = {
 const DialogContext = createContext<DialogContextType>({ isModal: false });
 DialogContext.displayName = 'DialogContext';
 
-export const DialogRoot = ({ children, ...props }: DialogRootProps) => {
-    const value = useMemo(() => ({ isModal: props.modal ?? false }), [props.modal]);
+export const DialogRoot = ({ children, modal, onOpenChange, open }: DialogRootProps) => {
+    const value = useMemo(() => ({ isModal: modal ?? false }), [modal]);
+
     return (
         <DialogContext.Provider value={value}>
-            <RadixDialog.Root {...props}>{children}</RadixDialog.Root>
+            <RadixDialog.Root open={open} onOpenChange={onOpenChange} modal={modal}>
+                {children}
+            </RadixDialog.Root>
         </DialogContext.Provider>
     );
 };
 DialogRoot.displayName = 'Dialog.Root';
 
 export const DialogTrigger = (
-    { asChild = true, children, 'data-test-id': dataTestId = 'fondue-dialog-trigger', ...props }: DialogTriggerProps,
+    { asChild = true, children, 'data-test-id': dataTestId = 'fondue-dialog-trigger' }: DialogTriggerProps,
     ref: ForwardedRef<HTMLButtonElement>,
 ) => {
     return (
@@ -168,7 +171,6 @@ export const DialogTrigger = (
             data-test-id={dataTestId}
             asChild={asChild}
             ref={ref}
-            {...props}
         >
             {children}
         </RadixDialog.Trigger>
@@ -203,7 +205,6 @@ export const DialogContent = (
         showUnderlay = false,
         rounded = true,
         children,
-        ...props
     }: DialogContentProps,
     ref: ForwardedRef<HTMLDivElement>,
 ) => {
@@ -218,7 +219,7 @@ export const DialogContent = (
         const dialogBody = contentRef.current?.querySelector('[data-dialog-layout-component="body"]');
 
         const firstFocusable = dialogBody?.querySelector(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+            'button:not([data-tooltip-trigger="true"]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
         );
 
         if (firstFocusable instanceof HTMLElement) {
@@ -246,7 +247,6 @@ export const DialogContent = (
                         data-dialog-rounded={rounded}
                         data-test-id={dataTestId}
                         data-dialog-vertical-align={verticalAlign}
-                        {...props}
                     >
                         {children}
                     </RadixDialog.Content>

--- a/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
+++ b/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 
 import { Button } from '#/components/Button/Button';
 import { TextInput } from '#/components/TextInput/TextInput';
+import { Tooltip } from '#/components/Tooltip/Tooltip';
 import { FOCUS_BORDER_CSS, FOCUS_OUTLINE_CSS } from '#/helpers/constants';
 
 import { Dialog } from '../Dialog';
@@ -496,4 +497,36 @@ test('should focus first input in body when dialog opens', async ({ mount, page 
     const textInput1 = page.getByTestId(TEXT_INPUT_TEST_ID_1);
 
     await expect(textInput1).toBeFocused();
+});
+
+test('should not focus the tooltip trigger when dialog opens', async ({ mount, page }) => {
+    const component = await mount(
+        <Dialog.Root>
+            <Dialog.Trigger>
+                <Button>{DIALOG_TRIGGER_TEXT}</Button>
+            </Dialog.Trigger>
+            <Dialog.Content>
+                <Dialog.Header>{DIALOG_HEADER_TEXT}</Dialog.Header>
+                <Dialog.Body>
+                    <Tooltip.Root>
+                        <Tooltip.Trigger data-test-id="tooltip-trigger">Tooltip Trigger</Tooltip.Trigger>
+                        <Tooltip.Content side="right" padding="compact">
+                            Tooltip Content
+                        </Tooltip.Content>
+                    </Tooltip.Root>
+                    <input data-test-id={TEXT_INPUT_TEST_ID_1} />
+                </Dialog.Body>
+            </Dialog.Content>
+        </Dialog.Root>,
+    );
+
+    const dialogTrigger = page.getByTestId(DIALOG_TRIGGER_TEST_ID);
+
+    await expect(component).toBeVisible();
+
+    await dialogTrigger.focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByTestId('tooltip-trigger')).not.toBeFocused();
+    await expect(page.getByTestId(TEXT_INPUT_TEST_ID_1)).toBeFocused();
 });

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -26,10 +26,10 @@ export type TooltipRootProps = {
     children: Array<ReactElement<TooltipTriggerProps | TooltipContentProps>>;
 };
 
-export const TooltipRoot = ({ children, enterDelay = 700, open, onOpenChange, ...props }: TooltipRootProps) => {
+export const TooltipRoot = ({ children, enterDelay = 700, open, onOpenChange }: TooltipRootProps) => {
     return (
         <RadixTooltip.Provider>
-            <RadixTooltip.Root delayDuration={enterDelay} open={open} onOpenChange={onOpenChange} {...props}>
+            <RadixTooltip.Root delayDuration={enterDelay} open={open} onOpenChange={onOpenChange}>
                 {children}
             </RadixTooltip.Root>
         </RadixTooltip.Provider>
@@ -53,6 +53,7 @@ export const TooltipTrigger = (
 ) => {
     return (
         <RadixTooltip.Trigger
+            data-tooltip-trigger
             data-test-id={dataTestId}
             type={!asChild ? 'button' : undefined}
             asChild={asChild}
@@ -86,7 +87,7 @@ export const TooltipContent = (
         maxWidth,
         'data-test-id': dataTestId = 'fondue-tooltip-content',
         padding = 'spacious',
-        ...props
+        side,
     }: TooltipContentProps,
     ref: ForwardedRef<HTMLDivElement>,
 ) => {
@@ -102,7 +103,7 @@ export const TooltipContent = (
                     collisionPadding={16}
                     sideOffset={8}
                     ref={ref}
-                    {...props}
+                    side={side}
                 >
                     {children}
                     <RadixTooltip.Arrow aria-hidden="true" className={styles.arrow} />


### PR DESCRIPTION
\+ removal of the spread since they are usually empty objects.

Prevents issues like this 

https://github.com/user-attachments/assets/8a0603ef-bde9-4cf1-ab27-41a2b25688cd

