### PR TITLE
feat(Components): improve documentation (AI enabled)

### DIFF
--- a/.changeset/dark-eagles-type.md
+++ b/.changeset/dark-eagles-type.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+Update documentation of all Fondue components

--- a/.claude/commands/document-component.md
+++ b/.claude/commands/document-component.md
@@ -1,0 +1,126 @@
+Document the component specified by `$ARGUMENTS` in `packages/components/src/components/`. If no component is specified, ask which one.
+
+## Steps
+
+1. **Read the source** — Read the component's `.tsx` file(s) and any `types.ts`. Identify all exported props types and the component export.
+2. **Read the stories** — Read the `.stories.tsx` file if it exists.
+3. **Read reference examples** — Read `packages/components/src/components/Button/Button.tsx` and `packages/components/src/components/Button/Button.stories.tsx` as the gold-standard reference for documentation style.
+4. **Apply the rules below** to add or improve documentation in both the component source and the story file.
+
+## JSDoc Rules for Props
+
+Every exported prop must have a JSDoc comment. Follow these rules strictly:
+
+### Voice & Tone
+- Write from the perspective of a **product designer advising a developer** — explain *when* and *why*, not just *what*.
+- Use second person sparingly. Prefer impersonal constructions: "Controls the…", "Defines the…", "Conveys the…"
+- Be concise. One sentence is ideal. Two sentences max.
+- Never restate the type or prop name. `size?: 'small' | 'medium' | 'large'` does NOT need "The size can be small, medium, or large."
+
+### Describing Variants (union types)
+When a prop accepts a union of string literals, explain when to use each option inline using backtick-quoted values:
+
+```typescript
+/**
+ * Conveys the tone. `'default'` for neutral actions, `'positive'` for confirmations like "Approve", `'danger'` for irreversible actions like "Delete".
+ * @default "default"
+ */
+variant?: 'default' | 'positive' | 'danger';
+```
+
+### @default Tag
+- Always include `@default` when a default value exists.
+- Always quote string defaults: `@default "medium"` (not `@default medium`).
+- Boolean defaults: `@default false`.
+- Number defaults: `@default 0`.
+
+### Callback Props
+- Start with "Callback fired when…" or "Event handler called when…"
+- Include `@param` for non-obvious parameters.
+
+```typescript
+/**
+ * Callback fired when the value changes.
+ * @param value - The new slider value as an array of numbers
+ */
+onChange?: (value: number[]) => void;
+```
+
+### children Props
+- Document what children are expected when there are constraints:
+
+```typescript
+/**
+ * Should contain `Accordion.Item` components.
+ */
+children?: ReactNode;
+```
+
+- Skip documentation for generic `children?: ReactNode` with no constraints.
+
+### Skip Documentation For
+- `data-test-id` — self-explanatory
+- `className` — self-explanatory
+- Standard ARIA props from `CommonAriaProps` / `CommonAriaAttrs` — self-explanatory
+
+### Compound Component Export
+Add a top-level JSDoc comment to the compound export object:
+
+```typescript
+/**
+ * A vertically stacked list of collapsible sections. Use `Accordion.Root` as the
+ * container, `Accordion.Item` for each section, `Accordion.Header` for the trigger,
+ * and `Accordion.Content` for the hidden panel.
+ */
+export const Accordion = { Root, Item, Header, Content };
+```
+
+## Storybook Description Rules
+
+### Meta Description
+Every story file must include a `docs.description.component` in `parameters`. Use this template:
+
+```
+Line 1: What it is — starts with "A" or "An", one sentence
+Line 2: (blank)
+Line 3: **When to use:** One sentence on the right context for this component
+Line 4: (blank)
+Line 5+: **Feature name:** One sentence per notable feature (optional, max 3)
+```
+
+Use `.join('\n')` for readability:
+
+```typescript
+parameters: {
+    docs: {
+        description: {
+            component: [
+                'A short, colored label for categorizing or highlighting status. Ideal for metadata, counts, or state indicators.',
+                '',
+                '**When to use:** To surface a quick status or category alongside other content — not for actions (use Button) or removable items (use Tag).',
+                '',
+                '**Icon:** Pass an icon as a child to reinforce meaning at a glance.',
+            ].join('\n'),
+        },
+    },
+},
+```
+
+### Description Language Rules
+- Start the first line with an article ("A", "An")
+- Use en-dashes (—) for parenthetical asides, not hyphens
+- Bold feature labels: `**When to use:**`, `**Icon:**`, `**Accessibility:**`
+- Keep the total description under 5 lines after blank-line separators
+- Never mention implementation details (Radix, SCSS, etc.) in descriptions
+
+### args Defaults
+Set sensible `args` in meta that show the component in its most common state.
+
+## Verification
+
+After making changes:
+1. Confirm every exported prop has JSDoc (except the skip list above)
+2. Confirm the story has a `docs.description.component`
+3. Confirm `@default` values match the actual defaults in the component
+4. Confirm no prop description references the wrong component name
+5. Summarize what you changed

--- a/packages/components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/components/Accordion/Accordion.stories.tsx
@@ -23,6 +23,19 @@ const meta: Meta<typeof AccordionRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A vertically stacked list of interactive headers that toggle the visibility of associated content. Helps organize large amounts of information by collapsing it into digestible sections.',
+                    '',
+                    "**When to use:** When content can be grouped into discrete sections and users don't need to see everything at once.",
+                    '',
+                    '**Actions:** Use `Accordion.Slot` with `name="action"` to place actions on the right of the header. Keep primary actions visible and tuck non-essential ones behind a three-dot menu.',
+                    '',
+                    '**Leading icon:** Add a leading icon as a child of `Accordion.Header` to reinforce the meaning of the label, or skip it for a simpler look.',
+                ].join('\n'),
+            },
+        },
     },
     args: {},
 };

--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -19,34 +19,34 @@ type AccordionPadding = 'none' | 'small' | 'medium' | 'large';
 export type AccordionRootProps = {
     'data-test-id'?: string;
     /**
-     * Show or hide the top and bottom border
+     * Shows or hides the top and bottom border.
      * @default true
      */
     border?: boolean;
     /**
-     * Children of the Accordion component. This should contain the `Accordion.Item` components
+     * Should contain `Accordion.Item` components.
      */
     children?: ReactNode;
     /**
-     * The value of the items whose contents are expanded when the accordion is initially rendered.
-     * Use `defaultValue` if you do not need to control the state of an accordion.
+     * The items whose contents are expanded on initial render. Use when you do not need to control accordion state.
      */
     defaultValue?: string[];
     /**
-     * Whether or not an accordion is disabled from user interaction.
+     * Prevents interaction and dims the accordion visually.
+     * @default false
      */
     disabled?: boolean;
     /**
-     * The controlled stateful value of the accordion items whose contents are expanded.
+     * The controlled value of the items whose contents are expanded.
      */
     value?: string[];
     /**
-     * Controls if we show paddings around the header.
+     * Controls padding around the header. `'none'` for no padding, `'small'`, `'medium'`, or `'large'` for increasing spacing.
      * @default 'large'
      */
     padding?: AccordionPadding;
     /**
-     * Callback function that is called when the value of the accordion changes.
+     * Callback fired when the expanded items change.
      */
     onValueChange?: (value: string[]) => void;
 };
@@ -82,7 +82,7 @@ AccordionRoot.displayName = 'Accordion.Root';
 export type AccordionItemProps = {
     'data-test-id'?: string;
     /**
-     * Children of the Accordion item. This should contain the `Accordion.Header` and `Accordion.Content` components
+     * The item content. Should contain an `Accordion.Header` and an `Accordion.Content`.
      */
     children?: ReactNode;
     /**
@@ -130,11 +130,11 @@ export type AccordionHeaderProps = {
      */
     asChild?: boolean;
     /**
-     * Click callback for this item.
+     * Callback fired when the header is clicked.
      */
     onClick?: MouseEventHandler<HTMLDivElement>;
     /**
-     * Children of the Accordion header.
+     * The header content — text, icons, and optional `Accordion.Slot` elements for actions.
      */
     children?: ReactNode;
 };
@@ -176,7 +176,7 @@ AccordionHeader.displayName = 'Accordion.Header';
 type AccordionContentProps = {
     'data-test-id'?: string;
     /**
-     * Children of the Accordion content. This contains the main content.
+     * The collapsible content revealed when this item is expanded.
      */
     children?: ReactNode;
     /**
@@ -184,12 +184,12 @@ type AccordionContentProps = {
      */
     divider?: boolean;
     /**
-     * Click callback for the content.
+     * Callback fired when the content area is clicked.
      */
     onClick?: MouseEventHandler<HTMLDivElement>;
     /**
-     * Controls if we show paddings around the content.
-     * @default 'large'
+     * Controls padding around the content area. Inherits from the root's `padding` when omitted.
+     * @default "large"
      */
     padding?: AccordionPadding;
 };
@@ -218,7 +218,13 @@ export const AccordionContent = ({
 AccordionContent.displayName = 'Accordion.Content';
 
 export type AccordionSlotProps = {
+    /**
+     * Content to render inside the slot, typically action buttons or controls.
+     */
     children: ReactNode;
+    /**
+     * The slot placement. Use `'action'` to position content on the right side of the header for quick-access actions.
+     */
     name?: 'action';
     'data-test-id'?: string;
 };
@@ -242,6 +248,7 @@ const ForwardedRefAccordionSlot = forwardRef<HTMLDivElement, AccordionSlotProps>
  */
 const DeprecatedAccordionTrigger = ({ children }: { children: ReactNode }) => children;
 
+/** A vertically stacked set of collapsible sections — compose `Root` with `Item`, `Header`, `Content`, and `Slot` sub-components. */
 export const Accordion = {
     Root: AccordionRoot,
     Item: AccordionItem,

--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -15,6 +15,17 @@ const meta: Meta<typeof Badge> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A small indicator used to highlight status, count, or category. Conveys concise data at a glance without overwhelming the interface.',
+                    '',
+                    '**When to use:** To surface metadata, counts, or status alongside other content — such as labels in a list, filter tags, or notification counts.',
+                    '',
+                    '**Icon:** Pass an icon as a child alongside the label to add visual context or reinforce meaning.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         emphasis: 'strong',

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -16,36 +16,46 @@ type BadgeSize = 'default' | 'small';
 
 type BadgeProps = {
     /**
+     * Controls visual weight. Use `'strong'` for high-priority information, `'weak'` for subtle or secondary content.
      * @default 'strong'
      */
     emphasis?: BadgeEmphasis;
     /**
+     * Conveys the tone. `'default'` for neutral, `'positive'` for success, `'highlight'` for informational, `'warning'` for caution, `'negative'` for critical.
      * @default 'default'
      */
     variant?: BadgeStyle;
     /**
+     * Controls the badge size. Use `'small'` when space is limited or the badge plays a secondary role.
      * @default 'default'
      */
     size?: BadgeSize;
     /**
+     * Prevents interaction and dims the badge visually.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Click handler
+     * Click handler. When provided, the badge renders as a button element.
      */
     onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
     /**
-     * Click handler on dismiss - providing this will show the dismiss button
+     * Dismiss handler. When provided, a dismiss button is shown, useful for filters or removable selections.
      */
     onDismiss?: (event: MouseEvent<HTMLButtonElement>) => void;
     /**
-     * The color of the status dot
+     * Displays a status dot to reflect live states or activity. Accepts a preset (`'positive'`, `'warning'`, etc.) or a custom color value.
      */
     status?: BadgeStatusProps['status'];
+    /**
+     * Tooltip text shown on hover. Also used as the accessible name when no `aria-label` is provided.
+     */
     title?: string;
     'aria-label'?: string;
     'data-test-id'?: string;
+    /**
+     * The badge content — typically short text, a number, or a label.
+     */
     children: ReactNode;
 };
 

--- a/packages/components/src/components/Box/Box.stories.tsx
+++ b/packages/components/src/components/Box/Box.stories.tsx
@@ -15,6 +15,15 @@ const meta: Meta<typeof Box> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A generic container with responsive spacing, sizing, and positioning props. The simplest layout primitive in Fondue.',
+                    '',
+                    '**When to use:** When you need margin, padding, or sizing control without Flex or Grid behavior. For directional layouts use `<Flex>`, for two-dimensional layouts use `<Grid>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         width: 25,

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -10,13 +10,13 @@ import styles from './styles/box.module.scss';
 
 export type BoxProps = LayoutComponentProps & {
     /**
-     * The element to render the Box component as.
-     * @default 'div'
+     * The HTML element to render. Use `'span'` for inline contexts.
+     * @default "div"
      */
     as?: 'div' | 'span';
     /**
-     * The display property.
-     * @default 'block'
+     * Controls the display mode. `'block'` for standard box, `'inline-block'` for inline with box behavior, `'none'` to hide.
+     * @default "block"
      */
     display?: Responsive<'none' | 'block' | 'inline-block' | 'inline'>;
 

--- a/packages/components/src/components/Button/Button.stories.tsx
+++ b/packages/components/src/components/Button/Button.stories.tsx
@@ -15,6 +15,21 @@ const meta: Meta<typeof Button> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'An interactive element that triggers actions — from submitting a form to opening a menu. At least one content element must be included: a label, an icon, or both.',
+                    '',
+                    '**When to use:** For actions and commands only. Use links for navigation — buttons trigger an immediate result, links navigate to a new location.',
+                    '',
+                    '**Icon:** Pass an icon as a child to add visual context. Use `aspect="square"` for icon-only buttons.',
+                    '',
+                    '**Caret:** Signals that clicking will reveal additional options. Usually used with the Dropdown component.',
+                    '',
+                    '**Accessible labeling:** Use concise, descriptive labels that reflect the action. Prefer specific verbs like "Submit" or "Download" over vague terms like "Go" or "Click here."',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         type: 'button',

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -18,43 +18,60 @@ type ButtonAspect = 'default' | 'square';
 
 export type ButtonProps = {
     /**
+     * The HTML button type. Use `'submit'` for form submission, `'reset'` to clear form fields, `'button'` for general actions.
      * @default "button"
      */
     type?: ButtonType;
     /**
-     * @default null
+     * Tooltip text shown on hover. Also used as the accessible name when no `aria-label` is provided.
      */
     title?: string;
     /**
+     * Conveys the tone. `'default'` for neutral actions, `'positive'` for confirmations like "Approve", `'negative'` for cautionary actions like "Cancel", `'danger'` for irreversible actions like "Delete", `'loud'` for high-visibility actions — use sparingly.
      * @default "default"
      */
     variant?: ButtonStyle;
     /**
+     * Controls visual weight. `'strong'` for primary actions, `'default'` for common actions, `'weak'` for secondary or less prominent options.
      * @default "strong"
      */
     emphasis?: ButtonEmphasis;
     /**
+     * Controls the button size. `'small'` for tight spaces or lower priority, `'medium'` for most layouts, `'large'` for prominent actions.
      * @default "medium"
      */
     size?: ButtonSize;
     /**
+     * Controls border radius. `'medium'` for standard buttons, `'full'` for pill-shaped buttons.
      * @default "medium"
      */
     rounding?: ButtonRounding;
     /**
+     * Prevents interaction and dims the button visually.
      * @default false
      */
     disabled?: boolean;
     /**
+     * Controls the aspect ratio. `'default'` for standard buttons with label, `'square'` for icon-only buttons.
      * @default "default"
      */
     aspect?: ButtonAspect;
     /**
+     * When `true`, the button sizes to fit its content. When `false`, the button expands to fill its container width. Use full-width sparingly — it works well on mobile or at the bottom of forms.
      * @default true
      */
     hugWidth?: boolean;
+    /**
+     * The button content — text, icons, or a combination of both.
+     */
     children?: ReactNode;
+    /**
+     * Callback fired when the button is pressed.
+     */
     onPress?: (event?: MouseEvent<HTMLButtonElement>) => void;
+    /**
+     * Associates the button with a `<form>` by its `id`. Use when the button sits outside the form element in the DOM.
+     */
     form?: string;
     'aria-label'?: string;
     'aria-describedby'?: string;

--- a/packages/components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.stories.tsx
@@ -21,6 +21,21 @@ const meta: Meta<typeof CheckboxComponent> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'An input for selecting from predefined options. On its own, it captures a single selection — group a few together for multi-select scenarios.',
+                    '',
+                    '**When to use:** For binary choices or selecting multiple items from a list. Pair with a `Label` component for usability and a larger tap target.',
+                    '',
+                    '**Selection state:** The `value` prop supports `true` (selected), `false` (unselected), and `"indeterminate"` (partial group selection). Indeterminate is a visual cue only and doesn\'t affect the underlying value.',
+                    '',
+                    "**Label:** Whenever possible, include a visible label. In patterns like card or image selection where labels aren't practical, ensure the checkbox's meaning is clear from context.",
+                    '',
+                    '**Tooltip:** Use a Tooltip component alongside the label when additional context is needed. Keep content concise and avoid relying on it for critical information.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         disabled: false,

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -10,57 +10,56 @@ export type CheckboxProps = {
     id?: string;
     name?: string;
     /**
-     * The default value of the checkbox
-     * Used for uncontrolled components
+     * The initial checked state for uncontrolled usage. Pass `'indeterminate'` for a mixed state (e.g., when some but not all child items are selected).
      * @default false
      */
     defaultValue?: boolean | 'indeterminate';
     /**
-     * The controlled value of the checkbox
+     * The controlled checked state. Use together with `onChange` for controlled usage. Pass `'indeterminate'` for a mixed state.
      * @default false
      */
     value?: boolean | 'indeterminate';
     /**
-     * The size of the checkbox
+     * Controls the checkbox size. `'default'` fits most layouts, `'large'` for touch-friendly environments or increased visual weight.
      * @default "default"
      */
     size?: 'default' | 'large';
     /**
-     * The emphasis of the checkbox
+     * Controls visual weight. `'default'` is subtle for standard forms, `'weak'` for reduced visual weight.
      * @default "default"
      */
     emphasis?: 'default' | 'weak';
     /**
-     * Disable the checkbox
+     * Prevents interaction and dims the checkbox visually.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Make the checkbox required in form
+     * Marks the checkbox as required for form submission. The indicator should appear next to the label.
      * @default false
      */
     required?: boolean;
     /**
-     * Make the checkbox read-only
+     * Makes the checkbox read-only. The checkbox is visible and focusable but its value cannot be changed by user interaction.
      * @default false
      */
     readOnly?: boolean;
     /**
-     * Status of the checkbox
+     * Visual status of the checkbox. Use `'error'` to indicate a validation failure.
      * @default "default"
      */
     status?: 'default' | 'error';
     className?: string;
     /**
-     * Event handler called when the checkbox value changes
+     * Callback fired when the checked state changes.
      */
     onChange?: (event: FormEvent<HTMLButtonElement>) => void;
     /**
-     * Event handler called when the checkbox is blurred
+     * Callback fired when the checkbox loses focus.
      */
     onBlur?: (event: FormEvent<HTMLButtonElement>) => void;
     /**
-     * Event handler called when the checkbox is focused
+     * Callback fired when the checkbox gains focus.
      */
     onFocus?: (event: FormEvent<HTMLButtonElement>) => void;
     'data-test-id'?: string;

--- a/packages/components/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -22,6 +22,15 @@ const meta: Meta<typeof ColorPickerRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'An interactive color selection control with gradient, hue, and value inputs. Outputs colors in hex, RGB, or HSL formats.',
+                    '',
+                    '**When to use:** When users need to pick or input a specific color — theme customization, brand settings, or design tools.',
+                ].join('\n'),
+            },
+        },
     },
     args: {},
 };

--- a/packages/components/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPicker.tsx
@@ -12,33 +12,30 @@ import { DEFAULT_COLOR, DEFAULT_FORMAT, getColorWithName } from './utils';
 
 type ColorPickerProps = {
     /**
-     * The children of the color picker component. This can contain multiple `ColorPicker.Values` or `ColorPicker.Gradient` components.
+     * The picker content. Compose with `ColorPicker.Values` for hex/rgba inputs and `ColorPicker.Gradient` for the visual color area.
      */
     children?: ReactNode;
     /**
-     * The active color in the color picker
+     * The active color. Pass an `RgbaColor` object with `red`, `green`, `blue`, and optional `alpha` channels.
      */
     currentColor?: RgbaColor;
     /**
-     * Event handler called when the color changes
+     * Callback fired whenever the color changes — through the gradient, the value inputs, or the alpha slider.
      */
     onColorChange?: (color: RgbaColor) => void;
     /**
-     * The active color format in the color picker
+     * The controlled color format. Use together with `onFormatChange` for controlled format switching between `'HEX'` and `'RGBA'`.
      */
     currentFormat?: ColorFormat;
     /**
-     * Event handler called when the color format changes
+     * Callback fired when the user toggles between HEX and RGBA format.
      */
     onFormatChange?: (format: ColorFormat) => void;
     /**
-     * The default format to use for the color input when not controlled externally
+     * The initial color format for uncontrolled usage.
      * @default "HEX"
      */
     defaultFormat?: ColorFormat;
-    /**
-     * The test id of the color picker
-     */
     'data-test-id'?: string;
 };
 
@@ -90,6 +87,7 @@ const ColorPickerSlot = ({ children, ...props }: ColorPickerSlotProps) => <Radix
 
 export const ForwardedRefColorPicker = forwardRef<HTMLDivElement, ColorPickerProps>(ColorPickerRoot);
 
+/** A color selection tool — compose `Root` with `Values`, `Gradient`, and `Input` sub-components. */
 export const ColorPicker = {
     Root: ForwardedRefColorPicker,
     Values: ForwardedRefColorValueInput,

--- a/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
+++ b/packages/components/src/components/ColorPicker/ColorPickerInput.tsx
@@ -15,28 +15,26 @@ import { colorToCss, getColorWithName } from './utils';
 type ColorPickerInputProps = {
     id?: string;
     /**
-     * The active color in the color picker
+     * The active color shown in the swatch preview.
      */
     currentColor?: RgbaColor;
     /**
-     * The open state of the color picker used to determine arrow state
+     * Whether the color picker panel is currently visible. Controls the caret direction indicator.
      */
     isOpen?: boolean;
     /**
-     * Whether the color picker input is disabled
+     * Prevents interaction and dims the input visually.
+     * @default false
      */
     disabled?: boolean;
     /**
-     * callback for clearing the color
+     * Callback fired when the user clicks the clear button. When provided, a clear button is shown.
      */
     onClear?: () => void;
     /**
-     * Event handler called when the color picker input is clicked
+     * Callback fired when the user clicks the input trigger. Use this to toggle the picker panel open.
      */
     onClick?: () => void;
-    /**
-     * The test id of the color picker input
-     */
     'data-test-id'?: string;
 } & CommonAriaAttrs;
 

--- a/packages/components/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/components/Dialog/Dialog.stories.tsx
@@ -42,6 +42,15 @@ const meta: Meta<typeof DialogContent> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A modal overlay that interrupts the user to request input or confirmation. Traps focus and blocks interaction with the page behind it.',
+                    '',
+                    '**When to use:** For critical decisions that require explicit user action — confirmations, destructive operations, or multi-step forms. For non-blocking secondary content use `<Flyout>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {},
     render: (args) => {

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -24,17 +24,17 @@ import styles from './styles/dialog.module.scss';
 
 export type DialogRootProps = {
     /**
-     * Disable interaction with the rest of the page
+     * When `true`, prevents interaction with the rest of the page and restricts screen-reader access to the dialog content only.
      * @default false
      */
     modal?: boolean;
     /**
-     * The controlled `open` state of the dialog
+     * The controlled open state. Use together with `onOpenChange` for controlled usage.
      * @default false
      */
     open?: boolean;
     /**
-     * Event handler called when the `open` state changes
+     * Callback fired when the dialog opens or closes. Receives the new `open` state.
      */
     onOpenChange?: (open: boolean) => void;
     children?: ReactNode;
@@ -42,43 +42,43 @@ export type DialogRootProps = {
 
 export type DialogContentProps = {
     /**
-     * Add rounded corners to the dialog
+     * Adds rounded corners to the dialog panel.
      * @default true
      */
     rounded?: boolean;
     /**
-     * Define the padding of the dialog
+     * Controls the inner padding of the dialog content. `'compact'` for most dialogs, `'spacious'` for rich content areas.
      * @default "compact"
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     /**
-     * The vertical alignment of the divider
+     * Controls the vertical position. `'center'` for standard dialogs, `'top'` for tall or scrollable content that should anchor near the top.
      * @default "center"
      */
     verticalAlign?: 'top' | 'center';
 
     /**
-     * Define a maximum width for the dialog
+     * The maximum width of the dialog panel. Accepts any CSS length value.
      * @default "800px"
      */
     maxWidth?: string;
     /**
-     * Define a minimum width for the dialog
+     * The minimum width of the dialog panel. Accepts any CSS length value.
      * @default "400px"
      */
     minWidth?: string;
     /**
-     * Define a minimum height for the dialog
+     * The minimum height of the dialog panel. Accepts any CSS length value.
      * @default "200px"
      */
     minHeight?: string;
     /**
-     * Show a dark underlay behind the dialog
+     * Shows a dark overlay behind the dialog to draw focus to the content.
      * @default false
      */
     showUnderlay?: boolean;
     /**
-     * Event handler called when the escape key is pressed.
+     * Callback fired when the Escape key is pressed. Use to intercept or prevent closing.
      */
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
     children?: ReactNode;
@@ -87,7 +87,7 @@ export type DialogContentProps = {
 
 export type DialogTriggerProps = {
     /**
-     * Change the default rendered element for the one passed as a child, merging their props and behavior.
+     * When `true`, merges the trigger's props and behavior onto its child element instead of rendering a wrapper.
      * @default true
      */
     asChild?: boolean;
@@ -97,19 +97,22 @@ export type DialogTriggerProps = {
 
 export type DialogHeaderProps = {
     /**
-     * Define the padding for the dialog header
+     * Overrides the content-level padding for the header section.
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     /**
-     * Show a border at the bottom of the header
+     * Shows a separator line at the bottom of the header.
      * @default true
      */
     showBorder?: boolean;
     /**
-     * Show a close button in the header
+     * Shows a close button (×) in the header corner.
      * @default true
      */
     showCloseButton?: boolean;
+    /**
+     * Additional ARIA props forwarded to the close button for accessibility customization.
+     */
     closeProps?: CommonAriaProps;
     children?: ReactNode;
     'data-test-id'?: string;
@@ -117,11 +120,11 @@ export type DialogHeaderProps = {
 
 export type DialogFooterProps = {
     /**
-     * Define the padding for the dialog footer
+     * Overrides the content-level padding for the footer section.
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     /**
-     * Show a border at the top of the footer
+     * Shows a separator line at the top of the footer.
      * @default true
      */
     showBorder?: boolean;
@@ -131,7 +134,7 @@ export type DialogFooterProps = {
 
 export type DialogBodyProps = {
     /**
-     * Define the padding for the dialog body
+     * Overrides the content-level padding for the body section.
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     children?: ReactNode;
@@ -374,6 +377,7 @@ export const DialogDescription = ({ children, asChild }: DialogAnnouncementProps
 };
 DialogDescription.displayName = 'Dialog.Description';
 
+/** A modal or non-modal dialog — compose `Root` with `Trigger`, `Content`, `Header`, `Body`, `Footer`, `Title`, `Description`, `Close`, and `SideContent` sub-components. */
 export const Dialog = {
     Root: DialogRoot,
     Title: DialogTitle,

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -19,6 +19,15 @@ const meta: Meta<typeof Divider> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A visual separator between content sections. Renders as an `<hr>` with configurable orientation, style, and spacing.',
+                    '',
+                    '**When to use:** To visually group or separate content areas. Set `decorative` to `true` when the divider carries no semantic meaning.',
+                ].join('\n'),
+            },
+        },
     },
     decorators: [
         (Story) => (

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -12,33 +12,32 @@ type DividerColor = 'weak' | 'default' | 'strong';
 
 export type DividerProps = {
     /**
-     * The style of the divider
+     * Controls the line style. `'solid'` for a continuous line, `'dashed'` for a dotted line, `'noline'` for spacing-only separation.
      * @default "solid"
      */
     variant?: DividerStyle;
     /**
-     * The padding of the divider
+     * Controls the spacing around the divider. `'none'` for tight layouts, `'medium'` for standard separation, `'large'` for prominent breaks.
      * @default "medium"
      */
     padding?: DividerPadding;
     /**
-     * The color of the divider
+     * Controls the line color intensity. `'weak'` for subtle separation, `'default'` for standard, `'strong'` for prominent borders.
      * @default "default"
      */
     color?: DividerColor;
     /**
-     * The direction of the divider
+     * Controls the orientation. `'horizontal'` for full-width breaks, `'vertical'` for side-by-side content separation.
      * @default "horizontal"
      */
     direction?: DividerDirection;
     /**
-     * The html element to be used
+     * The HTML element to render. Use `'li'` when the divider sits inside a list.
      * @default "div"
      */
     as?: 'div' | 'li';
     /**
-     * When `true`, signifies that it is purely visual, carries no semantic
-     * meaning, and ensures it is not present in the accessibility tree.
+     * When `true`, the divider is purely visual — it carries no semantic meaning and is hidden from the accessibility tree.
      * @default false
      */
     decorative?: boolean;

--- a/packages/components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.stories.tsx
@@ -37,6 +37,17 @@ const meta: Meta<typeof DropdownRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'An action menu triggered by a button press or right-click. Shows a list of commands, options, or navigation items in a floating panel.',
+                    '',
+                    '**When to use:** For contextual actions like "Edit", "Delete", or "Share." For selecting a value from a list, use `<Select>` instead.',
+                    '',
+                    '**Submenus:** Use `Dropdown.SubMenu` to nest related actions under a parent item.',
+                ].join('\n'),
+            },
+        },
     },
     args: {},
 };

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -12,16 +12,16 @@ import styles from './styles/dropdown.module.scss';
 export type DropdownRootProps = {
     children?: ReactNode;
     /**
-     * When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
+     * When `true`, prevents interaction with the rest of the page and restricts screen-reader access to the menu only.
      * @default false
      */
     modal?: boolean;
     /**
-     * Controls the open state of the dropdown.
+     * The controlled open state. Use together with `onOpenChange` for programmatic control.
      */
     open?: boolean;
     /**
-     * Callback that is called when the open state of the dropdown changes.
+     * Callback fired when the dropdown opens or closes.
      */
     onOpenChange?: (open: boolean) => void;
 
@@ -45,7 +45,7 @@ DropdownRoot.displayName = 'Dropdown.Root';
 
 export type DropdownTriggerProps = {
     /**
-     * Change the default rendered element for the one passed as a child, merging their props and behavior.
+     * When `true`, merges the trigger's props and behavior onto its child element instead of rendering a wrapper button.
      * @default true
      */
     asChild?: boolean;
@@ -76,36 +76,36 @@ export type DropdownContentProps = {
     children?: ReactNode;
     'data-test-id'?: string;
     /**
-     * Defines the alignment of the dropdown.
+     * Controls the horizontal alignment of the menu relative to the trigger.
      * @default "start"
      */
     align?: 'start' | 'center' | 'end';
     /**
-     * Defines the preferred side of the dropdown. It will not be respected if there are collisions with the viewport.
+     * The preferred side the menu opens on. Falls back to the opposite side if there isn't enough viewport space.
      * @default "bottom"
      */
     side?: 'top' | 'right' | 'bottom' | 'left';
     /**
-     * Defines the spacing between the dropdown and its trigger.
+     * Controls the spacing between the dropdown menu and its trigger. `'compact'` for tight layouts, `'spacious'` for breathing room.
      * @default 'compact'
      */
     triggerOffset?: DropdownSpacing;
     /**
-     * Prevents the focus from being set on the trigger when the dropdown is closed.
+     * When `true`, prevents focus from returning to the trigger when the dropdown closes. Useful when the trigger is removed from the DOM on close.
      */
     preventTriggerFocusOnClose?: boolean;
     /**
-     * Define the minimum distance between the dropdown and the viewport edge
+     * Controls the minimum distance between the menu and the viewport edge.
      * @default 'compact'
      */
     viewportCollisionPadding?: DropdownViewportCollisionPadding;
     /**
-     * When true, the content will always be mounted in the DOM. Before enabling, make sure you really need it.
+     * When `true`, the menu content stays mounted in the DOM even when closed. Use sparingly — only when unmounting causes layout issues.
      * @default false
      */
     forceMount?: boolean;
     /**
-     * Event handler called when the escape key is pressed.
+     * Callback fired when the Escape key is pressed while the menu is open.
      */
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
 };
@@ -302,24 +302,24 @@ DropdownSubContent.displayName = 'Dropdown.SubContent';
 export type DropdownItemProps = {
     children: ReactNode;
     /**
-     * Disables the item.
+     * Prevents interaction and dims the item visually.
      */
     disabled?: boolean;
     /**
-     * The text value of the item that is passed to the onSelect callback.
+     * A plain-text representation of the item's content, used for typeahead keyboard navigation.
      */
     textValue?: string;
     /**
-     * The style of the item.
+     * Controls the item's visual tone. Use `'danger'` for destructive actions like delete.
      * @default "default"
      */
     emphasis?: 'default' | 'danger';
     /**
-     * Callback that is called when the item is selected.
+     * Callback fired when the user selects this item.
      */
     onSelect?: (event: Event) => void;
     /**
-     * If true, the item props will be passed to the child element.
+     * When `true`, merges the item's props and behavior onto its child element.
      * @default false
      */
     asChild?: boolean;
@@ -396,6 +396,7 @@ const ForwardedRefDropdownSubContent = forwardRef<HTMLDivElement, DropdownSubCon
 const ForwardedRefDropdownItem = forwardRef<HTMLDivElement, DropdownItemProps>(DropdownItem);
 const ForwardedRefDropdownSlot = forwardRef<HTMLDivElement, DropdownSlotProps>(DropdownSlot);
 
+/** A menu triggered by a button — compose `Root` with `Trigger`, `Content`, `Item`, `Group`, `Slot`, `SubMenu`, `SubTrigger`, and `SubContent` sub-components. */
 export const Dropdown = {
     Root: DropdownRoot,
     Trigger: ForwardedRefDropdownTrigger,

--- a/packages/components/src/components/Flex/Flex.stories.tsx
+++ b/packages/components/src/components/Flex/Flex.stories.tsx
@@ -25,6 +25,15 @@ const meta: Meta<typeof Flex> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A one-dimensional layout container using CSS Flexbox. Arranges children along a row or column with configurable alignment, spacing, and wrapping.',
+                    '',
+                    '**When to use:** For single-axis layouts — toolbars, button groups, stacked forms. For two-dimensional layouts use `<Grid>`, for plain spacing use `<Box>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         gap: 4,

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -10,42 +10,42 @@ import styles from './styles/flex.module.scss';
 
 export type FlexProps = LayoutComponentProps & {
     /**
-     * The element to render the Flex component as.
-     * @default 'div'
+     * The HTML element to render. Use `'span'` for inline flex contexts.
+     * @default "div"
      */
     as?: 'div' | 'span';
     /**
-     * The display property.
-     * @default 'flex'
+     * Controls the display mode. `'flex'` for block-level flex, `'inline-flex'` for inline contexts, `'none'` to hide.
+     * @default "flex"
      */
     display?: Responsive<'none' | 'flex' | 'inline-flex'>;
     /**
-     * The direction of the children.
-     * @default 'row'
+     * Sets the main axis. `'row'` for horizontal, `'column'` for vertical stacking. Supports responsive values.
+     * @default "row"
      */
     direction?: Responsive<'row' | 'row-reverse' | 'column' | 'column-reverse'>;
     /**
-     * The alignment of the children.
+     * Aligns children along the cross axis. `'center'` for vertical centering in a row, `'stretch'` to fill the container height.
      */
     align?: Responsive<'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline'>;
     /**
-     * The justification of the children.
+     * Distributes children along the main axis. `'space-between'` for even spacing, `'center'` for centering.
      */
     justify?: Responsive<'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly'>;
     /**
-     * The wrap property.
+     * Controls whether children wrap to new lines. `'wrap'` for multi-line, `'nowrap'` to keep on one line.
      */
     wrap?: Responsive<'nowrap' | 'wrap' | 'wrap-reverse'>;
     /**
-     * The gap between the children.
+     * Spacing between children in both directions. Values are spacing tokens (1 = 0.25rem). Supports responsive values.
      */
     gap?: Responsive<SizeValue>;
     /**
-     * The horizontal gap between the children.
+     * Horizontal spacing between children. Overrides `gap` for the horizontal axis.
      */
     gapX?: Responsive<SizeValue>;
     /**
-     * The vertical gap between the children.
+     * Vertical spacing between children. Overrides `gap` for the vertical axis.
      */
     gapY?: Responsive<SizeValue>;
 

--- a/packages/components/src/components/Flyout/Flyout.stories.tsx
+++ b/packages/components/src/components/Flyout/Flyout.stories.tsx
@@ -28,6 +28,15 @@ const meta: Meta<typeof FlyoutContent> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A non-modal popover panel anchored to a trigger element. Displays supplementary content, forms, or actions without leaving the current context.',
+                    '',
+                    '**When to use:** For secondary interactions that don\'t warrant a full dialog — inline editing, filter panels, or preview cards. For modal interruptions use `<Dialog>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         children: 'Hello World',

--- a/packages/components/src/components/Flyout/Flyout.stories.tsx
+++ b/packages/components/src/components/Flyout/Flyout.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<typeof FlyoutContent> = {
                 component: [
                     'A non-modal popover panel anchored to a trigger element. Displays supplementary content, forms, or actions without leaving the current context.',
                     '',
-                    '**When to use:** For secondary interactions that don\'t warrant a full dialog — inline editing, filter panels, or preview cards. For modal interruptions use `<Dialog>`.',
+                    "**When to use:** For secondary interactions that don't warrant a full dialog — inline editing, filter panels, or preview cards. For modal interruptions use `<Dialog>`.",
                 ].join('\n'),
             },
         },

--- a/packages/components/src/components/Flyout/Flyout.tsx
+++ b/packages/components/src/components/Flyout/Flyout.tsx
@@ -15,17 +15,17 @@ import styles from './styles/flyout.module.scss';
 
 export type FlyoutRootProps = {
     /**
-     * Disable interaction with the rest of the page
+     * When `true`, prevents interaction with the rest of the page while the flyout is open.
      * @default false
      */
     modal?: boolean;
     /**
-     * The controlled `open` state of the flyout
+     * The controlled open state. Use together with `onOpenChange` for programmatic control.
      * @default false
      */
     open?: boolean;
     /**
-     * Event handler called when the `open` state changes
+     * Callback fired when the flyout opens or closes.
      */
     onOpenChange?: (open: boolean) => void;
     children?: ReactNode;
@@ -38,7 +38,7 @@ FlyoutRoot.displayName = 'Flyout.Root';
 
 export type FlyoutTriggerProps = {
     /**
-     * Change the default rendered element for the one passed as a child, merging their props and behavior.
+     * When `true`, merges the trigger's props and behavior onto its child element instead of rendering a wrapper button.
      * @default true
      */
     asChild?: boolean;
@@ -70,56 +70,56 @@ type FlyoutSpacing = 'compact' | 'comfortable' | 'spacious';
 type FlyoutViewportCollisionPadding = 'compact' | 'spacious';
 export type FlyoutContentProps = {
     /**
-     * Add a shadow to the flyout
+     * Controls the drop shadow. `'none'` for flat layouts, `'medium'` for standard elevation, `'large'` for prominent overlays.
      * @default "medium"
      */
     shadow?: 'none' | 'medium' | 'large';
     /**
-     * Add rounded corners to the flyout
+     * Controls the border radius. `'none'` for sharp edges, `'medium'` for standard, `'large'` for more rounded corners.
      * @default "medium"
      */
     rounded?: 'none' | 'medium' | 'large';
     /**
-     * Define the prefered side of the flyout. Can be overriden by viewport collisions viewport.
+     * The preferred side the flyout opens on. Falls back to the opposite side if there isn't enough viewport space.
      * @default "bottom"
      */
     side?: 'top' | 'right' | 'bottom' | 'left';
     /**
-     * Define the prefered alignment of the flyout. Can be overriden by viewport collisions viewport.
+     * Controls the horizontal alignment of the flyout relative to the trigger.
      * @default "start"
      */
     align?: 'start' | 'center' | 'end';
     /**
-     * Define the padding of the flyout
+     * Controls the inner padding of the flyout content.
      * @default "compact"
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     /**
-     * Define the fixed width of the flyout
+     * Sets a fixed width for the flyout. Accepts any CSS length value.
      * @default "fit-content"
      */
     width?: string;
     /**
-     * Defines the spacing between the dropdown and its trigger.
+     * Controls the spacing between the flyout and its trigger.
      * @default 'compact'
      */
     triggerOffset?: FlyoutSpacing;
     /**
-     * Define the maximum width of the flyout
+     * The maximum width of the flyout. Accepts any CSS length value.
      * @default "360px"
      */
     maxWidth?: string;
     /**
-     * Define the minimum distance between the flyout and the viewport edge
+     * Controls the minimum distance between the flyout and the viewport edge.
      * @default 'compact'
      */
     viewportCollisionPadding?: FlyoutViewportCollisionPadding;
     /**
-     * Event handler called when auto-focusing on open
+     * Callback fired when the flyout auto-focuses on open. Call `event.preventDefault()` to take manual control of focus.
      */
     onOpenAutoFocus?: (event: Event) => void;
     /**
-     * Event handler called when the escape key is pressed.
+     * Callback fired when the Escape key is pressed while the flyout is open.
      */
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
     children?: ReactNode;
@@ -206,12 +206,15 @@ FlyoutContent.displayName = 'Flyout.Content';
 
 export type FlyoutHeaderProps = {
     /**
-     * Show a close button in the header
+     * Shows a close button (x) in the header.
      * @default false
      */
     showCloseButton?: boolean;
     children?: ReactNode;
     'data-test-id'?: string;
+    /**
+     * Additional ARIA props forwarded to the close button for accessibility customization.
+     */
     closeProps?: CommonAriaProps;
 };
 
@@ -260,7 +263,7 @@ export type FlyoutBodyProps = {
     children?: ReactNode;
     'data-test-id'?: string;
     /**
-     * Allow the body to scroll if the max height of the flyout is reached
+     * When `true`, the body becomes scrollable when its content exceeds the flyout's max height.
      * @default false
      */
     scrollable?: boolean;
@@ -284,6 +287,7 @@ export const FlyoutBody = (
 };
 FlyoutBody.displayName = 'Flyout.Body';
 
+/** A popover panel — compose `Root` with `Trigger`, `Content`, `Header`, `Body`, and `Footer` sub-components. */
 export const Flyout = {
     Root: FlyoutRoot,
     Trigger: forwardRef<HTMLButtonElement, FlyoutTriggerProps>(FlyoutTrigger),

--- a/packages/components/src/components/Grid/Grid.stories.tsx
+++ b/packages/components/src/components/Grid/Grid.stories.tsx
@@ -25,6 +25,15 @@ const meta: Meta<typeof Grid> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A two-dimensional layout container using CSS Grid. Defines rows and columns for complex, responsive layouts.',
+                    '',
+                    '**When to use:** For two-dimensional layouts like card grids, dashboards, or form layouts. For single-axis layouts use `<Flex>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         columns: 'repeat(3, 1fr)',

--- a/packages/components/src/components/Grid/Grid.tsx
+++ b/packages/components/src/components/Grid/Grid.tsx
@@ -10,46 +10,45 @@ import styles from './styles/grid.module.scss';
 
 export type GridProps = LayoutComponentProps & {
     /**
-     * The element to render the Grid component as.
-     * @default 'div'
+     * The HTML element to render. Use `'span'` for inline grid contexts.
+     * @default "div"
      */
     as?: 'div' | 'span';
-
     /**
-     * The display property.
-     * @default 'grid'
+     * Controls the display mode. `'grid'` for block-level grid, `'inline-grid'` for inline contexts, `'none'` to hide.
+     * @default "grid"
      */
     display?: 'none' | 'grid' | 'inline-grid';
     /**
-     * The columns property.
+     * Defines the column template. Pass a number for equal-width columns or a CSS grid-template-columns string for custom sizing.
      */
     columns?: Responsive<string | number>;
     /**
-     * The rows property.
+     * Defines the row template. Pass a number for equal-height rows or a CSS grid-template-rows string for custom sizing.
      */
     rows?: Responsive<string | number>;
     /**
-     * The flow property.
+     * Controls the auto-placement algorithm. `'row'` fills rows first, `'column'` fills columns first, `'dense'` fills gaps.
      */
     flow?: Responsive<'row' | 'column' | 'dense' | 'row-dense' | 'column-dense'>;
     /**
-     * The alignment of the children.
+     * Aligns children along the block (vertical) axis within their grid area.
      */
     align?: Responsive<'start' | 'center' | 'end' | 'baseline' | 'stretch'>;
     /**
-     * The justification of the children.
+     * Aligns children along the inline (horizontal) axis within their grid area.
      */
     justify?: Responsive<'start' | 'center' | 'end' | 'between'>;
     /**
-     * The gap between the children.
+     * Spacing between children in both directions. Values are spacing tokens (1 = 0.25rem). Supports responsive values.
      */
     gap?: Responsive<SizeValue>;
     /**
-     * The horizontal gap between the children.
+     * Horizontal spacing between columns. Overrides `gap` for the horizontal axis.
      */
     gapX?: Responsive<SizeValue>;
     /**
-     * The vertical gap between the children.
+     * Vertical spacing between rows. Overrides `gap` for the vertical axis.
      */
     gapY?: Responsive<SizeValue>;
 

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -14,10 +14,26 @@ type TagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'p';
 
 export type HeadingProps<TTag extends TagType = 'span'> = CommonAriaProps & {
     'data-test-id'?: string;
+    /**
+     * The HTML element used to render the heading. Choose a semantic level that matches the document outline — the visual size is controlled independently via `size`.
+     * @default "span"
+     */
     as?: TTag;
     children?: ReactNode;
+    /**
+     * Controls the text color. `'default'` for primary headings, `'weak'` for secondary, `'x-weak'` for tertiary, `'disabled'` for inactive, `'interactive'` for clickable headings.
+     * @default "default"
+     */
     color?: HeadingColor;
+    /**
+     * Controls the visual size independently from the semantic HTML element. `'medium'` for section headings, `'large'` for page headings, `'x-large'` and `'xx-large'` for hero areas.
+     * @default "medium"
+     */
     size?: HeadingSize;
+    /**
+     * Controls the font weight. `'default'` for regular weight, `'strong'` for emphasized headings.
+     * @default "default"
+     */
     weight?: HeadingWeight;
     className?: string;
 };

--- a/packages/components/src/components/Label/Label.stories.tsx
+++ b/packages/components/src/components/Label/Label.stories.tsx
@@ -20,6 +20,15 @@ const meta: Meta<typeof LabelComponent> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A form field label that pairs with an input via `htmlFor`. Supports required indicators, tooltips, and optional secondary text.',
+                    '',
+                    '**When to use:** Always pair form controls (TextInput, Select, Checkbox, etc.) with a Label for accessibility.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         children: 'Label',

--- a/packages/components/src/components/Link/Link.stories.tsx
+++ b/packages/components/src/components/Link/Link.stories.tsx
@@ -14,6 +14,15 @@ const meta: Meta<LinkProps> = {
         status: {
             type: 'beta',
         },
+        docs: {
+            description: {
+                component: [
+                    'An anchor element for navigating to another page or URL. Integrates with RouterProvider for client-side routing.',
+                    '',
+                    '**When to use:** For navigation — going to a new page or URL. For triggering actions, use `<Button>` instead.',
+                ].join('\n'),
+            },
+        },
     },
     decorators: [
         (Story) => (

--- a/packages/components/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/components/src/components/LoadingBar/LoadingBar.tsx
@@ -7,36 +7,33 @@ import styles from './styles/loadingBar.module.scss';
 
 export type LoadingBarProps = {
     /**
-     * The current value of the loading bar. If `null`, the loading bar will be in an indeterminate state.
+     * The current progress value. Pass `null` for an indeterminate (unknown duration) state.
      * @default null
      */
     value: number | null;
     /**
-     * The maximum value of the loading bar
+     * The maximum value representing 100% completion.
      * @default 100
      */
     max?: number;
-    /**
-     * @default 'fondue-loading-bar'
-     */
     'data-test-id'?: string;
     /**
-     * Add rounded corners to the loading bar
+     * Adds rounded corners to the bar ends.
      * @default true
      */
     rounded?: boolean;
     /**
-     * The style of the loading bar
+     * Conveys the tone. `'default'` for neutral progress, `'positive'` for successful completion, `'negative'` for errors or warnings.
      * @default "default"
      */
     variant?: 'default' | 'positive' | 'negative';
     /**
-     * The size of the loading bar
+     * Controls the bar height. `'small'` for inline indicators, `'medium'` for standard use, `'large'` and `'x-large'` for prominent displays.
      * @default "medium"
      */
     size?: 'small' | 'medium' | 'large' | 'x-large';
     /**
-     * The label of the loading bar for accessibility purposes
+     * Custom function to generate an accessible value label. Receives the current value and max, returns a string like "42 of 100 files uploaded."
      */
     getValueLabel?: (value: number, max: number) => string;
 } & ({ 'aria-label': string } | { 'aria-labelledby': string });

--- a/packages/components/src/components/LoadingCircle/LoadingCircle.tsx
+++ b/packages/components/src/components/LoadingCircle/LoadingCircle.tsx
@@ -6,12 +6,12 @@ import styles from './styles/loadingCircleStyles.module.scss';
 
 export type LoadingCircleProps = {
     /**
-     * The  variant of the loading circle.
-     * @default 'progress'
+     * Controls the visual state. `'progress'` for an active spinner, `'success'` for a completed state, `'danger'` for a failed state.
+     * @default "progress"
      */
     variant?: 'progress' | 'success' | 'danger';
     /**
-     * The size of the loading circle
+     * Controls the spinner size. `'xx-small'` for inline indicators, `'medium'` for standard loading states, `'large'` for full-page spinners.
      * @default "medium"
      */
     size?: 'xx-small' | 'x-small' | 'small' | 'medium' | 'large';

--- a/packages/components/src/components/Notice/Notice.stories.tsx
+++ b/packages/components/src/components/Notice/Notice.stories.tsx
@@ -23,6 +23,15 @@ const meta: Meta<typeof Notice> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A persistent, inline message that communicates important information, status updates, or actions. Stays visible until dismissed, keeping users informed without interrupting their workflow.',
+                    '',
+                    '**When to use:** To surface contextual feedback, warnings, or success confirmations inline — not for transient toast-style notifications.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         variant: 'default',

--- a/packages/components/src/components/Notice/Notice.tsx
+++ b/packages/components/src/components/Notice/Notice.tsx
@@ -15,43 +15,40 @@ type NoticeSize = 'medium' | 'large';
 
 export type NoticeProps = {
     /**
+     * Conveys the tone. `'default'` for neutral messages, `'highlight'` for noteworthy information, `'positive'` for success, `'warning'` for caution, `'danger'` for critical errors — use sparingly.
      * @default 'default'
      */
     variant?: NoticeVariant;
     /**
+     * Controls visual weight. `'default'` for standard messages, `'strong'` for critical or high-priority information, `'weak'` for subtle, non-urgent messages.
      * @default 'default'
      */
     emphasis?: NoticeEmphasis;
     /**
+     * Controls the notice size. `'medium'` for standard use, `'large'` for more prominent messages.
      * @default 'medium'
      */
     size?: NoticeSize;
     /**
-     * Leading icon element
+     * Leading icon element to enhance recognizability and convey the notice's function at a glance.
      */
     icon?: ReactNode;
     /**
-     * Action element (typically a button)
+     * Action element (typically a Button). Use when there's a clear, lightweight action related to the message content.
      */
     action?: ReactNode;
     /**
-     * Callback when the dismiss button is clicked
+     * Callback when the dismiss button is clicked. When provided, a close icon is displayed allowing users to remove the message.
      */
     onDismiss?: (event?: MouseEvent<HTMLButtonElement>) => void;
     /**
-     * Custom aria-label for the dismiss button
+     * Custom accessible label for the dismiss button. Overrides the default "Dismiss" text.
      */
     'aria-label'?: string;
-    /**
-     * Test ID for the component
-     */
     'data-test-id'?: string;
-    /**
-     * Additional CSS class
-     */
     className?: string;
     /**
-     * Message content
+     * The message content — text, links, or formatted content describing the notice.
      */
     children: ReactNode;
 };

--- a/packages/components/src/components/RadioList/RadioList.stories.tsx
+++ b/packages/components/src/components/RadioList/RadioList.stories.tsx
@@ -19,6 +19,15 @@ const meta: Meta<typeof RadioListRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A list of mutually exclusive radio options. Only one option can be selected at a time.',
+                    '',
+                    '**When to use:** When users must choose exactly one option from a visible list. For 2–4 compact options, consider `<SegmentedControl>` instead. For dropdowns, use `<Select>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         disabled: false,

--- a/packages/components/src/components/RadioList/RadioList.tsx
+++ b/packages/components/src/components/RadioList/RadioList.tsx
@@ -8,15 +8,48 @@ import { useFondueTheme } from '#/components/ThemeProvider/ThemeProvider';
 import styles from './styles/radiolist.module.scss';
 
 type RadioListRootProps = {
+    /**
+     * Merge props onto the child element instead of rendering a wrapper.
+     * @default false
+     */
     asChild?: boolean;
+    /**
+     * Should contain `RadioList.RadioButton` components paired with labels.
+     */
     children?: ReactNode;
     className?: string;
+    /**
+     * Prevents interaction with all radio buttons in the group.
+     * @default false
+     */
     disabled?: boolean;
+    /**
+     * Controls the visual style. `'default'` for standard radio buttons, `'highlight'` for a more prominent selected state.
+     * @default "default"
+     */
     emphasis?: 'default' | 'highlight';
+    /**
+     * Callback fired when the selected value changes.
+     * @param value - The value of the newly selected radio button
+     */
     onValueChange?: (value: string) => void;
+    /**
+     * Controls the layout direction. `'vertical'` stacks options top-to-bottom, `'horizontal'` places them side by side.
+     */
     orientation?: 'vertical' | 'horizontal';
+    /**
+     * When `true`, the radio group is visually interactive but cannot be changed. Useful for displaying a locked selection.
+     * @default false
+     */
     readOnly?: boolean;
+    /**
+     * Marks the radio group as required in a form context.
+     * @default false
+     */
     required?: boolean;
+    /**
+     * The controlled selected value. Use together with `onValueChange`.
+     */
     value?: string;
     'data-test-id'?: string;
 };
@@ -103,6 +136,10 @@ const RadioListRadioButton = ({
 };
 RadioListRadioButton.displayName = 'RadioList.RadioButton';
 
+/**
+ * A group of mutually exclusive radio options — only one can be selected at a time.
+ * Use `RadioList.Root` as the container and `RadioList.RadioButton` for each option.
+ */
 export const RadioList = {
     Root: RadioListRoot,
     RadioButton: RadioListRadioButton,

--- a/packages/components/src/components/RouterProvider/RouterProvider.tsx
+++ b/packages/components/src/components/RouterProvider/RouterProvider.tsx
@@ -5,11 +5,13 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react';
 export type RouterProviderProps = {
     children: ReactNode;
     /**
-     * Function to navigate to a specific path
+     * Navigation function called when a `<Link>` is clicked. Wire this to your router's push/navigate method.
+     * @param path - The destination path
      */
     navigate: (path: string) => void;
     /**
-     * Function to resolves a URL against the current location.
+     * Resolves a path into a full URL. Wire this to your router's href resolution logic.
+     * @param path - The path to resolve
      */
     useHref: (path: string) => string;
 };

--- a/packages/components/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -13,6 +13,15 @@ const meta: Meta<typeof ScrollArea> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A scrollable container with styled scrollbars and optional shadow indicators. Provides consistent scroll behavior across browsers.',
+                    '',
+                    '**When to use:** When content may overflow a fixed-height or fixed-width container — such as sidebar panels, dropdown lists, or modal bodies.',
+                ].join('\n'),
+            },
+        },
     },
     args: {},
 };

--- a/packages/components/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.tsx
@@ -9,35 +9,33 @@ import styles from './styles/scrollArea.module.scss';
 
 export type ScrollAreaProps = {
     /**
-     * "auto" visible when content is overflowing on the corresponding orientation.
-     * "always" always visible regardless of whether the content is overflowing. Sets the scrollbar gutter to stable.
-     * "scroll" visible when the user is scrolling along its corresponding orientation.
-     * "hover" when the user is hovering over the scroll area.
-     * @default 'hover'
+     * Controls scrollbar visibility. `'hover'` shows on mouse-over, `'scroll'` shows while scrolling, `'auto'` shows when content overflows, `'always'` keeps scrollbars permanently visible.
+     * @default "hover"
      */
     type?: 'auto' | 'always' | 'scroll' | 'hover';
     /**
-     * Determines if the scrollbar should take up space in the content area
-     * @default 'auto'
+     * Controls whether scrollbars reserve space in the layout. `'stable'` prevents content shift when scrollbars appear, `'auto'` lets the browser decide.
+     * @default "auto"
      */
     scrollbarGutter?: 'auto' | 'stable' | 'stable-horizontal' | 'stable-vertical';
     /**
-     * Maximum height of the scroll area
-     * @default '100%'
+     * Maximum height before vertical scrolling activates. Accepts CSS values or numbers (pixels).
+     * @default "100%"
      */
     maxHeight?: string | number;
     /**
-     * Minimum width of the scroll area
-     * @default '100%'
+     * Maximum width before horizontal scrolling activates. Accepts CSS values or numbers (pixels).
+     * @default "100%"
      */
     maxWidth?: string | number;
     /**
-     * Define the padding of the scroll area
+     * Controls the inner padding of the scroll area. `'compact'` for most use cases, `'spacious'` for breathing room.
      * @default "compact"
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     /**
-     * Determines if a inset shadow should be shown the edge of the component
+     * Shows an inset shadow at the scroll edges to indicate more content is available.
+     * @default false
      */
     showShadow?: boolean;
     'data-test-id'?: string;

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -21,6 +21,15 @@ const meta: Meta<typeof SegmentedControlRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A compact, horizontal toggle group for switching between 2–4 mutually exclusive options. Behaves like radio buttons with a tab-like appearance.',
+                    '',
+                    '**When to use:** For view-mode toggles, layout switchers, or small option sets where all choices should be visible at once. For longer lists, use `<RadioList>` or `<Select>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         defaultValue: 'first',

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -9,27 +9,30 @@ import styles from './styles/segmentedControl.module.scss';
 
 export type SegmentedControlRootProps<TValue extends string = string> = {
     id?: string;
+    /**
+     * Should contain `SegmentedControl.Item` components.
+     */
     children: ReactNode;
     /**
-     * The default value of the segmented control
-     * Used for uncontrolled components
+     * The initially selected value for uncontrolled usage.
      */
     defaultValue?: TValue;
     /**
-     * The controlled value of the segmented control
+     * The controlled selected value. Use together with `onValueChange`.
      */
     value?: TValue;
     /**
-     * Event handler called when the value changes
+     * Callback fired when the selected option changes.
+     * @param value - The value of the newly selected item
      */
     onValueChange?: (value: TValue) => void;
     /**
-     * Disable the segmented control
+     * Prevents interaction with the entire control.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Specify if the segmented control should only take the width of its content
+     * When `true`, the control sizes to fit its content. When `false`, it expands to fill its container width.
      * @default true
      */
     hugWidth?: boolean;
@@ -77,7 +80,13 @@ export const SegmentedControlRoot = <TValue extends string = string>(
 SegmentedControlRoot.displayName = 'SegmentedControl.Root';
 
 type SegmentedControlItemProps = {
+    /**
+     * The label content displayed inside the segment — text, an icon, or both.
+     */
     children: ReactNode;
+    /**
+     * A unique value that identifies this option. Passed to `onValueChange` when selected.
+     */
     value: string;
 };
 
@@ -99,6 +108,10 @@ export const SegmentedControlItem = (
 );
 SegmentedControlItem.displayName = 'SegmentedControl.Item';
 
+/**
+ * A compact, horizontal toggle group for switching between 2–4 mutually exclusive options.
+ * Use `SegmentedControl.Root` as the container and `SegmentedControl.Item` for each option.
+ */
 export const SegmentedControl = {
     Root: forwardRef(SegmentedControlRoot) as <TValue extends string = string>(
         props: SegmentedControlRootProps<TValue> & { ref?: ForwardedRef<HTMLDivElement> },

--- a/packages/components/src/components/Select/ComboboxMultiple.tsx
+++ b/packages/components/src/components/Select/ComboboxMultiple.tsx
@@ -7,15 +7,20 @@ import { useMultiselect } from './hooks/useMultiselect';
 
 export type ComboboxMultipleProps = ComboboxSharedProps & {
     /**
-     * The active value in the combobox component. This is used to control the combobox externally
+     * The controlled selected values. Use together with `onSelect` for controlled usage.
+     * Pass `null` to clear all selections.
      */
     value?: string[] | null;
     /**
-     * Callback function that is called when items are selected
+     * Callback fired when the selection changes.
+     * Receives the full array of selected `value` strings, or `null` when all are cleared.
+     *
+     * @param selectedValues - The values of all selected items, or `null`.
      */
     onSelect?: (selectedValues: string[] | null) => void;
     /**
-     * The default value of the combobox component. Used for uncontrolled usages
+     * The initial selected values for uncontrolled usage.
+     * The component manages its own state internally.
      */
     defaultValue?: string[];
 };

--- a/packages/components/src/components/Select/ComboboxSingle.tsx
+++ b/packages/components/src/components/Select/ComboboxSingle.tsx
@@ -7,15 +7,20 @@ import { useSingleSelect } from './hooks/useSingleSelect';
 
 export type ComboboxSingleProps = ComboboxSharedProps & {
     /**
-     * The active value in the combobox component. This is used to control the combobox externally
+     * The controlled selected value. Use together with `onSelect` for controlled usage.
+     * Pass `null` to clear the selection.
      */
     value?: string | null;
     /**
-     * Callback function that is called when an item is selected
+     * Callback fired when the user picks or clears an option.
+     * Receives the selected item's `value` string, or `null` when cleared.
+     *
+     * @param selectedValue - The value of the selected item, or `null`.
      */
     onSelect?: (selectedValue: string | null) => void;
     /**
-     * The default value of the combobox component. Used for uncontrolled usages
+     * The initial selected value for uncontrolled usage.
+     * The component manages its own state internally.
      */
     defaultValue?: string;
 };

--- a/packages/components/src/components/Select/SelectMultiple.tsx
+++ b/packages/components/src/components/Select/SelectMultiple.tsx
@@ -7,15 +7,20 @@ import { useMultiselect } from './hooks/useMultiselect';
 
 export type SelectMultipleProps = SelectSharedProps & {
     /**
-     * The active value in the select component. This is used to control the select externally
+     * The controlled selected values. Use together with `onSelect` for controlled usage.
+     * Pass `null` to clear all selections.
      */
     value?: string[] | null;
     /**
-     * Callback function that is called when items are selected
+     * Callback fired when the selection changes.
+     * Receives the full array of selected `value` strings, or `null` when all are cleared.
+     *
+     * @param selectedValues - The values of all selected items, or `null`.
      */
     onSelect?: (selectedValues: string[] | null) => void;
     /**
-     * The default value of the select component. Used for uncontrolled usages
+     * The initial selected values for uncontrolled usage.
+     * The component manages its own state internally.
      */
     defaultValue?: string[];
 };

--- a/packages/components/src/components/Select/SelectSingle.tsx
+++ b/packages/components/src/components/Select/SelectSingle.tsx
@@ -7,15 +7,20 @@ import { useSingleSelect } from './hooks/useSingleSelect';
 
 export type SelectSingleProps = SelectSharedProps & {
     /**
-     * The active value in the select component. This is used to control the select externally
+     * The controlled selected value. Use together with `onSelect` for controlled usage.
+     * Pass `null` to clear the selection.
      */
     value?: string | null;
     /**
-     * Callback function that is called when an item is selected
+     * Callback fired when the user picks or clears an option.
+     * Receives the selected item's `value` string, or `null` when cleared.
+     *
+     * @param selectedValue - The value of the selected item, or `null`.
      */
     onSelect?: (selectedValue: string | null) => void;
     /**
-     * The default value of the select component. Used for uncontrolled usages
+     * The initial selected value for uncontrolled usage.
+     * The component manages its own state internally.
      */
     defaultValue?: string;
 };

--- a/packages/components/src/components/Select/components/ComboboxBase.tsx
+++ b/packages/components/src/components/Select/components/ComboboxBase.tsx
@@ -38,51 +38,57 @@ type SelectItem = {
 
 export type ComboboxSharedProps = {
     /**
-     * Children of the Combobox component. This can contain the `Select.Slot` components for the label, decorators, clear action and menu
+     * The combobox content. Use `Select.Item` for options, `Select.Group` for grouped options,
+     * and `Select.Slot` for decorators, clear actions, or custom menu content.
      */
     children?: ReactNode;
     /**
-     * The placeholder in the combobox component
+     * Text shown when no value is selected.
+     * Use it to hint at the expected choice — e.g., "Search languages\u2026"
      */
     placeholder?: string;
     /**
-     * Status of the text input
+     * Conveys validation state. `'neutral'` for default, `'success'` for valid input,
+     * `'error'` for invalid input.
+     *
      * @default "neutral"
      */
     status?: 'neutral' | 'success' | 'error';
     /**
-     * Disables the combobox component
+     * Prevents interaction and dims the combobox visually.
+     *
+     * @default false
      */
     disabled?: boolean;
     /**
-     * The alignment of the menu
+     * Controls the horizontal alignment of the dropdown menu relative to the trigger.
+     *
      * @default "start"
      */
     alignMenu?: 'start' | 'center' | 'end';
     /**
-     * Defines the preferred side of the combobox. It will not be respected if there are collisions with the viewport
+     * The preferred side the dropdown opens on.
+     * Falls back to the opposite side if there isn't enough viewport space.
+     *
      * @default "bottom"
      */
     side?: 'left' | 'right' | 'bottom' | 'top';
-    /**
-     * Id of the combobox component
-     */
     id?: string;
-    /**
-     * The data test id of the combobox component
-     */
     'data-test-id'?: string;
     /**
-     * Define the minimum distance between the select menu and the viewport edge
-     * @default 'compact'
+     * Controls the minimum distance between the dropdown menu and the viewport edge.
+     * `'compact'` keeps it tight, `'spacious'` adds breathing room.
+     *
+     * @default "compact"
      */
     viewportCollisionPadding?: SelectMenuViewportCollisionPadding;
     /**
-     * Function to fetch items asynchronously
+     * Async function that fetches items based on the user's typed filter text.
+     * Use this for server-side search or large datasets that shouldn't be loaded upfront.
      */
     getAsyncItems?: AsyncItemsFetcher;
     /**
-     * Event handler called when the escape key is pressed
+     * Callback fired when the Escape key is pressed while the menu is open.
      */
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
 } & CommonAriaProps;
@@ -203,43 +209,30 @@ const ComboboxBaseInput = (
             setHasInteractedSinceOpening(true);
         },
         itemToString: (item) => (item ? item.label : ''),
-        stateReducer: (state, actionAndChanges) => {
-            const { changes, type } = actionAndChanges;
-            if (multiple) {
-                switch (type) {
-                    case useCombobox.stateChangeTypes.InputKeyDownEnter:
-                    case useCombobox.stateChangeTypes.ItemClick:
-                        return {
-                            ...changes,
-                            isOpen: true,
-                            highlightedIndex: state.highlightedIndex,
-                            inputValue: '',
-                        };
-                    case useCombobox.stateChangeTypes.InputBlur:
-                        // Select item on blur (Tab key) but clear the input
-                        return {
-                            ...changes,
-                            inputValue: '',
-                        };
-                }
-            } else {
-                // For single select, handle re-selection of the same item
-                // onSelectedItemChange doesn't fire when selecting the same item, so we call onItemSelect here
-                switch (type) {
-                    case useCombobox.stateChangeTypes.InputKeyDownEnter:
-                    case useCombobox.stateChangeTypes.ItemClick:
-                        if (
-                            changes.selectedItem &&
-                            state.selectedItem &&
-                            changes.selectedItem.value === state.selectedItem.value
-                        ) {
-                            onItemSelect(changes.selectedItem.value);
-                        }
-                        break;
-                }
-            }
-            return changes;
-        },
+        ...(multiple
+            ? {
+                  stateReducer: (state, actionAndChanges) => {
+                      const { changes, type } = actionAndChanges;
+                      switch (type) {
+                          case useCombobox.stateChangeTypes.InputKeyDownEnter:
+                          case useCombobox.stateChangeTypes.ItemClick:
+                              return {
+                                  ...changes,
+                                  isOpen: true,
+                                  highlightedIndex: state.highlightedIndex,
+                                  inputValue: '',
+                              };
+                          case useCombobox.stateChangeTypes.InputBlur:
+                              // Select item on blur (Tab key) but clear the input
+                              return {
+                                  ...changes,
+                                  inputValue: '',
+                              };
+                      }
+                      return changes;
+                  },
+              }
+            : {}),
     });
 
     const valueInvalid = useMemo(() => {

--- a/packages/components/src/components/Select/components/SelectBase.tsx
+++ b/packages/components/src/components/Select/components/SelectBase.tsx
@@ -20,53 +20,59 @@ import { StatusIcons } from './StatusIcons';
 
 export type SelectSharedProps = {
     /**
-     * Children of the Select component. This can contain the `Select.Slot` components for the label, decorators, clear action and menu
+     * The select content. Use `Select.Item` for options, `Select.Group` for grouped options,
+     * and `Select.Slot` for decorators, clear actions, or custom menu content.
      */
     children?: ReactNode;
     /**
-     * The placeholder in the select component
+     * Text shown when no value is selected.
+     * Use it to hint at the expected choice — e.g., "Choose a language."
      */
     placeholder?: string;
     /**
-     * Status of the text input
+     * Conveys validation state. `'neutral'` for default, `'success'` for valid input,
+     * `'error'` for invalid input.
+     *
      * @default "neutral"
      */
     status?: 'neutral' | 'success' | 'error';
     /**
-     * Disables the select component
+     * Prevents interaction and dims the select visually.
+     *
+     * @default false
      */
     disabled?: boolean;
     /**
-     * The alignment of the menu
+     * Controls the horizontal alignment of the dropdown menu relative to the trigger.
+     *
      * @default "start"
      */
     alignMenu?: 'start' | 'center' | 'end';
     /**
-     * Defines the preferred side of the select. It will not be respected if there are collisions with the viewport
+     * The preferred side the dropdown opens on.
+     * Falls back to the opposite side if there isn't enough viewport space.
+     *
      * @default "bottom"
      */
     side?: 'left' | 'right' | 'bottom' | 'top';
-    /**
-     * The data test id of the select component
-     */
     'data-test-id'?: string;
-    /**
-     * Id of the select component
-     */
     id?: string;
     /**
-     * The value of the select is shown as plain text (from the label prop) when set to true
-     * Items child components are used if set to false
+     * When `true`, shows the selected item's `label` as plain text.
+     * When `false`, renders the item's `children` instead — useful for rich content like icons or badges.
+     *
      * @default true
      */
     showStringValue?: boolean;
     /**
-     * Define the minimum distance between the select menu and the viewport edge
-     * @default 'compact'
+     * Controls the minimum distance between the dropdown menu and the viewport edge.
+     * `'compact'` keeps it tight, `'spacious'` adds breathing room.
+     *
+     * @default "compact"
      */
     viewportCollisionPadding?: SelectMenuViewportCollisionPadding;
     /**
-     * Event handler called when the escape key is pressed
+     * Callback fired when the Escape key is pressed while the menu is open.
      */
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
 } & CommonAriaProps;

--- a/packages/components/src/components/Select/components/SelectItem.tsx
+++ b/packages/components/src/components/Select/components/SelectItem.tsx
@@ -7,26 +7,30 @@ import styles from '../styles/select.module.scss';
 
 export type SelectItemProps = {
     /**
-     * The value of the select item.
+     * A unique string that identifies this option.
+     * This is the value passed to `onSelect` when the user picks this item.
      */
     value: string;
-    /**
-     * The data test id of the select item.
-     */
     'data-test-id'?: string;
 } & (
     | {
           /**
-           * The label of the select item. Required when the child is not a string.
+           * The plain-text label for this option. Required when `children` is a custom component
+           * so the select can display and filter by text.
            */
           label: string;
           /**
-           * The children of the select item. This can be a custom component or a string.
+           * Custom content rendered inside the option.
+           * When omitted, the `label` text is displayed instead.
            */
           children?: ReactNode;
       }
     | {
           label?: string;
+          /**
+           * The text content for this option. When passed as a string,
+           * it doubles as both the label and the display content.
+           */
           children: string;
       }
 );
@@ -48,20 +52,17 @@ export const ForwardedRefSelectItem = forwardRef<HTMLLIElement, SelectItemProps>
 
 export type SelectItemGroupProps = {
     /**
-     * The children of the select item group. This can contain multiple `Select.Item` components.
+     * The group's options. Nest `Select.Item` components here.
      */
     children: ReactNode;
     /**
-     * The internal group ID of the select item group.
+     * A unique identifier for this group, used internally to track option membership.
      */
     groupId: string;
     /**
-     * The groups heading
+     * An optional visible heading displayed above the group's options — e.g., "Recently used."
      */
     heading?: string;
-    /**
-     * The data test id of the select item group.
-     */
     'data-test-id'?: string;
 };
 

--- a/packages/components/src/components/Select/components/SelectSlot.tsx
+++ b/packages/components/src/components/Select/components/SelectSlot.tsx
@@ -6,16 +6,14 @@ import styles from '../styles/select.module.scss';
 
 export type SelectSlotProps = {
     /**
-     * The children of the select slot. This can be a custom component.
+     * The content to render in this slot — typically an icon, badge, or custom action.
      */
     children?: ReactNode;
     /**
-     * The slot name that is used to determine the placement.
+     * Controls where the slot content appears. `'left'` and `'right'` sit beside the selected value,
+     * `'clear'` renders a clear action, `'menu'` adds custom content at the bottom of the dropdown.
      */
     name: 'menu' | 'left' | 'right' | 'clear';
-    /**
-     * The data test id of the select slot.
-     */
     'data-test-id'?: string;
 };
 

--- a/packages/components/src/components/Slider/Slider.stories.tsx
+++ b/packages/components/src/components/Slider/Slider.stories.tsx
@@ -18,6 +18,15 @@ const meta: Meta<typeof Slider> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A draggable range input for selecting a numeric value or range within a defined minimum and maximum. Supports single and multi-thumb configurations.',
+                    '',
+                    '**When to use:** For continuous numeric values where the exact number matters less than the relative position — volume, opacity, price ranges.',
+                ].join('\n'),
+            },
+        },
     },
     argTypes: {
         defaultValue: {

--- a/packages/components/src/components/Slider/Slider.tsx
+++ b/packages/components/src/components/Slider/Slider.tsx
@@ -11,42 +11,48 @@ export type SliderProps = {
     id?: string;
     name?: string;
     /**
-     * The default value of the slider
-     * Used for uncontrolled components
+     * The initial value for uncontrolled usage. Pass an array with one number for a single thumb, or two numbers for a range.
      * @default [0]
      */
     defaultValue?: number[];
     /**
-     * The controlled value of the slider
-     * @default [0]
+     * The controlled value. Use together with `onChange`. Pass an array with one number for a single thumb, or two numbers for a range.
      */
     value?: number[];
     /**
-     * Minimum value of the slider
+     * The minimum selectable value.
      * @default 0
      */
     min?: number;
     /**
-     * Maximum value of the slider
+     * The maximum selectable value.
      * @default 100
      */
     max?: number;
     /**
-     * The granularity with which the slider can step through values
+     * The granularity of allowed values. For example, `step={5}` snaps to multiples of 5.
      * @default 1
      */
     step?: number;
     /**
-     * The minimum steps between thumbs in a range slider
+     * The minimum distance between thumbs in a range slider, measured in steps. Prevents thumbs from overlapping.
      * @default 0
      */
     minStepsBetweenThumbs?: number;
     /**
-     * Disable the slider
+     * Prevents interaction and dims the slider visually.
      * @default false
      */
     disabled?: boolean;
+    /**
+     * Callback fired continuously as the thumb is dragged. Use for live previews.
+     * @param value - The current slider value(s)
+     */
     onChange?: (value: number[]) => void;
+    /**
+     * Callback fired when the thumb is released. Use for committing the final value (e.g., saving to state or API).
+     * @param value - The committed slider value(s)
+     */
     onCommit?: (value: number[]) => void;
     'data-test-id'?: string;
 } & CommonAriaAttrs;

--- a/packages/components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.stories.tsx
@@ -22,6 +22,19 @@ const meta: Meta<typeof SplitButtonRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'Combines a primary action with a dropdown of related options. Clicking the lead button triggers the default action, while the trailing button opens a dropdown with additional choices.',
+                    '',
+                    '**When to use:** When an action has related alternatives that can be grouped together without crowding the interface.',
+                    '',
+                    "**Leading icon:** An icon can enhance recognizability and convey the button's function more intuitively.",
+                    '',
+                    '**Dropdown trigger:** The trailing button should only use the caret or vertical dots icon. Split buttons are designed only to trigger dropdown menus — no other behaviors should be attached.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         emphasis: 'strong',

--- a/packages/components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.tsx
@@ -10,14 +10,17 @@ type ButtonEmphasis = 'default' | 'weak' | 'strong';
 
 export type SplitButtonProps = {
     /**
+     * Controls the visual prominence. `'default'` for standard actions, `'weak'` for secondary options, `'strong'` for primary calls to action.
      * @default 'default'
      */
     emphasis?: ButtonEmphasis;
     /**
+     * Controls the button size. `'small'` for toolbars, `'medium'` for most layouts, `'large'` for prominent actions.
      * @default 'medium'
      */
     size?: ButtonSize;
     /**
+     * Prevents interaction and dims the entire button group visually.
      * @default false
      */
     disabled?: boolean;
@@ -34,17 +37,17 @@ export type SplitButtonProps = {
 
 export type SplitButtonContentProps = {
     /**
-     * Button type
+     * The HTML button type. Use `'submit'` inside forms, `'button'` (default) everywhere else.
      * @default 'button'
      */
     type?: 'button' | 'submit' | 'reset';
     /**
-     * Whether the button is disabled
+     * Prevents interaction with the primary button independently of the root `disabled` state.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Click handler
+     * Callback fired when the primary button is clicked.
      */
     onPress?: (event?: MouseEvent<HTMLButtonElement>) => void;
     /**
@@ -60,7 +63,7 @@ export type SplitButtonContentProps = {
      */
     'data-test-id'?: string;
     /**
-     * Button title
+     * Tooltip text shown on hover.
      */
     title?: string;
     children: ReactNode;
@@ -76,7 +79,7 @@ export type SplitButtonActionProps = {
      */
     'data-test-id'?: string;
     /**
-     * Whether to rotate the icon 180 degrees when active (typically for caret icons)
+     * When `true`, rotates the child icon 180° when the action is active — typically used with a caret icon to indicate an open dropdown.
      * @default true
      */
     rotateIcon?: boolean;
@@ -85,12 +88,12 @@ export type SplitButtonActionProps = {
 
 export type SplitButtonActionButtonProps = {
     /**
-     * Button type
+     * The HTML button type. Use `'submit'` inside forms, `'button'` (default) everywhere else.
      * @default 'button'
      */
     type?: 'button' | 'submit' | 'reset';
     /**
-     * Whether the button is disabled
+     * Prevents interaction with the action button independently of the root `disabled` state.
      * @default false
      */
     disabled?: boolean;
@@ -107,7 +110,7 @@ export type SplitButtonActionButtonProps = {
      */
     'data-test-id'?: string;
     /**
-     * Button title
+     * Tooltip text shown on hover.
      */
     title?: string;
     children: ReactNode;
@@ -224,6 +227,7 @@ export const SplitButtonActionButton = forwardRef<HTMLButtonElement, SplitButton
 );
 SplitButtonActionButton.displayName = 'SplitButton.ActionButton';
 
+/** A two-part button — compose `Root` with a primary `Content` button and a secondary `Action` with an `ActionButton` trigger. */
 export const SplitButton = {
     Root: SplitButtonRoot,
     Content: SplitButtonContent,

--- a/packages/components/src/components/Switch/Switch.stories.tsx
+++ b/packages/components/src/components/Switch/Switch.stories.tsx
@@ -19,6 +19,17 @@ const meta: Meta<typeof Switch> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A toggle control for binary on/off settings. Applies the change immediately without requiring a form submission.',
+                    '',
+                    '**When to use:** For instant-effect settings like "Enable notifications" or "Dark mode." For choices that require confirmation, use a Checkbox with a submit button instead.',
+                    '',
+                    '**Label:** Always pair with a `<Label>` for accessibility. Place the label to the left of the switch.',
+                ].join('\n'),
+            },
+        },
     },
     argTypes: {
         size: {

--- a/packages/components/src/components/Switch/Switch.tsx
+++ b/packages/components/src/components/Switch/Switch.tsx
@@ -12,43 +12,41 @@ type SwitchProps = {
     id?: string;
     name?: string;
     /**
-     * The size of the switch component.
-     * @default medium
+     * Controls the switch size. `'small'` for tight spaces, `'medium'` for most layouts, `'large'` for prominent toggles.
+     * @default "medium"
      */
     size?: 'small' | 'medium' | 'large';
     /**
-     * The active value in the select component. This is used to control the select externally.
+     * The controlled checked state of the switch. Use together with `onChange` for controlled usage.
      * @default false
      */
     value?: boolean;
     /**
-     * The default value of the select component. Used for uncontrolled usages.
+     * The initial checked state for uncontrolled usage.
      * @default false
      */
     defaultValue?: boolean;
     /**
-     * Disables the select component.
+     * Prevents interaction and dims the switch visually.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Whether the switch is required.
+     * Marks the switch as required in a form context.
      * @default false
      */
     required?: boolean;
     /**
-     * Callback function that is called when the switch is toggled.
-     * @param checked - The new checked state of the switch
+     * Callback fired when the switch is toggled.
+     * @param checked - The new checked state
      */
     onChange?: (checked: boolean) => void;
     /**
-     * Event handler called when the checkbox is blurred
-     * @param event - The event object
+     * Event handler called when the switch loses focus.
      */
     onBlur?: (event: FormEvent<HTMLButtonElement>) => void;
     /**
-     * Event handler called when the checkbox is focused
-     * @param event - The event object
+     * Event handler called when the switch receives focus.
      */
     onFocus?: (event: FormEvent<HTMLButtonElement>) => void;
     'data-test-id'?: string;

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -29,6 +29,15 @@ const meta: Meta<typeof TableRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A structured data table with header, body, rows, and cells. Supports sorting indicators, row selection, and inline actions.',
+                    '',
+                    '**When to use:** For displaying tabular data that users scan, compare, or act on — user lists, asset inventories, permission matrices.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         'aria-label': 'User Management Table',

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -28,13 +28,13 @@ import { handleKeyDown, shouldIgnoreRowClick } from './utils';
 
 type TableRootProps = {
     /**
-     * Whether the table should have a fixed or auto layout
+     * Controls how column widths are calculated. `'auto'` sizes columns to fit their content, `'fixed'` distributes width evenly for predictable layouts.
      * @default 'auto'
      */
     layout?: 'auto' | 'fixed';
     /**
-     * Font size of the table content
-     * @default 'small'
+     * Controls the text size of table content. `'small'` for dense data tables, `'medium'` for standard readability.
+     * @default 'medium'
      */
     fontSize?: 'small' | 'medium';
     /**
@@ -56,7 +56,7 @@ type TableRootProps = {
      */
     sticky?: 'head' | 'col' | 'both';
     /**
-     * Whether to remove the top and bottom borders from the table
+     * Removes the top and bottom borders. Useful when the table sits inside a container that already provides visual separation.
      * @default false
      */
     noBorder?: boolean;
@@ -141,7 +141,7 @@ TableCaption.displayName = 'Table.Caption';
 
 type TableHeaderProps = {
     /**
-     * Whether the header should stick to the top when scrolling
+     * Pins the header row to the top of the scroll container so column labels remain visible while scrolling.
      * @default false
      */
     sticky?: boolean;
@@ -171,15 +171,15 @@ type TableHeaderCellProps = {
      */
     scope?: HTMLTableCellElement['scope'];
     /**
-     * Number of columns the cell should span
+     * The number of columns this header cell spans. Use for grouped column headers.
      */
     colSpan?: HTMLTableCellElement['colSpan'];
     /**
-     * Width of the column
+     * Sets a fixed column width. Accepts any CSS length value (e.g., `'200px'`, `'25%'`).
      */
     width?: CSSProperties['width'];
     /**
-     * Current sort direction of the column
+     * The current sort state of this column. Pass `'ascending'` or `'descending'` to show the active sort indicator, or `undefined` for unsorted.
      */
     sortDirection?: SortDirection;
     /**
@@ -193,7 +193,7 @@ type TableHeaderCellProps = {
      */
     truncate?: boolean;
     /**
-     * Aria label for ascending/descending sort. Variables: {column} - column name
+     * Custom labels for the sort button's accessible text. Use `{column}` as a placeholder for the column name.
      * @default "Sort by {column} ascending/descending"
      */
     sortTranslations?: {
@@ -201,22 +201,21 @@ type TableHeaderCellProps = {
         sortDescending?: string;
     };
     /**
-     * Whether the column should have a minimum width
+     * Prevents the column from shrinking below its content width. Useful for action columns or fixed-width cells.
      * @default false
      */
     noShrink?: boolean;
     /**
-     * State of the cell, used for displaying loading state
+     * Controls the cell's visual state. Set to `'loading'` to show a spinner alongside the header text.
      * @default 'idle'
      */
     state?: 'idle' | 'loading';
     /**
-     * The aria-label to be applied when state='loading'
+     * Accessible label announced by screen readers when `state` is `'loading'`.
      */
     loadingStateAriaLabel?: string;
     /**
-     * Handler called when the sort direction changes
-     * @param direction - The new sort direction
+     * Callback fired when the user clicks the sort button. Receives the new sort direction. Providing this prop makes the column sortable.
      */
     onSortChange?: (direction: SortDirection) => void;
     children: ReactNode;
@@ -324,12 +323,12 @@ TableHeaderCell.displayName = 'Table.HeaderCell';
 
 type TableBodyProps = {
     /**
-     * Whether the first column should stick to the left when scrolling horizontally
+     * Pins the first column to the left edge when the table scrolls horizontally. Useful for row labels or identifiers.
      * @default false
      */
     firstColumnSticky?: boolean;
     /**
-     * Whether the last column should stick to the right when scrolling horizontally
+     * Pins the last column to the right edge when the table scrolls horizontally. Useful for row actions.
      * @default false
      */
     lastColumnSticky?: boolean;
@@ -356,23 +355,19 @@ TableBody.displayName = 'Table.Body';
 
 type TableRowProps = {
     /**
-     * Whether the row is in a selected state
+     * Whether the row is in a selected (highlighted) state. Pairs with `onClick` for selectable rows.
      * @default false
      */
     selected?: boolean;
     /**
-     * Whether to disable interactions for this row
+     * Prevents interaction and dims the row visually.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Handler called when the row is clicked or activated via keyboard
-     * If provided, the row will be hoverable and interactive
+     * Callback fired when the row is clicked or activated via keyboard (Enter/Space). When provided, the row becomes hoverable and interactive. Receives the current `selected` state.
      */
     onClick?: (selected: boolean) => void;
-    /**
-     * Content to be rendered within the row
-     */
     children: ReactNode;
     /**
      * Accessible label for the row
@@ -438,7 +433,7 @@ TableRow.displayName = 'Table.Row';
 
 type TableRowCellProps = {
     /**
-     * Number of columns the cell should span
+     * The number of columns this cell spans.
      */
     colSpan?: HTMLTableCellElement['colSpan'];
     /**
@@ -478,6 +473,7 @@ export const TableRowCell = forwardRef<HTMLTableCellElement, TableRowCellProps>(
 );
 TableRowCell.displayName = 'Table.RowCell';
 
+/** A data table — compose `Root` with `Caption`, `Header`, `HeaderCell`, `Body`, `Row`, and `RowCell` sub-components. */
 export const Table = {
     Root: TableRoot,
     Caption: TableCaption,

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -24,6 +24,17 @@ const meta: Meta<typeof TabsRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A set of layered content panels — only one visible at a time. Organizes related content into switchable views without leaving the page.',
+                    '',
+                    '**When to use:** When content naturally splits into parallel categories that users switch between. For collapsible sections stacked vertically, use Accordion instead.',
+                    '',
+                    '**Overflow:** Tabs that exceed the container width are automatically tucked into a dropdown menu.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         onActiveTabChange: action('onActiveTabChange'),

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -26,33 +26,36 @@ import { type TabTrigger } from './types';
 
 export type TabsRootProps = {
     id?: string;
+    /**
+     * Should contain `Tabs.Tab` components.
+     */
     children: ReactNode;
     /**
-     * Define the padding of the dialog
+     * Controls the content area padding. `'none'` for custom layouts, `'compact'` for most use cases, `'spacious'` for breathing room.
      * @default "compact"
      */
     padding?: 'none' | 'tight' | 'compact' | 'comfortable' | 'spacious';
     /**
-     * The default active tab
-     * Used for uncontrolled components
+     * The initially active tab value for uncontrolled usage.
      */
     defaultActiveTab?: string;
     /**
-     * The controlled value of the active tab
+     * The controlled active tab value. Use together with `onActiveTabChange`.
      */
     activeTab?: string;
     /**
-     * The height of the tabs
-     * @default 'medium'
+     * Controls the tab trigger height. `'medium'` for standard layouts, `'large'` for prominent navigation.
+     * @default "medium"
      */
     size?: 'medium' | 'large';
     /**
-     * Event handler called when the active tab changes
+     * Callback fired when the active tab changes.
+     * @param value - The value of the newly active tab
      */
     onActiveTabChange?: (value: string) => void;
     /**
-     * Select the used variant
-     * “default 'default'
+     * Controls the visual style. `'default'` for underline-style tabs, `'pill'` for filled pill-shaped tabs.
+     * @default "default"
      */
     variant?: 'default' | 'pill';
 };
@@ -169,8 +172,18 @@ export const TabsRoot = (
 TabsRoot.displayName = 'Tabs.Root';
 
 type TabsTabProps = {
+    /**
+     * Should contain a `Tabs.Trigger` and a `Tabs.Content`.
+     */
     children: ReactNode;
+    /**
+     * A unique value that identifies this tab. Passed to `onActiveTabChange` when selected.
+     */
     value: string;
+    /**
+     * Prevents the tab from being selected.
+     * @default false
+     */
     disabled?: boolean;
 };
 
@@ -182,6 +195,9 @@ export const TabsTab = ({ children, value, disabled }: TabsTabProps) => {
 TabsTab.displayName = 'Tabs.Tab';
 
 type TabsTriggerProps = {
+    /**
+     * The label or content rendered inside the tab trigger. Can include text, icons, or badges.
+     */
     children: ReactNode;
 };
 
@@ -211,7 +227,14 @@ export const TabsTrigger = ({ children, ...props }: TabsTriggerProps, ref: Forwa
 TabsTrigger.displayName = 'Tabs.Trigger';
 
 type TabsContentProps = {
+    /**
+     * The content displayed when the parent tab is active.
+     */
     children: ReactNode;
+    /**
+     * Merge props onto the child element instead of rendering a wrapper.
+     * @default false
+     */
     asChild?: boolean;
 };
 
@@ -226,6 +249,11 @@ export const TabsContent = ({ children, ...itemProps }: TabsContentProps, ref: F
 };
 TabsContent.displayName = 'Tabs.Content';
 
+/**
+ * A set of layered content panels — only one is visible at a time. Use `Tabs.Root` as the container,
+ * `Tabs.Tab` to define each tab, `Tabs.Trigger` for the clickable header, and `Tabs.Content` for the panel.
+ * Tabs that overflow the container are automatically collapsed into a dropdown menu.
+ */
 export const Tabs = {
     Root: forwardRef<HTMLDivElement, TabsRootProps>(TabsRoot),
     Tab: forwardRef<HTMLDivElement, TabsTabProps>(TabsTab),

--- a/packages/components/src/components/Tag/Tag.stories.tsx
+++ b/packages/components/src/components/Tag/Tag.stories.tsx
@@ -19,6 +19,15 @@ const meta: Meta<typeof Tag> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A compact, interactive chip for representing keywords, categories, or user-generated labels. Supports selection, dismissal, and hover actions.',
+                    '',
+                    '**When to use:** For removable or selectable keywords — filter chips, applied tags, or multi-select tokens. For non-interactive status indicators, use `<Badge>` instead.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         emphasis: 'strong',

--- a/packages/components/src/components/Tag/Tag.tsx
+++ b/packages/components/src/components/Tag/Tag.tsx
@@ -13,31 +13,35 @@ type TagSize = 'default' | 'small';
 
 type TagProps = {
     /**
-     * @default 'strong'
+     * Controls visual weight. `'strong'` for prominent tags, `'weak'` for subtle or secondary tags.
+     * @default "strong"
      */
     emphasis?: TagEmphasis;
     /**
-     * @default 'default'
+     * Controls the color scheme. `'default'` for neutral tags, `'highlight'` for visually distinct or active tags.
+     * @default "default"
      */
     variant?: TagStyle;
     /**
-     * @default 'default'
+     * Controls the tag size. `'default'` for standard use, `'small'` for compact layouts or inline usage.
+     * @default "default"
      */
     size?: TagSize;
     /**
+     * Prevents interaction and dims the tag visually.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Click handler - when provided, the Tag renders as a button element
+     * Callback fired when the tag is clicked. When provided, the tag renders as a `<button>` element.
      */
     onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
     /**
-     * Click handler on dismiss - providing this will show the dismiss button
+     * Callback fired when the dismiss button is clicked. When provided, a dismiss icon is shown.
      */
     onDismiss?: (event?: MouseEvent<HTMLButtonElement>) => void;
     /**
-     * Click handler on add click - providing this will show the add button
+     * Callback fired when the add button is clicked. When provided, an add icon is shown.
      */
     onAddClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
     title?: string;

--- a/packages/components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/components/src/components/TextInput/TextInput.stories.tsx
@@ -23,6 +23,15 @@ const meta: Meta<typeof TextFieldRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A single-line text field for short-form input — names, emails, search queries, URLs. Supports slots for icons, buttons, or other decorations.',
+                    '',
+                    '**When to use:** For single-line text entry. For multi-line content use `<Textarea>`, for choosing from a predefined list use `<Select>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         placeholder: 'Placeholder',

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -20,84 +20,83 @@ export type TextInputProps = {
     id?: string;
     name?: string;
     /**
-     * The place where the input slots are placed
+     * Slot content placed alongside the input. Use `TextInput.Slot` for left/right decorators or actions.
      */
     children?: ReactNode;
     /**
-     * The default value of the text input
-     * Used for uncontrolled components
+     * The initial value for uncontrolled usage. Accepts a string or number.
      */
     defaultValue?: string | number;
     /**
-     * The controlled value of the text input
+     * The controlled value. Use together with `onChange` for controlled usage.
      */
     value?: string | number;
     /**
-     * Type of the text input
+     * The HTML input type. Use `'password'` for secrets, `'email'` for email addresses, `'number'` for numeric input, `'search'` for search fields.
      * @default "text"
      */
     type?: 'date' | 'email' | 'hidden' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'time' | 'url';
     /**
-     * The placeholder in the text input
+     * Text shown when the input is empty. Use it to hint at the expected input.
      */
     placeholder?: string;
     /**
-     * Disable the text input
+     * Prevents interaction and dims the input visually.
      * @default false
      */
     disabled?: boolean;
     /**
-     * Make the text input required in form
+     * Marks the input as required for form validation.
      * @default false
      */
     required?: boolean;
     /**
-     * Make the text input spell-checkable
+     * Enables browser spell-checking for the input content.
      * @default true
      */
     spellCheck?: boolean;
     /**
-     * Make the text input read-only
+     * Makes the input read-only — the value is visible but cannot be edited.
      * @default false
      */
     readOnly?: boolean;
     /**
-     * Set the type of input so autocomplete can help the user
+     * Controls the browser's autocomplete behavior. Pass a specific token like `'email'`, `'username'`, or `'off'` to disable.
      * @default "on"
      */
     autoComplete?: string;
     /**
-     * The maximum length of the text input
+     * The maximum number of characters the user can enter.
      */
     maxLength?: number;
     /**
-     * Status of the text input
+     * Conveys validation state visually. `'success'` shows a checkmark, `'error'` shows a warning icon, `'loading'` shows a spinner.
      * @default "neutral"
      */
     status?: 'neutral' | 'success' | 'error' | 'loading';
     className?: string;
     /**
-     * Event handler called when the text input value changes
+     * Callback fired when the input value changes.
      */
     onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
     /**
-     * Event handler called when the text input is blurred
+     * Callback fired when the input loses focus.
      */
     onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
     /**
-     * Event handler called when the text input is focused
+     * Callback fired when the input gains focus.
      */
     onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
     /**
-     * Event handler called when a key is pressed
+     * Callback fired when a key is pressed inside the input.
      */
     onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
     /**
-     * Event handler called when a key is released
+     * Callback fired when a key is released inside the input.
      */
     onKeyUp?: (event: KeyboardEvent<HTMLInputElement>) => void;
     /**
-     * Event handler called when the text inside of text input is selected
+     * Callback fired when the user selects text inside the input.
      */
     onSelect?: (event: SyntheticEvent<HTMLInputElement>) => void;
     'data-test-id'?: string;
@@ -179,7 +178,13 @@ export const TextFieldRoot = (
 TextFieldRoot.displayName = 'TextField.Root';
 
 export type TextFieldSlotProps = {
+    /**
+     * The slot content — typically an icon, button, or other action.
+     */
     children: ReactNode;
+    /**
+     * Controls where the slot appears. `'left'` places content at the start, `'right'` at the end of the input.
+     */
     name?: 'left' | 'right';
     className?: string;
 };

--- a/packages/components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/components/src/components/Textarea/Textarea.stories.tsx
@@ -20,6 +20,15 @@ const meta: Meta<typeof TextareaRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A multi-line text field for longer-form content — descriptions, comments, or code. Supports auto-sizing, character limits, and action slots.',
+                    '',
+                    '**When to use:** When users need to enter more than a single line of text. For short inputs use `<TextInput>`.',
+                ].join('\n'),
+            },
+        },
     },
     args: {
         autocomplete: false,

--- a/packages/components/src/components/Textarea/Textarea.tsx
+++ b/packages/components/src/components/Textarea/Textarea.tsx
@@ -32,34 +32,35 @@ export type ExtraAction = {
 type Status = 'default' | 'loading' | 'success' | 'error';
 
 type TextareaProps = {
-    /**
-     * The id of the textarea
-     */
     id?: string;
     /**
-     * The place where the textarea slots are placed
+     * Slot content placed alongside the textarea. Use `Textarea.Slot` for left/right decorators or actions.
      */
     children?: ReactNode;
     /**
-     * If `true`, Textarea will have `autoComplete` functionality
+     * Enables browser autocomplete suggestions for the textarea.
      */
     autocomplete?: boolean;
     /**
-     * If `true`, component rendered is a auto sizing Textarea
+     * When `true`, the textarea grows automatically as the user types, eliminating the need for manual resizing.
      */
     autosize?: boolean;
     /**
-     * Render `clear` button to clear input on click
+     * Shows a clear button that empties the textarea on click.
      */
     clearable?: boolean;
     /**
-     * A `ReactElement` that will be rendered at the start of the `Textarea`
+     * A React element rendered at the start of the textarea — typically an icon or label prefix.
      */
     decorator?: ReactElement;
     /**
-     * Initial value
+     * The initial value for uncontrolled usage.
      */
     defaultValue?: string;
+    /**
+     * Prevents interaction and dims the textarea visually.
+     * @default false
+     */
     disabled?: boolean;
     /**
      * Collection of extra actions the input can preform
@@ -67,63 +68,76 @@ type TextareaProps = {
      */
     extraActions?: ExtraAction[];
     /**
-     * If `true`, Textarea will be focused on mount
+     * When `true`, the textarea receives focus automatically when the component mounts.
      */
     focusOnMount?: boolean;
     /**
-     * If autosize is false, this is used as rows property for default textarea
+     * The minimum number of visible text rows. Only applies when `autosize` is `false`.
      * @default 1
      */
     minRows?: number;
     /**
-     * If `autosize` is `false`, this property is ignored
+     * The maximum number of visible text rows before scrolling activates. Only applies when `autosize` is `true`.
      */
     maxRows?: number;
     /**
-     * Event handler called when the textarea value changes
+     * Callback fired when the textarea value changes.
      */
     onChange?: ChangeEventHandler<HTMLTextAreaElement>;
     /**
-     * Event handler called when the text input is blurred
+     * Callback fired when the textarea loses focus.
      */
     onBlur?: FocusEventHandler<HTMLTextAreaElement>;
     /**
-     * Event handler called when the text input is focused
+     * Callback fired when the textarea gains focus.
      */
     onFocus?: FocusEventHandler<HTMLTextAreaElement>;
     /**
-     * Event handler called when a key is pressed
+     * Callback fired when a key is pressed inside the textarea.
      */
     onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
     /**
-     * Event handler called when Enter is pressed
+     * Callback fired specifically when the Enter key is pressed. Useful for submit-on-enter behavior.
      */
     onEnterPressed?: KeyboardEventHandler<HTMLTextAreaElement>;
     /**
-     * Event handler called when a key is released
+     * Callback fired when a key is released inside the textarea.
      */
     onKeyUp?: KeyboardEventHandler<HTMLTextAreaElement>;
     /**
-     * Event handler called when the text inside of text input is selected
+     * Callback fired when the user selects text inside the textarea.
      */
     onSelect?: (event: SyntheticEvent<HTMLTextAreaElement>) => void;
     /**
-     * If `true`, Textarea will be required
+     * Marks the textarea as required for form validation.
      */
     required?: boolean;
-    /**
-     * The test id of the textarea
-     */
     'data-test-id'?: string;
+    /**
+     * Text shown when the textarea is empty. Use it to hint at the expected input.
+     */
     placeholder?: string;
+    /**
+     * Makes the textarea read-only — the value is visible but cannot be edited.
+     */
     readOnly?: boolean;
+    /**
+     * When `true`, shows a drag handle for manual resizing.
+     */
     resizable?: boolean;
+    /**
+     * When `false`, prevents the user from selecting text inside the textarea.
+     * @default true
+     */
     selectable?: boolean;
     /**
-     * The current status of the input. It will trigger the corresponding icon to be appended to the Textarea.
+     * Conveys the validation state visually. `'success'` shows a checkmark, `'error'` shows a warning icon, `'loading'` shows a progress indicator.
      * @default 'default'
      */
     status?: Status;
+    /**
+     * The controlled value. Use together with `onChange` for controlled usage.
+     */
     value?: string;
 };
 
@@ -269,7 +283,13 @@ export const TextareaRoot = (
 TextareaRoot.displayName = 'Textarea.Root';
 
 export type TextareaSlotProps = {
+    /**
+     * The slot content — typically an icon, button, or other action.
+     */
     children: ReactNode;
+    /**
+     * Controls where the slot appears. `'left'` places content at the start, `'right'` at the end of the textarea.
+     */
     name?: 'left' | 'right';
     className?: string;
 };

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -25,6 +25,15 @@ const meta: Meta<typeof TooltipRoot> = {
         status: {
             type: 'released',
         },
+        docs: {
+            description: {
+                component: [
+                    'A small, floating text label that appears on hover or focus to describe an element. Disappears when the user moves away.',
+                    '',
+                    '**When to use:** To provide supplementary context for icons, truncated text, or controls that lack a visible label. Keep content brief — for richer content use `<Flyout>`.',
+                ].join('\n'),
+            },
+        },
     },
     render: ({ ...args }) => {
         return (

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -9,15 +9,15 @@ import styles from './styles/tooltip.module.scss';
 
 export type TooltipRootProps = {
     /**
-     * Sets the open state of the tooltip.
+     * The controlled open state. Use together with `onOpenChange` for programmatic control.
      */
     open?: boolean;
     /**
-     * Callback that is called when the open state of the tooltip changes.
+     * Callback fired when the tooltip opens or closes.
      */
     onOpenChange?: (open: boolean) => void;
     /**
-     * The delay in milliseconds before the tooltip appears.
+     * The delay in milliseconds before the tooltip appears on hover. Set to `0` for instant display.
      * @default 700
      */
     enterDelay?: number;
@@ -37,7 +37,7 @@ TooltipRoot.displayName = 'Tooltip.Root';
 
 export type TooltipTriggerProps = {
     /**
-     * Change the default rendered element for the one passed as a child, merging their props and behavior.
+     * When `true`, merges the trigger's props and behavior onto its child element instead of rendering a wrapper button.
      * @default false
      */
     asChild?: boolean;
@@ -65,13 +65,17 @@ TooltipTrigger.displayName = 'Tooltip.Trigger';
 
 export type TooltipContentProps = {
     /**
+     * Controls the inner padding. `'spacious'` for text tooltips, `'compact'` for dense layouts.
      * @default "spacious"
      */
     padding?: 'spacious' | 'compact';
     /**
-     * Defines the preferred side of the tooltip. It will not be respected if there are collisions with the viewport.
+     * The preferred side the tooltip appears on. Falls back to the opposite side if there isn't enough viewport space.
      */
     side?: 'top' | 'right' | 'bottom' | 'left';
+    /**
+     * The maximum width of the tooltip. Accepts any CSS length value.
+     */
     maxWidth?: string;
     className?: string;
     children: ReactNode;
@@ -129,6 +133,7 @@ export const TooltipContent = (
 };
 TooltipContent.displayName = 'Tooltip.Content';
 
+/** An informational popup — compose `Root` with `Trigger` and `Content` sub-components. */
 export const Tooltip = {
     Root: TooltipRoot,
     Trigger: forwardRef<HTMLButtonElement, TooltipTriggerProps>(TooltipTrigger),


### PR DESCRIPTION
## Todo
- [ ] Check with Joanna on the resulting quality.

## Context
I upgraded the documentation with help of claude:

## Steps taken

1. First extracted documentation from: https://fondue.frontify.com/document/50#/-/fondue-components to storybook
2. I let AI as a copy writer iterate of the storybook documentation and migrate stuff to Props JSDoc
3. Then I let AI define consistent rules to add as a Claude command. (see first file checked in)
4. I let AI extract a report (copied below)
6. Then I Claude fill in the blanks based on this report and make documentation more consistent.


# Component Documentation Audit Report

> Audit date: 2026-02-14 | Scope: `packages/components/src/components/` (35 components)

---

## Executive Summary

The Fondue component library has **strong documentation in its best components** (Button, Notice, Badge, Accordion, Checkbox) that could serve as the gold standard for the rest. However, there is **significant inconsistency** across the library — roughly a third of components have excellent prop-level JSDoc, a third have partial coverage, and a third are barely documented. Storybook descriptions follow a similar pattern: only ~6 of 30 story files include a component-level description.

**Overall documentation health: 6/10** — good bones, inconsistent execution.

---

## Part 1: Storybook Documentation Audit

### 1.1 Coverage

- **30 of 35** components have Storybook stories (86%)
- **All** stories use `tags: ['autodocs']` and `parameters.status`
- **Only 6** stories include a `docs.description.component` block

### 1.2 Component Descriptions — Who Has Them

| Has description | Missing description |
|---|---|
| Accordion, Button, Checkbox, Notice, Badge (brief), Dialog (minimal) | Box, Flex, Grid, Divider, Dropdown, Flyout, Label, Link, RadioList, ScrollArea, SegmentedControl, Select, Slider, Switch, Tabs, Tag, Text, Textarea, TextInput, Tooltip, ColorPicker, Table, SplitButton |

### 1.3 What Good Descriptions Look Like

The best descriptions (Accordion, Button, Checkbox) follow a clear template:

```
Line 1: What it is (one sentence, starts with "A…" or "An…")
Line 2: (blank)
Line 3: **When to use:** Guidance on the right context
Line 4: (blank)
Line 5+: **Feature label:** Specific guidance on key features
```

**Example (Button):**
> An interactive element that triggers actions — from submitting a form to opening a menu. At least one content element must be included: a label, an icon, or both.
>
> **When to use:** For actions and commands only. Use links for navigation — buttons trigger an immediate result, links navigate to a new location.
>
> **Icon:** Pass an icon as a child to add visual context. Use `aspect="square"` for icon-only buttons.

### 1.4 argTypes Usage

Only **5** of 30 stories define `argTypes` with descriptions:
- Slider (9 argTypes — best example, includes `table` metadata)
- Link (8 argTypes)
- Table (layout and gutter)
- RadioList (3 argTypes)
- Switch (size control only)

**Finding:** Most components rely on autodocs to pull descriptions from JSDoc. This works well *when JSDoc exists*, but leaves the controls table blank for undocumented props.

### 1.5 Story Variant Coverage

Most components have decent variant coverage through named stories. Notable patterns:

| Coverage level | Components |
|---|---|
| Excellent (10+ stories) | Notice, Dialog, Dropdown, Flyout, Select, ScrollArea, Tag, Badge |
| Good (5–9 stories) | Accordion, Button, Checkbox, Switch, SegmentedControl, Label, Slider, Tabs |
| Minimal (1–4 stories) | Box, Divider, Grid, Link, Text, Tooltip, ColorPicker |

### 1.6 Anti-patterns Found

1. **No JSDoc on individual stories** — No story uses `parameters.docs.description.story` to explain *why* a variant exists
2. **Lorem Ipsum overuse** — ScrollArea stories are 90% Lorem Ipsum with no meaningful content showing realistic usage
3. **No `args` defaults in most stories** — Only Button and Accordion set sensible `args` defaults in meta
4. **Missing subcomponents declarations** — Some compound components don't list their sub-components in meta

---

## Part 2: JSDoc / Prop Documentation Audit

### 2.1 Tier System

#### Tier 1 — Excellent (100% or near-complete prop documentation)

| Component | Props documented | Coverage | Notes |
|---|---|---|---|
| **Button** | 12/15 | 80% | Gold standard for descriptions; missing `form`, `children`, `className` |
| **Notice** | 10/10 | 100% | Every prop has a clear, contextual description |
| **Badge** | 7/8 | 88% | Clear variant explanations |
| **Accordion** | Sub-components well documented | ~90% | Good `@deprecated` usage |
| **Checkbox** | Comprehensive | ~90% | Includes accessibility notes |
| **Link** | All props | 100% | Concise and clear |
| **Label** | All props | 100% | — |
| **Divider** | All props | 100% | Good a11y doc for `decorative` |
| **LoadingCircle** | All props | 100% | — |

#### Tier 2 — Partial (key props documented, gaps in secondary props)

| Component | Coverage | Key gaps |
|---|---|---|
| **Dialog** | ~85% | Sub-components well documented, some `children` props missing |
| **Flyout** | ~80% | Good FlyoutContent docs, sparse on Header/Footer |
| **Dropdown** | ~80% | Some brief/generic descriptions |
| **TextInput** | ~75% | Missing `id`, `name`, `className` |
| **Textarea** | ~75% | Good `@deprecated` on extraActions |
| **Switch** | ~65% | **Wrong terminology** (says "select" instead of "switch") |
| **Slider** | ~70% | Missing `onChange` vs `onCommit` explanation |
| **Select** | ~60% | Insufficient for such a complex component |
| **Tabs** | ~70% | Typo in variant description |

#### Tier 3 — Poor (minimal or no prop documentation)

| Component | Coverage | Notes |
|---|---|---|
| **Heading** | 0% | **Zero JSDoc on any prop** — worst in the library |
| **Text** | ~55% | Has some docs but inconsistent with Heading |
| **Box** | ~50% | Only `as` and `display` documented; inherited layout props undocumented |
| **Flex** | ~30% | Layout-specific props (direction, align, justify) undocumented |
| **Grid** | ~30% | Same as Flex |
| **Section** | ~20% | — |
| **ScrollArea** | ~40% | — |
| **SegmentedControl** | ~50% | — |

### 2.2 Terminology Bugs

| Component | Prop | Issue |
|---|---|---|
| **Switch** | `value` | Says "The active value in the **select** component" — should say "switch" |
| **Switch** | `defaultValue` | Says "The default value of the **select** component" — should say "switch" |
| **Switch** | `disabled` | Says "Disables the **select** component" — should say "switch" |
| **Switch** | `onBlur` / `onFocus` | Says "called when the **checkbox** is blurred/focused" — should say "switch" |
| **Tabs** | `variant` | Malformed JSDoc: `"default 'default'"` (missing `@` prefix) |

### 2.3 Description Style Inconsistencies

**Problem: Two different documentation voices exist**

*Voice A — Contextual/designer-friendly (Button, Notice, Badge):*
> Controls visual weight. `'strong'` for primary actions, `'default'` for common actions, `'weak'` for secondary or less prominent options.

*Voice B — Mechanical/developer-only (Slider, TextInput, Switch):*
> The default value of the slider, used for uncontrolled components.

Voice A explains *when and why* to use each option. Voice B just restates the type. **Voice A should be the standard.**

### 2.4 Default Value Documentation

**Good news:** `@default` tags are used consistently when JSDoc exists. The pattern is well-established.

**Issue:** Some defaults are quoted (`@default "button"`) and others are not (`@default medium`). Minor but inconsistent.

### 2.5 Missing Patterns

1. **No `@example` tags anywhere** — Would help with complex props
2. **No top-level JSDoc on compound component exports** — `export const Dialog = { Root, Trigger, ... }` has no doc comment explaining the composition pattern
3. **`children` props rarely documented** — When children must be specific components (e.g., `Accordion.Item` inside `Accordion.Root`), this constraint isn't noted
4. **Inherited prop types undocumented** — `LayoutComponentProps`, `CommonAriaProps`, `CommonAriaAttrs` are used widely but their individual props aren't documented at the usage site

---

## Part 3: Cross-cutting Issues

### 3.1 Storybook ↔ JSDoc Misalignment

For autodocs to work well, JSDoc must be complete. When it's not, the Storybook controls table shows props without descriptions. This is the case for:
- All Tier 3 components
- Inherited props from `LayoutComponentProps` (affects Box, Flex, Grid, Section)
- `CommonAriaProps` and `CommonAriaAttrs` spread props

### 3.2 Component Selection Guide (AI.md) vs Storybook

The `AI.md` component selection guide is excellent and comprehensive. But Storybook descriptions — the developer-facing docs — don't include "when to use" guidance for most components. Developers using Storybook directly miss the decision-making context that exists in AI.md.

### 3.3 Priority Fix List (Quick Wins)

1. **Fix Switch terminology** — 5 JSDoc strings reference the wrong component name
2. **Fix Tabs variant JSDoc** — Malformed comment
3. **Add JSDoc to Heading** — Zero documentation on a fundamental component
4. **Add Storybook descriptions to form components** — TextInput, Textarea, Select, RadioList, Switch
5. **Add Storybook descriptions to layout components** — Box, Flex, Grid
6. **Document LayoutComponentProps** — One fix helps Box, Flex, Grid, and Section

---

## Part 4: Component-by-Component Scoreboard

| Component | JSDoc coverage | Storybook desc | Story count | Overall |
|---|---|---|---|---|
| Accordion | A | A | 9 | A |
| Badge | A | B | 13 | A- |
| Box | D | F | 2 | D |
| Button | A | A | 6 | A |
| Checkbox | A | A | 8 | A |
| ColorPicker | C | F | 5 | C- |
| Dialog | B+ | D | 19 | B |
| Divider | A | F | 5 | B- |
| Dropdown | B | F | 18 | B- |
| Flex | D | F | 5 | D |
| Flyout | B | F | 22 | B- |
| Grid | D | F | 3 | D |
| Heading | F | — | — | F |
| Label | A | F | 8 | B- |
| Link | A | F | 3 | B |
| LoadingBar | B | — | — | C |
| LoadingCircle | A | — | — | B |
| Notice | A | A | 15 | A+ |
| RadioList | C | F | 6 | C |
| ScrollArea | D | F | 10 | C- |
| Section | D | — | — | D |
| SegmentedControl | C | F | 7 | C |
| Select | C | F | 25 | C |
| Slider | B | F | 9 | B- |
| SplitButton | C | F | — | C- |
| Switch | C* | F | 8 | C- |
| Table | C | F | — | C |
| Tabs | C | F | 3 | C |
| Tag | C | F | 14 | C |
| Text | C | F | — | C- |
| Textarea | B | F | 5 | B- |
| TextInput | B | F | 5 | B- |
| Tooltip | B | F | 5 | B |
| ThemeProvider | C | — | — | C |
| RouterProvider | D | — | — | D |

*Switch: C with a critical terminology bug — see Part 2.2*

---

## Part 5: Recommendations Summary

### Must Fix (Bugs)
1. Switch: Replace all "select component" / "checkbox" references with "switch"
2. Tabs: Fix malformed `@default` comment on `variant`

### High Priority (Gap-closing)
3. Add JSDoc to **Heading** — match Text component's style
4. Add Storybook `docs.description.component` to **all 24 missing** components
5. Document **LayoutComponentProps** shared props (benefits 4 components)
6. Add JSDoc to **Flex** and **Grid** specific layout props

### Medium Priority (Consistency)
7. Standardize on "Voice A" (contextual, designer-friendly) for all prop descriptions
8. Add top-level JSDoc comment to all compound component exports
9. Document `children` constraints where they exist
10. Quote all `@default` values consistently: `@default "medium"` not `@default medium`

### Nice to Have
11. Add `@example` tags for complex props
12. Add `parameters.docs.description.story` to story variants that aren't self-explanatory
13. Set `args` defaults in all story meta blocks
