### PR TITLE
fix(Select): Focus ring in firefox

### DIFF
--- a/.changeset/lazy-wolves-travel.md
+++ b/.changeset/lazy-wolves-travel.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix(Select): Focus ring in firefox

--- a/packages/components/src/components/Select/styles/select.module.scss
+++ b/packages/components/src/components/Select/styles/select.module.scss
@@ -33,6 +33,11 @@
         @include focusStyle.focus-outline;
     }
 
+    &:-moz-focusring {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+    }
+
     // Focus outline for nested inputs (e.g., inside CollapsibleBadges)
     &:has(input[data-show-focus-ring='true']:focus) {
         @include focusStyle.focus-outline-styles;
@@ -103,6 +108,11 @@
     line-height: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &:-moz-focusring {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+    }
 }
 
 .input,
@@ -413,5 +423,10 @@
 
     &:disabled {
         color: var(--color-disabled-default);
+    }
+
+    &:-moz-focusring {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
     }
 }


### PR DESCRIPTION
## fix(Select): Add missing Firefox focus ring override

### Problem

The Select component can displays an ugly default outline in Firefox when focused. 

### Fix

Added `:-moz-focusring { outline: 2px solid transparent; outline-offset: 2px; }` to all three focusable selectors in `select.module.scss`:

This matches the existing pattern in `TextInput` and `Textarea`. The transparent outline suppresses Firefox's default focus ring while the component's custom `box-shadow`-based focus ring (from the `focus-outline` mixin) remains intact.

