### PR TITLE
fix(`OrderableList`): not ordering when dragging and dropping

### DIFF
--- a/.changeset/nasty-chairs-listen.md
+++ b/.changeset/nasty-chairs-listen.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(`OrderableList`): not ordering when dragging and dropping

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -11,14 +11,6 @@ const peerDependencies = Object.keys(peerDependenciesMap);
 const dependencies = Object.keys(dependenciesMap);
 const externalPackages = [...dependencies, ...peerDependencies, 'react-dom/client', 'react/jsx-runtime'];
 
-// Externalize a declared dependency AND any of its subpath imports (e.g.
-// `@dnd-kit/react/sortable`, `@dnd-kit/abstract/modifiers`). Rollup's static `external`
-// array does exact-string matching, so without subpath handling those modules get
-// inlined into the bundle, dragging in their transitive deps (`@dnd-kit/dom`,
-// `@dnd-kit/state`, etc.) as duplicate copies alongside the consumer's. That breaks
-// libraries that rely on a single shared runtime instance — most visibly dnd-kit,
-// whose registry uses `instanceof Draggable` / `instanceof Droppable` checks that
-// silently fail when two copies of the class exist.
 const isExternal = (id: string) => externalPackages.some((pkg) => id === pkg || id.startsWith(`${pkg}/`));
 
 export const globals = {

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -9,6 +9,17 @@ import { dependencies as dependenciesMap, peerDependencies as peerDependenciesMa
 
 const peerDependencies = Object.keys(peerDependenciesMap);
 const dependencies = Object.keys(dependenciesMap);
+const externalPackages = [...dependencies, ...peerDependencies, 'react-dom/client', 'react/jsx-runtime'];
+
+// Externalize a declared dependency AND any of its subpath imports (e.g.
+// `@dnd-kit/react/sortable`, `@dnd-kit/abstract/modifiers`). Rollup's static `external`
+// array does exact-string matching, so without subpath handling those modules get
+// inlined into the bundle, dragging in their transitive deps (`@dnd-kit/dom`,
+// `@dnd-kit/state`, etc.) as duplicate copies alongside the consumer's. That breaks
+// libraries that rely on a single shared runtime instance — most visibly dnd-kit,
+// whose registry uses `instanceof Draggable` / `instanceof Droppable` checks that
+// silently fail when two copies of the class exist.
+const isExternal = (id: string) => externalPackages.some((pkg) => id === pkg || id.startsWith(`${pkg}/`));
 
 export const globals = {
     react: 'React',
@@ -39,7 +50,7 @@ export default defineConfig({
         sourcemap: true,
         minify: true,
         rollupOptions: {
-            external: [...dependencies, ...peerDependencies, 'react-dom/client', 'react/jsx-runtime'],
+            external: isExternal,
             output: [
                 {
                     name: 'FondueComponents',


### PR DESCRIPTION
## What

`OrderableList`'s drag choreography (items shifting to make space) works in Storybook but does nothing once consumed from the published package.

## Why

Our Vite config used the array form of Rollup's `external`, which only does exact-string matching. So `@dnd-kit/react` was external, but `@dnd-kit/react/sortable` (a subpath we actually use) wasn't. Rollup walked into it and bundled the transitive deps. Consumers ended up with two copies of dnd-kit's classes; the `instanceof` checks dnd-kit's registry uses internally silently failed and choreography never ran.

Storybook didn't see this because it builds from source single class identity, no duplication.

This is a known Rollup/Vite footgun:
- [egoist/tsup#722](https://github.com/egoist/tsup/pull/722) — tsup's PR fixing the exact same array-vs-subpath issue
- [vitejs/vite#6198](https://github.com/vitejs/vite/discussions/6198) — Vite library-mode external discussion that spawned [`vite-plugin-externalize-deps`](https://github.com/davidmyersdev/vite-plugin-externalize-deps) for this class of problem

## Fix

Swap the array for a function that matches declared deps **and** their subpaths. One file, one option, no `package.json` changes.

## Verified

Rebuilt the dist (no more inlined dnd-kit classes), yalc-linked into web-app, drag-and-drop works.
