### PR TITLE
fix: address date picker issues

### DIFF
--- a/.changeset/all-rivers-grow.md
+++ b/.changeset/all-rivers-grow.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: adress issues in date picker implementation

--- a/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
+++ b/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
@@ -1,6 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconArrowLeft, IconArrowRight, IconCaretLeftDouble, IconCaretRightDouble } from '@frontify/fondue-icons';
+import {
+    IconArrowLeft,
+    IconArrowRight,
+    IconCaretLeft,
+    IconCaretLeftDouble,
+    IconCaretRight,
+    IconCaretRightDouble,
+} from '@frontify/fondue-icons';
 import { addYears, subYears } from 'date-fns';
 import { forwardRef, useEffect, useMemo, useRef } from 'react';
 import {
@@ -165,7 +172,7 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
                         }
                     }}
                 >
-                    <IconArrowLeft size={16} />
+                    <IconCaretLeft size={16} />
                 </Button>
             </div>
         );
@@ -192,7 +199,7 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
                         }
                     }}
                 >
-                    <IconArrowRight size={16} />
+                    <IconCaretRight size={16} />
                 </Button>
                 <Button
                     emphasis="weak"

--- a/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
+++ b/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
@@ -1,10 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconArrowLeft, IconArrowRight } from '@frontify/fondue-icons';
+import { IconArrowLeft, IconArrowRight, IconCaretLeftDouble, IconCaretRightDouble } from '@frontify/fondue-icons';
+import { addYears, subYears } from 'date-fns';
 import { forwardRef, useEffect, useMemo, useRef } from 'react';
 import {
     getDefaultClassNames,
     DayPicker,
+    useDayPicker,
     type PreviousMonthButtonProps,
     type NextMonthButtonProps,
     type OnSelectHandler,
@@ -123,7 +125,7 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
                 onMouseLeave={onMouseLeave}
                 type="button"
             >
-                <div className={`${styles.dayContent} ${styles.button}`}>{day.date.getDate()}</div>
+                <div className={styles.dayContent}>{day.date.getDate()}</div>
             </button>
         );
     },
@@ -132,8 +134,25 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
         'aria-label': ariaLabel,
         'aria-disabled': ariaDisabled,
     }: PreviousMonthButtonProps): JSX.Element => {
+        const { months, goToMonth, previousMonth } = useDayPicker();
+        const currentMonth = months[0]?.date;
+        const isYearDisabled = !previousMonth;
         return (
-            <div className={`${styles.toggleMonthButtonContainer} `}>
+            <div className={`${styles.toggleMonthButtonContainer} ${styles.previousMonthButtonContainer}`}>
+                <Button
+                    emphasis="weak"
+                    size="small"
+                    aspect="square"
+                    aria-label="Go to the Previous Year"
+                    aria-disabled={isYearDisabled}
+                    onPress={() => {
+                        if (currentMonth && !isYearDisabled) {
+                            goToMonth(subYears(currentMonth, 1));
+                        }
+                    }}
+                >
+                    <IconCaretLeftDouble size={16} />
+                </Button>
                 <Button
                     emphasis="weak"
                     size="small"
@@ -156,6 +175,9 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
         'aria-label': ariaLabel,
         'aria-disabled': ariaDisabled,
     }: NextMonthButtonProps): JSX.Element => {
+        const { months, goToMonth, nextMonth } = useDayPicker();
+        const currentMonth = months[0]?.date;
+        const isYearDisabled = !nextMonth;
         return (
             <div className={`${styles.toggleMonthButtonContainer} ${styles.nextMonthButtonContainer}`}>
                 <Button
@@ -171,6 +193,20 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
                     }}
                 >
                     <IconArrowRight size={16} />
+                </Button>
+                <Button
+                    emphasis="weak"
+                    size="small"
+                    aspect="square"
+                    aria-label="Go to the Next Year"
+                    aria-disabled={isYearDisabled}
+                    onPress={() => {
+                        if (currentMonth && !isYearDisabled) {
+                            goToMonth(addYears(currentMonth, 1));
+                        }
+                    }}
+                >
+                    <IconCaretRightDouble size={16} />
                 </Button>
             </div>
         );

--- a/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
+++ b/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
@@ -1,13 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import {
-    IconArrowLeft,
-    IconArrowRight,
-    IconCaretLeft,
-    IconCaretLeftDouble,
-    IconCaretRight,
-    IconCaretRightDouble,
-} from '@frontify/fondue-icons';
+import { IconCaretLeft, IconCaretLeftDouble, IconCaretRight, IconCaretRightDouble } from '@frontify/fondue-icons';
 import { addYears, subYears } from 'date-fns';
 import { forwardRef, useEffect, useMemo, useRef } from 'react';
 import {

--- a/packages/components/src/components/DatePicker/RangeDatePicker.tsx
+++ b/packages/components/src/components/DatePicker/RangeDatePicker.tsx
@@ -16,8 +16,8 @@ export const RangeDatePicker = (
     { 'data-test-id': dataTestId, onChange, selected, ...props }: RangeDatePickerProps,
     ref: ForwardedRef<HTMLDivElement>,
 ): JSX.Element => {
-    const { selectedDateRange, handleSelect } = useDateRange(selected, onChange);
-    const { hoverModifiers } = useRangeHover(selectedDateRange);
+    const { selectedDateRange, handleSelect, isAwaitingEndDate } = useDateRange(selected, onChange);
+    const { hoverModifiers } = useRangeHover(isAwaitingEndDate ? selectedDateRange : undefined);
 
     return (
         <DatePickerCalendar

--- a/packages/components/src/components/DatePicker/__tests__/DatePicker.ct.tsx
+++ b/packages/components/src/components/DatePicker/__tests__/DatePicker.ct.tsx
@@ -59,7 +59,7 @@ test.describe('SingleDatePicker', () => {
         const component = await mount(
             <DatePicker data-test-id={DATE_PICKER_TEST_ID} selected={{ year: 2025, month: 3, day: 15 }} />,
         );
-        await component.getByRole('button', { name: /next/i }).click();
+        await component.getByRole('button', { name: /next month/i }).click();
         await expect(component.getByText('April 2025')).toBeVisible();
     });
 
@@ -67,8 +67,24 @@ test.describe('SingleDatePicker', () => {
         const component = await mount(
             <DatePicker data-test-id={DATE_PICKER_TEST_ID} selected={{ year: 2025, month: 3, day: 15 }} />,
         );
-        await component.getByRole('button', { name: /previous/i }).click();
+        await component.getByRole('button', { name: /previous month/i }).click();
         await expect(component.getByText('February 2025')).toBeVisible();
+    });
+
+    test('should navigate to the next year', async ({ mount }) => {
+        const component = await mount(
+            <DatePicker data-test-id={DATE_PICKER_TEST_ID} selected={{ year: 2025, month: 3, day: 15 }} />,
+        );
+        await component.getByRole('button', { name: /next year/i }).click();
+        await expect(component.getByText('March 2026')).toBeVisible();
+    });
+
+    test('should navigate to the previous year', async ({ mount }) => {
+        const component = await mount(
+            <DatePicker data-test-id={DATE_PICKER_TEST_ID} selected={{ year: 2025, month: 3, day: 15 }} />,
+        );
+        await component.getByRole('button', { name: /previous year/i }).click();
+        await expect(component.getByText('March 2024')).toBeVisible();
     });
 
     test('should render 7 weekday columns', async ({ mount }) => {

--- a/packages/components/src/components/DatePicker/__tests__/RangeDatePicker.ct.tsx
+++ b/packages/components/src/components/DatePicker/__tests__/RangeDatePicker.ct.tsx
@@ -48,25 +48,39 @@ test.describe('RangeDatePicker', () => {
         expect(count).toBeGreaterThan(0);
     });
 
-    test('should call onChange when a day is clicked', async ({ mount }) => {
+    test('should call onChange only after both range ends have been clicked', async ({ mount }) => {
         const onChange = sinon.spy();
         const component = await mount(
             <DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} onChange={onChange} />,
         );
         await component.getByText('20', { exact: true }).click();
+        expect(onChange.callCount).toBe(0);
+        await component.getByText('25', { exact: true }).click();
         expect(onChange.callCount).toBe(1);
     });
 
     test('should navigate to the next month', async ({ mount }) => {
         const component = await mount(<DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} />);
-        await component.getByRole('button', { name: /next/i }).click();
+        await component.getByRole('button', { name: /next month/i }).click();
         await expect(component.getByText('April 2025')).toBeVisible();
     });
 
     test('should navigate to the previous month', async ({ mount }) => {
         const component = await mount(<DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} />);
-        await component.getByRole('button', { name: /previous/i }).click();
+        await component.getByRole('button', { name: /previous month/i }).click();
         await expect(component.getByText('February 2025')).toBeVisible();
+    });
+
+    test('should navigate to the next year', async ({ mount }) => {
+        const component = await mount(<DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} />);
+        await component.getByRole('button', { name: /next year/i }).click();
+        await expect(component.getByText('March 2026')).toBeVisible();
+    });
+
+    test('should navigate to the previous year', async ({ mount }) => {
+        const component = await mount(<DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} />);
+        await component.getByRole('button', { name: /previous year/i }).click();
+        await expect(component.getByText('March 2024')).toBeVisible();
     });
 
     test('should render 7 weekday columns', async ({ mount }) => {

--- a/packages/components/src/components/DatePicker/__tests__/RangeDatePicker.ct.tsx
+++ b/packages/components/src/components/DatePicker/__tests__/RangeDatePicker.ct.tsx
@@ -53,9 +53,9 @@ test.describe('RangeDatePicker', () => {
         const component = await mount(
             <DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} onChange={onChange} />,
         );
-        await component.getByText('20', { exact: true }).click();
+        await component.getByRole('button', { name: /March 20th/ }).click();
         expect(onChange.callCount).toBe(0);
-        await component.getByText('25', { exact: true }).click();
+        await component.getByRole('button', { name: /March 25th/ }).click();
         expect(onChange.callCount).toBe(1);
     });
 

--- a/packages/components/src/components/DatePicker/hooks/__tests__/useDateRange.spec.ts
+++ b/packages/components/src/components/DatePicker/hooks/__tests__/useDateRange.spec.ts
@@ -32,6 +32,15 @@ describe('useDateRange', () => {
 
             act(() => {
                 result.current.handleSelect(
+                    { from: new Date(Date.UTC(2025, 4, 1)), to: new Date(Date.UTC(2025, 4, 1)) },
+                    new Date(Date.UTC(2025, 4, 1)),
+                    {},
+                    {} as React.MouseEvent,
+                );
+            });
+
+            act(() => {
+                result.current.handleSelect(
                     { from: new Date(Date.UTC(2025, 4, 1)), to: new Date(Date.UTC(2025, 4, 10)) },
                     new Date(Date.UTC(2025, 4, 10)),
                     {},
@@ -47,9 +56,38 @@ describe('useDateRange', () => {
     });
 
     describe('controlled mode', () => {
-        it('should call onSelect callback when handleSelect is invoked with a valid range', () => {
+        it('should not call onSelect on the first click (start-date selection)', () => {
             const onSelect = vi.fn();
             const { result } = renderHook(() => useDateRange(undefined, onSelect));
+
+            act(() => {
+                result.current.handleSelect(
+                    { from: new Date(Date.UTC(2025, 0, 5)), to: new Date(Date.UTC(2025, 0, 5)) },
+                    new Date(Date.UTC(2025, 0, 5)),
+                    {},
+                    {} as React.MouseEvent,
+                );
+            });
+
+            expect(onSelect).not.toHaveBeenCalled();
+            expect(result.current.selectedDateRange).toStrictEqual({
+                from: new Date(Date.UTC(2025, 0, 5)),
+                to: new Date(Date.UTC(2025, 0, 5)),
+            });
+        });
+
+        it('should call onSelect only after the end-date has been selected', () => {
+            const onSelect = vi.fn();
+            const { result } = renderHook(() => useDateRange(undefined, onSelect));
+
+            act(() => {
+                result.current.handleSelect(
+                    { from: new Date(Date.UTC(2025, 0, 5)), to: new Date(Date.UTC(2025, 0, 5)) },
+                    new Date(Date.UTC(2025, 0, 5)),
+                    {},
+                    {} as React.MouseEvent,
+                );
+            });
 
             act(() => {
                 result.current.handleSelect(
@@ -60,9 +98,39 @@ describe('useDateRange', () => {
                 );
             });
 
+            expect(onSelect).toHaveBeenCalledTimes(1);
             expect(onSelect).toHaveBeenCalledWith({
                 from: { year: 2025, month: 1, day: 5 },
                 to: { year: 2025, month: 1, day: 25 },
+            });
+        });
+
+        it('should commit a same-day range when the end-date click repeats the start-date', () => {
+            const onSelect = vi.fn();
+            const { result } = renderHook(() => useDateRange(undefined, onSelect));
+
+            act(() => {
+                result.current.handleSelect(
+                    { from: new Date(Date.UTC(2025, 0, 5)), to: new Date(Date.UTC(2025, 0, 5)) },
+                    new Date(Date.UTC(2025, 0, 5)),
+                    {},
+                    {} as React.MouseEvent,
+                );
+            });
+
+            act(() => {
+                result.current.handleSelect(
+                    { from: new Date(Date.UTC(2025, 0, 5)), to: new Date(Date.UTC(2025, 0, 5)) },
+                    new Date(Date.UTC(2025, 0, 5)),
+                    {},
+                    {} as React.MouseEvent,
+                );
+            });
+
+            expect(onSelect).toHaveBeenCalledTimes(1);
+            expect(onSelect).toHaveBeenCalledWith({
+                from: { year: 2025, month: 1, day: 5 },
+                to: { year: 2025, month: 1, day: 5 },
             });
         });
 

--- a/packages/components/src/components/DatePicker/hooks/useDateRange.ts
+++ b/packages/components/src/components/DatePicker/hooks/useDateRange.ts
@@ -8,11 +8,13 @@ import { type DatePickerDateRange } from '../types';
 
 export const useDateRange = (selected: DatePickerDateRange, onSelect?: (dateRange: DatePickerDateRange) => void) => {
     const [internalSelectedDateRange, setInternalSelectedDateRange] = useState<DatePickerDateRange>(selected);
+    const [isAwaitingEndDate, setIsAwaitingEndDate] = useState(false);
     const [prevSelected, setPrevSelected] = useState<DatePickerDateRange | undefined>(selected);
 
     if (prevSelected !== selected) {
         setPrevSelected(selected);
         setInternalSelectedDateRange(selected);
+        setIsAwaitingEndDate(false);
     }
 
     const selectedDateRange = useMemo(() => {
@@ -22,14 +24,23 @@ export const useDateRange = (selected: DatePickerDateRange, onSelect?: (dateRang
     const handleSelect: OnSelectHandler<InternalDayPickerDateRange> = (pickerDateRange) => {
         const dateRange = transformPickerDateRangeToDateRange(pickerDateRange);
 
-        if (dateRange) {
+        if (!dateRange) {
+            return;
+        }
+
+        setInternalSelectedDateRange(dateRange);
+
+        if (isAwaitingEndDate) {
+            setIsAwaitingEndDate(false);
             onSelect?.(dateRange);
-            setInternalSelectedDateRange(dateRange);
+        } else {
+            setIsAwaitingEndDate(true);
         }
     };
 
     return {
         selectedDateRange,
         handleSelect,
+        isAwaitingEndDate,
     };
 };

--- a/packages/components/src/components/DatePicker/styles/datePickerCalendar.module.scss
+++ b/packages/components/src/components/DatePicker/styles/datePickerCalendar.module.scss
@@ -7,6 +7,10 @@
     width: fit-content;
 }
 
+.root {
+    --rdp-nav_button-width: #{sizeToken.get(15)};
+}
+
 .root[dir='rtl'] {
     .toggleMonthButtonContainer {
         transform: rotate(180deg);
@@ -15,24 +19,28 @@
 
 .toggleMonthButtonContainer {
     position: absolute;
+    top: 0;
     height: var(--rdp-nav-height);
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: sizeToken.get(2);
-    margin-right: sizeToken.get(2);
+    gap: sizeToken.get(0.5);
+    padding-inline: sizeToken.get(1);
+}
+
+.previousMonthButtonContainer {
+    inset-inline-start: 0;
 }
 
 .nextMonthButtonContainer {
     inset-inline-end: 0;
-    top: 0;
 }
 
 .weekday {
     font-size: var(--typography-font-size-small);
     line-height: var(--typography-line-height-tight);
-    font-weight: var(--typography-font-weight-bold);
-    color: var(--color-container-secondary-on-secondary-container);
+    font-weight: var(--typography-font-weight-regular);
+    color: var(--color-secondary-default);
     height: sizeToken.get(6);
     width: sizeToken.get(9);
     display: flex;
@@ -59,17 +67,23 @@
     width: sizeToken.get(9);
     padding: 0;
 
-    &[data-today='true']:after {
-        content: '';
-        position: absolute;
-        top: sizeToken.get(0.5);
-        left: sizeToken.get(0.5);
-        width: sizeToken.get(8);
-        height: sizeToken.get(8);
-        border: 1px solid var(--color-primary-default);
-        border-radius: var(--border-radius-large);
-        pointer-events: none;
-        box-sizing: border-box;
+    &[data-today='true'] {
+        & .dayContent {
+            font-weight: var(--typography-font-weight-bold);
+        }
+
+        &:after {
+            content: '';
+            position: absolute;
+            bottom: sizeToken.get(1.5);
+            left: sizeToken.get(3.5);
+            width: sizeToken.get(2);
+            height: sizeToken.get(0.5);
+            border: 1px solid var(--text-color, var(--color-primary-default));
+            border-radius: 2px;
+            pointer-events: none;
+            box-sizing: border-box;
+        }
     }
 
     &.disabled {
@@ -136,9 +150,10 @@
 }
 
 .selected {
+    --text-color: var(--color-container-highlight-on-highlight-container);
     .dayButton > .dayContent {
         background-color: var(--color-container-highlight-active);
-        color: var(--color-container-highlight-on-highlight-container);
+        color: var(--text-color);
         width: sizeToken.get(8);
         margin-left: sizeToken.get(0.5);
         padding-left: 0;
@@ -149,10 +164,10 @@
 
 @mixin rangeStartDay {
     opacity: 1;
+    --text-color: var(--color-container-highlight-on-highlight-container);
     .dayButton > .dayContent {
         background-color: var(--color-container-highlight-active);
-        color: var(--color-container-highlight-on-highlight-container);
-
+        color: var(--text-color);
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
         border-top-left-radius: var(--border-radius-large);
@@ -167,10 +182,10 @@
 
 @mixin rangeEndDay {
     opacity: 1;
+    --text-color: var(--color-container-highlight-on-highlight-container);
     .dayButton > .dayContent {
         background-color: var(--color-container-highlight-active);
-        color: var(--color-container-highlight-on-highlight-container);
-
+        color: var(--text-color);
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         border-top-right-radius: var(--border-radius-large);
@@ -185,10 +200,11 @@
 
 @mixin rangeMiddleDay {
     opacity: 1;
+    --text-color: var(--color-container-highlight-on-highlight-container);
     .dayButton > .dayContent {
+        color: var(--text-color);
         border-radius: 0;
         background-color: var(--color-container-highlight-default);
-        color: var(--color-container-highlight-on-highlight-container);
         margin-left: 0;
         padding-left: sizeToken.get(0.5);
         margin-right: 0;

--- a/packages/components/src/components/DatePicker/styles/datePickerCalendar.module.scss
+++ b/packages/components/src/components/DatePicker/styles/datePickerCalendar.module.scss
@@ -9,6 +9,8 @@
 
 .root {
     --rdp-nav_button-width: #{sizeToken.get(15)};
+    --rdp-nav-height: #{sizeToken.get(6)};
+    margin-top: sizeToken.get(2);
 }
 
 .root[dir='rtl'] {
@@ -50,7 +52,11 @@
 
 .weekdays {
     display: flex;
+    align-items: center;
     width: 100%;
+    height: sizeToken.get(9);
+    margin-bottom: sizeToken.get(1);
+    margin-top: sizeToken.get(2);
 }
 
 .week {


### PR DESCRIPTION
Adjust the `DatePicker` component to adrdess several concerns raised by consuming teams and designers.

Changes:
- Range Selection can have the same day as the start and end
- Todays date is indicated by a underline instead of a border
- Added Buttons to jump years
- Adjusted styling for weekdays -> color=secondary + weight=normal
