### PR TITLE
fix: handle meta keys in select key listener

### DIFF
--- a/.changeset/moody-beans-visit.md
+++ b/.changeset/moody-beans-visit.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: minor component adjustments

--- a/packages/components/src/components/Select/components/ComboboxBase.tsx
+++ b/packages/components/src/components/Select/components/ComboboxBase.tsx
@@ -312,6 +312,11 @@ const ComboboxBaseInput = (
                                     // eslint-disable-next-line react-hooks/refs
                                     {...getInputProps({
                                         ref: inputCallbackRef,
+                                        onKeyDown: (event: React.KeyboardEvent) => {
+                                            if (event.metaKey || event.ctrlKey) {
+                                                Object.assign(event.nativeEvent, { preventDownshiftDefault: true });
+                                            }
+                                        },
                                         'aria-label': 'aria-label' in props ? props['aria-label'] : undefined,
                                         // Remove auto-generated aria-labelledby if not explicitly provided
                                         'aria-labelledby':
@@ -333,6 +338,11 @@ const ComboboxBaseInput = (
                     ) : (
                         <input
                             {...getInputProps({
+                                onKeyDown: (event: React.KeyboardEvent) => {
+                                    if (event.metaKey || event.ctrlKey) {
+                                        Object.assign(event.nativeEvent, { preventDownshiftDefault: true });
+                                    }
+                                },
                                 'aria-label': 'aria-label' in props ? props['aria-label'] : undefined,
                                 // Remove auto-generated aria-labelledby if not explicitly provided
                                 'aria-labelledby':

--- a/packages/components/src/components/Select/components/SelectBase.tsx
+++ b/packages/components/src/components/Select/components/SelectBase.tsx
@@ -218,6 +218,11 @@ const SelectBaseInput = (
                               'aria-label': 'aria-label' in props ? props['aria-label'] : undefined,
                               'aria-describedby': selectionDescription ? selectionDescriptionId : undefined,
                               ref: triggerRef,
+                              onKeyDown: (event) => {
+                                  if (event.metaKey || event.ctrlKey) {
+                                      Object.assign(event.nativeEvent, { preventDownshiftDefault: true });
+                                  }
+                              },
                           }))}
                 >
                     {selectionDescription ? (

--- a/packages/components/src/components/Select/styles/select.module.scss
+++ b/packages/components/src/components/Select/styles/select.module.scss
@@ -29,6 +29,10 @@
     border: var(--border-width-default) solid var(--color-line-mid);
     cursor: pointer;
 
+    &:has(.input) {
+        cursor: default;
+    }
+
     & {
         @include focusStyle.focus-outline;
     }
@@ -139,7 +143,7 @@
         color: var(--color-disabled-default);
     }
 
-    &:disabled~.slot {
+    &:disabled ~ .slot {
         color: var(--color-disabled-default);
     }
 }
@@ -166,7 +170,7 @@
         margin-inline: 0px;
         padding-inline-end: 0px;
 
-        &>svg {
+        & > svg {
             margin-inline-start: sizeToken.get(1);
             margin-inline-end: sizeToken.get(1);
         }
@@ -195,7 +199,7 @@
     justify-content: center;
     padding: 0 sizeToken.get(1);
 
-    button:not(:hover)>.clearIcon {
+    button:not(:hover) > .clearIcon {
         color: var(--color-secondary-default);
     }
 }
@@ -206,12 +210,12 @@
     padding-inline-start: 0;
     padding-inline-end: sizeToken.get(2);
 
-    &>svg {
+    & > svg {
         margin-inline-start: sizeToken.get(1);
         margin-inline-end: sizeToken.get(1);
     }
 
-    &>button:has(.caret) {
+    & > button:has(.caret) {
         padding-inline-start: sizeToken.get(1);
         padding-inline-end: sizeToken.get(1);
     }
@@ -353,7 +357,7 @@
 }
 
 .group {
-    .item+& {
+    .item + & {
         border-top: var(--border-width-default) solid var(--color-line-mid);
         margin-bottom: 0.5rem;
     }
@@ -387,7 +391,7 @@
     min-width: 0;
     flex: 1;
 
-    .root>& {
+    .root > & {
         padding-inline-start: sizeToken.get(2);
     }
 }


### PR DESCRIPTION
- Ignore key commands on `Select` when a meta key is held down
- Use correct cursor for combobox element