### PR TITLE
fix: card component border

### DIFF
--- a/.changeset/card-border-box-sizing.md
+++ b/.changeset/card-border-box-sizing.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix(Card): prevent card from growing on hover/selection by setting box-sizing to border-box

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -8,12 +8,14 @@
 @mixin card-state(
     $root-border-color: transparent,
     $root-bg: null,
-    $box-shadow: none,
+    $inner-ring-color: transparent,
     $banner-border-color: transparent,
     $banner-border-radius: 0
 ) {
-    border-color: $root-border-color;
-    box-shadow: $box-shadow;
+    &::after {
+        outline-color: $root-border-color;
+        box-shadow: inset 0 0 0 calc(var(--border-width-default) + 1px) $inner-ring-color;
+    }
 
     @if $root-bg {
         background-color: var(--color-#{$root-bg});
@@ -61,11 +63,24 @@
     grid-template-columns: auto 1fr auto auto;
     grid-template-rows: auto minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto) minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto);
     border-radius: var(--border-radius-large);
-    border: var(--border-width-default) solid transparent;
+    border: none;
     background-color: var(--color-surface-default);
     overflow: hidden;
     outline: none;
-    @include transitions.transition((background-color, border-color, box-shadow));
+    @include transitions.transition((background-color, box-shadow));
+
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        outline: var(--border-width-default) solid transparent;
+        outline-offset: calc(-1 * var(--border-width-default));
+        box-shadow: inset 0 0 0 calc(var(--border-width-default) + 1px) transparent;
+        pointer-events: none;
+        z-index: 1;
+        @include transitions.transition((outline-color, box-shadow));
+    }
 
     &:not(:has(> .banner)) {
         background-color: var(--color-surface-dim);
@@ -99,7 +114,7 @@
             @include card-state(
                 $root-border-color: var(--color-line-strong),
                 $root-bg: 'surface-dim',
-                $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
+                $inner-ring-color: var(--color-interactive-default)
             );
         }
 
@@ -109,7 +124,7 @@
             @include card-state(
                 $root-border-color: var(--color-interactive-default),
                 $root-bg: 'surface-hover',
-                $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
+                $inner-ring-color: var(--color-interactive-default)
             );
         }
     }

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -8,14 +8,12 @@
 @mixin card-state(
     $root-border-color: transparent,
     $root-bg: null,
-    $inner-ring-color: transparent,
+    $box-shadow: none,
     $banner-border-color: transparent,
     $banner-border-radius: 0
 ) {
-    &::after {
-        outline-color: $root-border-color;
-        box-shadow: inset 0 0 0 calc(var(--border-width-default) + 1px) $inner-ring-color;
-    }
+    border-color: $root-border-color;
+    box-shadow: $box-shadow;
 
     @if $root-bg {
         background-color: var(--color-#{$root-bg});
@@ -63,24 +61,12 @@
     grid-template-columns: auto 1fr auto auto;
     grid-template-rows: auto minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto) minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto);
     border-radius: var(--border-radius-large);
-    border: none;
+    box-sizing: border-box;
+    border: var(--border-width-default) solid transparent;
     background-color: var(--color-surface-default);
     overflow: hidden;
     outline: none;
-    @include transitions.transition((background-color, box-shadow));
-
-    &::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        outline: var(--border-width-default) solid transparent;
-        outline-offset: calc(-1 * var(--border-width-default));
-        box-shadow: inset 0 0 0 calc(var(--border-width-default) + 1px) transparent;
-        pointer-events: none;
-        z-index: 1;
-        @include transitions.transition((outline-color, box-shadow));
-    }
+    @include transitions.transition((background-color, border-color, box-shadow));
 
     &:not(:has(> .banner)) {
         background-color: var(--color-surface-dim);
@@ -114,7 +100,7 @@
             @include card-state(
                 $root-border-color: var(--color-line-strong),
                 $root-bg: 'surface-dim',
-                $inner-ring-color: var(--color-interactive-default)
+                $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
             );
         }
 
@@ -124,7 +110,7 @@
             @include card-state(
                 $root-border-color: var(--color-interactive-default),
                 $root-bg: 'surface-hover',
-                $inner-ring-color: var(--color-interactive-default)
+                $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
             );
         }
     }


### PR DESCRIPTION
### Summary
- Move the Card component's border from a CSS `border` on `.root` to an `outline` on a `::after` pseudo-element, so the border renders inside the card's box without increasing its dimensions on hover/selection
- The `::after` overlay sits above the banner (`z-index: 1`), ensuring the border is visible over banner images
- The selected state's inner ring uses an inset `box-shadow` on the same `::after` pseudo-element

### Problem
The Card used a regular CSS `border` which painted outside the content box, causing the card to grow by 1px on each side when transitioning from idle (transparent border) to hover/selected (visible border). This resulted in a visible layout shift.