### PR TITLE
chore(Tag): fix focus ring visibility

### DIFF
--- a/.changeset/crazy-walls-mate.md
+++ b/.changeset/crazy-walls-mate.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+chore(Tag): fix focus ring visibility

--- a/packages/components/src/components/Tag/styles/tag.module.scss
+++ b/packages/components/src/components/Tag/styles/tag.module.scss
@@ -62,7 +62,6 @@
     align-items: stretch;
     white-space: nowrap;
     min-height: 1rem;
-    overflow: hidden;
 
     &[data-size="small"] {
         .mainContent {
@@ -102,6 +101,12 @@
         background: transparent;
         color: inherit;
         font: inherit;
+        border-radius: var(--radius);
+
+        &:not(:last-child) {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
 
         &:has(~.actionButton) {
             margin-right: -0.3rem;
@@ -125,7 +130,6 @@
         border: none 0 transparent;
         background: transparent;
         color: inherit;
-        border-radius: 0;
         cursor: pointer;
         display: flex;
         align-items: center;
@@ -133,6 +137,12 @@
         transition: background-color 250ms, color 250ms;
         flex-shrink: 0;
         aspect-ratio: 1;
+        border-radius: 0;
+
+        &:last-child {
+            border-top-right-radius: var(--radius);
+            border-bottom-right-radius: var(--radius);
+        }
 
         & {
             @include focusStyle.focus-outline;


### PR DESCRIPTION
Previous:
<img width="719" height="308" alt="image" src="https://github.com/user-attachments/assets/8b348c1b-5d47-46d0-b7c8-1076a1ca45fa" />

Now:
<img width="129" height="71" alt="Screenshot 2025-10-01 at 12 55 01" src="https://github.com/user-attachments/assets/3f2b15ba-59cf-4505-b634-50feb44b835a" />
