### PR TITLE
feat: add onNavigate to card for tracking purposes

### DIFF
--- a/.changeset/card-on-navigate.md
+++ b/.changeset/card-on-navigate.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Card): add `onNavigate` prop to track link overlay activation for analytics

--- a/packages/components/src/components/Card/CardRoot.tsx
+++ b/packages/components/src/components/Card/CardRoot.tsx
@@ -52,6 +52,13 @@ type CardRootInteractiveProps = {
      * ID of the element that describes the card (e.g. a subtitle element).
      */
     'aria-describedby'?: string;
+    /**
+     * Called when the user activates the card's link overlay, before navigation.
+     * Fires for plain clicks, modifier clicks (cmd/ctrl/shift/middle), and keyboard activation.
+     * Does not fire when the card is selected (the overlay becomes a button that calls `onSelect`).
+     * Useful for analytics/tracking. Call `event.preventDefault()` to cancel navigation.
+     */
+    onNavigate?: MouseEventHandler<HTMLAnchorElement>;
 };
 
 export type CardRootProps = CardRootBaseProps &
@@ -74,6 +81,7 @@ export type CardRootProps = CardRootBaseProps &
           })
         | {
               href?: never;
+              onNavigate?: never;
               onSelect?: never;
               selected?: never;
               'aria-label'?: never;
@@ -88,6 +96,7 @@ export const CardRoot = (
         'aria-describedby': ariaDescribedby,
         selected = false,
         href,
+        onNavigate,
         onSelect,
         onMouseEnter,
         onMouseLeave,
@@ -107,12 +116,16 @@ export const CardRoot = (
 
     const handleLinkClick = useCallback(
         (event: MouseEvent<HTMLAnchorElement>) => {
+            onNavigate?.(event);
+            if (event.defaultPrevented) {
+                return;
+            }
             if (href && !event.metaKey && !event.ctrlKey && !event.shiftKey && event.button === 0) {
                 event.preventDefault();
                 navigate(href);
             }
         },
-        [href, navigate],
+        [href, navigate, onNavigate],
     );
 
     const labelledby = ariaLabel ? undefined : titleId;

--- a/packages/components/src/components/Card/__tests__/Card.spec.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.spec.tsx
@@ -312,13 +312,7 @@ describe('Card Component', () => {
     it('should not call onNavigate when the card is selected (overlay is a button)', async () => {
         const handleNavigate = vi.fn();
         renderWithRouter(
-            <Card.Root
-                href="/page"
-                onNavigate={handleNavigate}
-                onSelect={() => {}}
-                selected
-                aria-label="Card"
-            >
+            <Card.Root href="/page" onNavigate={handleNavigate} onSelect={() => {}} selected aria-label="Card">
                 <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
             </Card.Root>,
         );
@@ -329,11 +323,7 @@ describe('Card Component', () => {
     it('should not navigate when onNavigate calls preventDefault', async () => {
         navigateStub.mockClear();
         renderWithRouter(
-            <Card.Root
-                href="/page"
-                onNavigate={(event) => event.preventDefault()}
-                aria-label="Card"
-            >
+            <Card.Root href="/page" onNavigate={(event) => event.preventDefault()} aria-label="Card">
                 <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
             </Card.Root>,
         );

--- a/packages/components/src/components/Card/__tests__/Card.spec.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.spec.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -283,6 +283,62 @@ describe('Card Component', () => {
         const title = screen.getByText(CARD_TITLE_TEXT);
         const actionsContainer = screen.getByTestId('fondue-card-actions');
         expect(actionsContainer).not.toContainElement(title);
+    });
+
+    it('should call onNavigate when the link overlay is clicked', async () => {
+        const handleNavigate = vi.fn();
+        renderWithRouter(
+            <Card.Root href="/page" onNavigate={handleNavigate} aria-label="Card">
+                <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
+            </Card.Root>,
+        );
+        await userEvent.click(screen.getByRole('link', { name: 'Card' }));
+        expect(handleNavigate).toHaveBeenCalledOnce();
+    });
+
+    it('should call onNavigate with a modifier click without triggering internal navigation', () => {
+        const handleNavigate = vi.fn();
+        navigateStub.mockClear();
+        renderWithRouter(
+            <Card.Root href="/page" onNavigate={handleNavigate} aria-label="Card">
+                <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
+            </Card.Root>,
+        );
+        fireEvent.click(screen.getByRole('link', { name: 'Card' }), { metaKey: true });
+        expect(handleNavigate).toHaveBeenCalledOnce();
+        expect(navigateStub).not.toHaveBeenCalled();
+    });
+
+    it('should not call onNavigate when the card is selected (overlay is a button)', async () => {
+        const handleNavigate = vi.fn();
+        renderWithRouter(
+            <Card.Root
+                href="/page"
+                onNavigate={handleNavigate}
+                onSelect={() => {}}
+                selected
+                aria-label="Card"
+            >
+                <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
+            </Card.Root>,
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Card' }));
+        expect(handleNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate when onNavigate calls preventDefault', async () => {
+        navigateStub.mockClear();
+        renderWithRouter(
+            <Card.Root
+                href="/page"
+                onNavigate={(event) => event.preventDefault()}
+                aria-label="Card"
+            >
+                <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
+            </Card.Root>,
+        );
+        await userEvent.click(screen.getByRole('link', { name: 'Card' }));
+        expect(navigateStub).not.toHaveBeenCalled();
     });
 
     it('should allow tabbing through interactive elements', async () => {


### PR DESCRIPTION
- Added onNavigate?: MouseEventHandler<HTMLAnchorElement> to the interactive variant of CardRootProps
- Added onNavigate?: never to the non-interactive variant (discriminated-union completeness)
- Wired into handleLinkClick — fires before navigation, respects event.preventDefault() so consumers can cancel

CU-869cvg2mu