### PR TITLE
feat: add pressed state to card component

### DIFF
--- a/.changeset/card-pressed-state.md
+++ b/.changeset/card-pressed-state.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Card): add pressed state that shifts the card and banner background to `surface-active` while the card is actively clicked

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -113,6 +113,11 @@
                 $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
             );
         }
+
+        // Pressed state (while actively clicking, via :active)
+        &:active {
+            background-color: var(--color-surface-active);
+        }
     }
 }
 
@@ -172,6 +177,10 @@
     .root[data-interactive='true']:hover &:has(> .bannerIcon),
     .root[data-interactive='true']:has([data-state='open']) &:has(> .bannerIcon) {
         background-color: var(--color-surface-hover);
+    }
+
+    .root[data-interactive='true']:active &:has(> .bannerIcon) {
+        background-color: var(--color-surface-active);
     }
 
     &[data-size='small'] {


### PR DESCRIPTION
## Summary
- Adds a "pressed" visual state to interactive cards, triggered by the CSS `:active` pseudo-class (while the user holds the mouse/touch on the card).
- Background shifts to `--color-surface-active` on the card root and on the banner (when it contains a `bannerIcon`).
- Border and box-shadow are untouched, so the press overlay composes on top of hover, selected, and hover+selected states.

## Design
Matches Figma: [link](https://www.figma.com/design/vYLXkUhWGHIpEftV1zTpqI/Patterns-v1.0?node-id=4056-90892)
