### PR TITLE
feat(Dialog): dismissable prop

### DIFF
--- a/.changeset/quiet-clouds-try.md
+++ b/.changeset/quiet-clouds-try.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Dialog): add dismissable prop to control escape and underlay-click close behavior

--- a/packages/components/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/components/Dialog/Dialog.stories.tsx
@@ -828,6 +828,34 @@ export const PreventCloseOnEscape: Story = {
     },
 };
 
+export const NotDismissable: Story = {
+    args: {
+        children: 'This dialog cannot be dismissed by pressing Escape or clicking outside the dialog.',
+    },
+    render: (args) => {
+        const [isDialogOpen, setIsDialogOpen] = useState(false);
+        return (
+            <Dialog.Root open={isDialogOpen} onOpenChange={setIsDialogOpen} dismissable={false}>
+                <Dialog.Trigger>
+                    <Button>Open dialog</Button>
+                </Dialog.Trigger>
+                <Dialog.Content {...args} showUnderlay>
+                    <Dialog.Header>
+                        <Dialog.Title>Non-dismissable dialog</Dialog.Title>
+                    </Dialog.Header>
+                    <Dialog.Body {...args} />
+                    <Dialog.Footer>
+                        <Dialog.Close>
+                            <Button emphasis="default">Cancel</Button>
+                        </Dialog.Close>
+                        <Button onPress={() => setIsDialogOpen(false)}>Submit</Button>
+                    </Dialog.Footer>
+                </Dialog.Content>
+            </Dialog.Root>
+        );
+    },
+};
+
 export const NestedDialogsWithEscapeKey: Story = {
     render: (args) => {
         const [outerEscapeCount, setOuterEscapeCount] = useState(0);

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -37,6 +37,12 @@ export type DialogRootProps = {
      * Event handler called when the `open` state changes
      */
     onOpenChange?: (open: boolean) => void;
+    /**
+     * Whether the dialog can be closed by clicking the underlay or pressing Escape.
+     * When set to `false`, the dialog can only be closed programmatically or via `Dialog.Close`.
+     * @default true
+     */
+    dismissable?: boolean;
     children?: ReactNode;
 };
 
@@ -154,13 +160,14 @@ export type DialogAnnouncementProps = {
 
 type DialogContextType = {
     isModal: boolean;
+    dismissable: boolean;
 };
 
-const DialogContext = createContext<DialogContextType>({ isModal: false });
+const DialogContext = createContext<DialogContextType>({ isModal: false, dismissable: true });
 DialogContext.displayName = 'DialogContext';
 
-export const DialogRoot = ({ children, modal, onOpenChange, open }: DialogRootProps) => {
-    const value = useMemo(() => ({ isModal: modal ?? false }), [modal]);
+export const DialogRoot = ({ children, modal, onOpenChange, open, dismissable = true }: DialogRootProps) => {
+    const value = useMemo(() => ({ isModal: modal ?? false, dismissable }), [modal, dismissable]);
 
     return (
         <DialogContext.Provider value={value}>
@@ -224,8 +231,22 @@ export const DialogContent = (
 ) => {
     const { theme, dir } = useFondueTheme();
     const contentRef = useRef<HTMLDivElement>(null);
+    const { dismissable } = useContext(DialogContext);
 
     useSyncRefs<HTMLDivElement>(contentRef, ref);
+
+    const handleEscapeKeyDown = (event: KeyboardEvent) => {
+        if (!dismissable) {
+            event.preventDefault();
+        }
+        onEscapeKeyDown?.(event);
+    };
+
+    const handleInteractOutside = (event: Event) => {
+        if (!dismissable) {
+            event.preventDefault();
+        }
+    };
 
     const handleOpenAutoFocus = (event: Event) => {
         event.preventDefault();
@@ -264,7 +285,8 @@ export const DialogContent = (
                         className={styles.content}
                         onFocus={addShowFocusRing}
                         onOpenAutoFocus={handleOpenAutoFocus}
-                        onEscapeKeyDown={onEscapeKeyDown}
+                        onEscapeKeyDown={handleEscapeKeyDown}
+                        onInteractOutside={handleInteractOutside}
                         data-dialog-padding={padding}
                         data-dialog-rounded={rounded}
                         data-test-id={dataTestId}

--- a/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
+++ b/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
@@ -1,7 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { expect, test } from '@playwright/experimental-ct-react';
-import { useState } from 'react';
 import sinon from 'sinon';
 
 import { Button } from '#/components/Button/Button';

--- a/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
+++ b/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
@@ -720,35 +720,6 @@ test('should still close via Dialog.Close when dismissable is false', async ({ m
     await expect(contentElement).not.toBeVisible();
 });
 
-test('should still close programmatically when dismissable is false', async ({ mount, page }) => {
-    const DialogWithProgrammaticClose = () => {
-        const [open, setOpen] = useState(true);
-        return (
-            <Dialog.Root open={open} dismissable={false}>
-                <Dialog.Trigger>
-                    <Button>{DIALOG_TRIGGER_TEXT}</Button>
-                </Dialog.Trigger>
-                <Dialog.Content data-test-id={DIALOG_CONTENT_TEST_ID}>
-                    <Dialog.Header showCloseButton={false}>{DIALOG_HEADER_TEXT}</Dialog.Header>
-                    <Dialog.Body>
-                        <Button data-test-id="programmatic-close" onPress={() => setOpen(false)}>
-                            Close
-                        </Button>
-                    </Dialog.Body>
-                </Dialog.Content>
-            </Dialog.Root>
-        );
-    };
-
-    await mount(<DialogWithProgrammaticClose />);
-
-    const contentElement = page.getByTestId(DIALOG_CONTENT_TEST_ID);
-    await expect(contentElement).toBeVisible();
-
-    await page.getByTestId('programmatic-close').click();
-    await expect(contentElement).not.toBeVisible();
-});
-
 test('should forward onEscapeKeyDown when dismissable is false', async ({ mount, page }) => {
     const onEscapeKeyDown = sinon.spy();
     await mount(

--- a/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
+++ b/packages/components/src/components/Dialog/__tests__/Dialog.ct.tsx
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { expect, test } from '@playwright/experimental-ct-react';
+import { useState } from 'react';
 import sinon from 'sinon';
 
 import { Button } from '#/components/Button/Button';
@@ -653,6 +654,121 @@ test('should close nested dropdown before dialog when escape is pressed', async 
     // Second escape should close the dialog
     await page.keyboard.press('Escape');
     await expect(dialogContent).not.toBeVisible();
+});
+
+test('should not close on escape when dismissable is false', async ({ mount, page }) => {
+    await mount(
+        <Dialog.Root open dismissable={false}>
+            <Dialog.Trigger>
+                <Button>{DIALOG_TRIGGER_TEXT}</Button>
+            </Dialog.Trigger>
+            <Dialog.Content data-test-id={DIALOG_CONTENT_TEST_ID}>
+                <Dialog.Header>{DIALOG_HEADER_TEXT}</Dialog.Header>
+                <Dialog.Body>{DIALOG_BODY_TEXT}</Dialog.Body>
+            </Dialog.Content>
+        </Dialog.Root>,
+    );
+
+    const contentElement = page.getByTestId(DIALOG_CONTENT_TEST_ID);
+    await expect(contentElement).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(contentElement).toBeVisible();
+});
+
+test('should not close on underlay click when dismissable is false', async ({ mount, page }) => {
+    await mount(
+        <Dialog.Root open dismissable={false} modal>
+            <Dialog.Trigger>
+                <Button>{DIALOG_TRIGGER_TEXT}</Button>
+            </Dialog.Trigger>
+            <Dialog.Content data-test-id={DIALOG_CONTENT_TEST_ID} showUnderlay>
+                <Dialog.Header>{DIALOG_HEADER_TEXT}</Dialog.Header>
+                <Dialog.Body>{DIALOG_BODY_TEXT}</Dialog.Body>
+            </Dialog.Content>
+        </Dialog.Root>,
+    );
+
+    const contentElement = page.getByTestId(DIALOG_CONTENT_TEST_ID);
+    await expect(contentElement).toBeVisible();
+
+    // Click the underlay (outside the dialog content)
+    await page.mouse.click(10, 10);
+    await expect(contentElement).toBeVisible();
+});
+
+test('should still close via Dialog.Close when dismissable is false', async ({ mount, page }) => {
+    await mount(
+        <Dialog.Root dismissable={false}>
+            <Dialog.Trigger data-test-id={DIALOG_TRIGGER_TEST_ID}>
+                <Button>{DIALOG_TRIGGER_TEXT}</Button>
+            </Dialog.Trigger>
+            <Dialog.Content data-test-id={DIALOG_CONTENT_TEST_ID}>
+                <Dialog.Header data-test-id={DIALOG_HEADER_TEST_ID}>{DIALOG_HEADER_TEXT}</Dialog.Header>
+                <Dialog.Body>{DIALOG_BODY_TEXT}</Dialog.Body>
+            </Dialog.Content>
+        </Dialog.Root>,
+    );
+
+    const triggerElement = page.getByTestId(DIALOG_TRIGGER_TEST_ID);
+    const contentElement = page.getByTestId(DIALOG_CONTENT_TEST_ID);
+    const closeElement = page.getByTestId(DIALOG_HEADER_CLOSE_TEST_ID);
+
+    await triggerElement.click();
+    await expect(contentElement).toBeVisible();
+
+    await closeElement.click();
+    await expect(contentElement).not.toBeVisible();
+});
+
+test('should still close programmatically when dismissable is false', async ({ mount, page }) => {
+    const DialogWithProgrammaticClose = () => {
+        const [open, setOpen] = useState(true);
+        return (
+            <Dialog.Root open={open} dismissable={false}>
+                <Dialog.Trigger>
+                    <Button>{DIALOG_TRIGGER_TEXT}</Button>
+                </Dialog.Trigger>
+                <Dialog.Content data-test-id={DIALOG_CONTENT_TEST_ID}>
+                    <Dialog.Header showCloseButton={false}>{DIALOG_HEADER_TEXT}</Dialog.Header>
+                    <Dialog.Body>
+                        <Button data-test-id="programmatic-close" onPress={() => setOpen(false)}>
+                            Close
+                        </Button>
+                    </Dialog.Body>
+                </Dialog.Content>
+            </Dialog.Root>
+        );
+    };
+
+    await mount(<DialogWithProgrammaticClose />);
+
+    const contentElement = page.getByTestId(DIALOG_CONTENT_TEST_ID);
+    await expect(contentElement).toBeVisible();
+
+    await page.getByTestId('programmatic-close').click();
+    await expect(contentElement).not.toBeVisible();
+});
+
+test('should forward onEscapeKeyDown when dismissable is false', async ({ mount, page }) => {
+    const onEscapeKeyDown = sinon.spy();
+    await mount(
+        <Dialog.Root open dismissable={false}>
+            <Dialog.Trigger>
+                <Button>{DIALOG_TRIGGER_TEXT}</Button>
+            </Dialog.Trigger>
+            <Dialog.Content data-test-id={DIALOG_CONTENT_TEST_ID} onEscapeKeyDown={onEscapeKeyDown}>
+                <Dialog.Header>{DIALOG_HEADER_TEXT}</Dialog.Header>
+                <Dialog.Body>{DIALOG_BODY_TEXT}</Dialog.Body>
+            </Dialog.Content>
+        </Dialog.Root>,
+    );
+
+    const contentElement = page.getByTestId(DIALOG_CONTENT_TEST_ID);
+    await expect(contentElement).toBeVisible();
+    expect(onEscapeKeyDown.callCount).toBe(0);
+    await page.keyboard.press('Escape');
+    expect(onEscapeKeyDown.callCount).toBe(1);
+    await expect(contentElement).toBeVisible();
 });
 
 test('should close inner dialog before outer dialog when escape is pressed in nested dialogs', async ({


### PR DESCRIPTION
### 🎯 What does this PR do?

Adds a (default `true`) `dismissable` prop to `Dialog.Root`. When set to `false`, this prevents the dialog from closing via Escape key press or clicking the underlay.

![Screen Recording 2026-04-10 at 15 16 31](https://github.com/user-attachments/assets/016b9964-40ed-40be-9993-f46f176cfa46)