### PR TITLE
fix: prevent input clicks and keydown events inside <Table.Row> from triggering row click [CU-869d2t9c6]

### DIFF
--- a/.changeset/itchy-tips-unite.md
+++ b/.changeset/itchy-tips-unite.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: prevent input clicks and keydown events inside <Table.Row> from triggering row click

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -678,7 +678,7 @@ export const Interactive: Story = {
                         <Table.RowCell>{user.lastSeen}</Table.RowCell>
                         <Table.RowCell>
                             <TextInput
-                                onClick={()=> alert('Input clicked — this does NOT trigger row click')}
+                                onBlur={()=> alert('Input clicked — this does NOT trigger row click')}
                                 placeholder='Neither Space nor Enter keydown should trigger a row click.'
                             />
                         </Table.RowCell>

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -679,7 +679,7 @@ export const Interactive: Story = {
                         <Table.RowCell>
                             <TextInput
                                 onBlur={()=> alert('Input clicked — this does NOT trigger row click')}
-                                placeholder='Neither Space nor Enter keydown should trigger a row click.'
+                                placeholder="Neither Space nor Enter keydown should trigger a row click."
                             />
                         </Table.RowCell>
                         <Table.RowCell>

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -659,6 +659,7 @@ export const Interactive: Story = {
                     <Table.HeaderCell>Name</Table.HeaderCell>
                     <Table.HeaderCell>Invited by</Table.HeaderCell>
                     <Table.HeaderCell>Last seen</Table.HeaderCell>
+                    <Table.HeaderCell>Input</Table.HeaderCell>
                     <Table.HeaderCell>Action</Table.HeaderCell>
                 </Table.Row>
             </Table.Header>
@@ -675,6 +676,12 @@ export const Interactive: Story = {
                         </Table.RowCell>
                         <Table.RowCell>{user.invited}</Table.RowCell>
                         <Table.RowCell>{user.lastSeen}</Table.RowCell>
+                        <Table.RowCell>
+                            <TextInput
+                                onClick={()=> alert('Input clicked — this does NOT trigger row click')}
+                                placeholder='Neither Space nor Enter keydown should trigger a row click.'
+                            />
+                        </Table.RowCell>
                         <Table.RowCell>
                             <Button onPress={() => alert('Button pressed — this does NOT trigger row click')}>
                                 <span>Press me</span>

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -678,7 +678,7 @@ export const Interactive: Story = {
                         <Table.RowCell>{user.lastSeen}</Table.RowCell>
                         <Table.RowCell>
                             <TextInput
-                                onBlur={()=> alert('Input clicked — this does NOT trigger row click')}
+                                onBlur={() => alert('Input clicked — this does NOT trigger row click')}
                                 placeholder="Neither Space nor Enter keydown should trigger a row click."
                             />
                         </Table.RowCell>

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -24,7 +24,7 @@ import { Box } from '../Box/Box';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import styles from './styles/table.module.scss';
-import { handleKeyDown, shouldIgnoreRowClick } from './utils';
+import { handleKeyDown, shouldIgnoreRowClick, shouldIgnoreRowKeyDown } from './utils';
 
 type TableRootProps = {
     /**
@@ -403,7 +403,7 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
         };
 
         const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>) => {
-            if (!isInteractive) {
+            if (!isInteractive || shouldIgnoreRowKeyDown(event)) {
                 return;
             }
 

--- a/packages/components/src/components/Table/__tests__/Table.ct.tsx
+++ b/packages/components/src/components/Table/__tests__/Table.ct.tsx
@@ -269,7 +269,7 @@ test('should handle all row states and interactions', async ({ mount }) => {
                 <Table.Row onClick={onClick}>
                     <Table.RowCell>Test</Table.RowCell>
                     <Table.RowCell>
-                        <input type="text"/>
+                        <input type="text" />
                     </Table.RowCell>
                 </Table.Row>
             </Table.Body>

--- a/packages/components/src/components/Table/__tests__/Table.ct.tsx
+++ b/packages/components/src/components/Table/__tests__/Table.ct.tsx
@@ -258,12 +258,18 @@ test('should handle all row states and interactions', async ({ mount }) => {
                     <Table.RowCell>Test</Table.RowCell>
                     <Table.RowCell>Test</Table.RowCell>
                 </Table.Row>
-                <Table.Row>
+                <Table.Row onClick={onClick}>
                     <Table.RowCell>Test</Table.RowCell>
                     <Table.RowCell>
                         <button type="button" onClick={onButtonClick}>
                             Test
                         </button>
+                    </Table.RowCell>
+                </Table.Row>
+                <Table.Row onClick={onClick}>
+                    <Table.RowCell>Test</Table.RowCell>
+                    <Table.RowCell>
+                        <input type="text"/>
                     </Table.RowCell>
                 </Table.Row>
             </Table.Body>
@@ -286,7 +292,15 @@ test('should handle all row states and interactions', async ({ mount }) => {
     const fourthRow = component.locator('tr').nth(3);
     const button = fourthRow.locator('button');
     await button.click();
+    sinon.assert.calledOnce(onClick);
     sinon.assert.calledOnce(onButtonClick);
+
+    const fifthRow = component.locator('tr').nth(4);
+    const input = fifthRow.locator('input');
+    await input.click();
+    await input.press('Space');
+    await input.press('Enter');
+    sinon.assert.calledOnce(onClick);
 });
 
 test('should handle all cell configurations', async ({ mount }) => {

--- a/packages/components/src/components/Table/__tests__/utils.spec.ts
+++ b/packages/components/src/components/Table/__tests__/utils.spec.ts
@@ -3,7 +3,7 @@
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { describe, it, expect, vi, beforeEach, test } from 'vitest';
 
-import { handleKeyDown, shouldIgnoreRowClick } from '../utils';
+import { handleKeyDown, shouldIgnoreRowClick, shouldIgnoreRowKeyDown } from '../utils';
 
 describe('handleKeyDown', () => {
     beforeEach(() => {
@@ -269,5 +269,23 @@ describe('shouldIgnoreRowClick', () => {
         const result = shouldIgnoreRowClick(fakeEvent);
 
         expect(result).toBe(true);
+    });
+});
+
+describe('shouldIgnoreRowKeyDown', () => {
+    it('should return false when target is the row itself', () => {
+        const row = document.createElement('tr');
+        const fakeEvent = { target: row, currentTarget: row } as unknown as KeyboardEvent<HTMLTableRowElement>;
+
+        expect(shouldIgnoreRowKeyDown(fakeEvent)).toBe(false);
+    });
+
+    it('should return true when target is an input inside the row', () => {
+        const row = document.createElement('tr');
+        const input = document.createElement('input');
+        row.appendChild(input);
+        const fakeEvent = { target: input, currentTarget: row } as unknown as KeyboardEvent<HTMLTableRowElement>;
+
+        expect(shouldIgnoreRowKeyDown(fakeEvent)).toBe(true);
     });
 });

--- a/packages/components/src/components/Table/utils.ts
+++ b/packages/components/src/components/Table/utils.ts
@@ -31,7 +31,7 @@ export function handleKeyDown(event: KeyboardEvent<HTMLTableElement>) {
     }
 }
 
-const INTERACTIVE_ELEMENTS_LIST = [HTMLButtonElement, HTMLAnchorElement];
+const INTERACTIVE_ELEMENTS_LIST = [HTMLButtonElement, HTMLAnchorElement, HTMLInputElement];
 const INTERACTIVE_ROLES_LIST = ['button', 'link'];
 
 export function shouldIgnoreRowClick(event?: MouseEvent): boolean {
@@ -61,4 +61,8 @@ export function shouldIgnoreRowClick(event?: MouseEvent): boolean {
     }
 
     return false;
+}
+
+export function shouldIgnoreRowKeyDown(event: KeyboardEvent<HTMLTableRowElement>): boolean {
+    return event.target !== event.currentTarget;
 }


### PR DESCRIPTION
## What
This PR updates how keyboard and mouse events work in the `<Table.Row>` component.

If the `onClick` prop is defined for `<Table.Row>`:
- clicking inside an input cell will only focus the input, not trigger the row's click
- pressing `Space` or `Enter` inside an input cell will only trigger the input's native behavior and no more trigger the row's click

## Why
Previously, clicks and keyboard events from input cells would bubble up to the row and fire the row's click handler, making it difficult to interact with inputs inside a table row.

## Issue in video

https://github.com/user-attachments/assets/884c790d-a098-4820-a791-2e4b8a264cac

