### PR TITLE
feat: add forwardRef to ThemeProvider

### DIFF
--- a/.changeset/polite-streets-lie.md
+++ b/.changeset/polite-streets-lie.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat: add forwardRef to `ThemeProvider` to avoid an error to be thrown in Radix UIs `Presence` component

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -8,7 +8,6 @@ import { action } from 'storybook/actions';
 import { Flex } from '#/components/Flex/Flex.tsx';
 
 import { Button } from '../Button/Button';
-import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
 
 import { ComboboxMultiple } from './ComboboxMultiple';
 import { ComboboxSingle } from './ComboboxSingle';

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -8,6 +8,7 @@ import { action } from 'storybook/actions';
 import { Flex } from '#/components/Flex/Flex.tsx';
 
 import { Button } from '../Button/Button';
+import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
 
 import { ComboboxMultiple } from './ComboboxMultiple';
 import { ComboboxSingle } from './ComboboxSingle';

--- a/packages/components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -2,7 +2,7 @@
 
 import styles from '@frontify/fondue-tokens/themes';
 import { Slot } from '@radix-ui/react-slot';
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { createContext, type ForwardedRef, forwardRef, useContext, useMemo, type ReactNode } from 'react';
 
 import { enUS, type Translations } from '../../locales';
 
@@ -61,29 +61,30 @@ export const useFondueTheme = () => {
     };
 };
 
-export const ThemeProvider = ({
-    children,
-    theme = 'light',
-    dir = 'ltr',
-    translations = enUS,
-    asChild = false,
-}: ThemeProviderProps) => {
-    const Comp = asChild ? Slot : 'div';
+export const ThemeProvider = forwardRef<HTMLDivElement, ThemeProviderProps>(
+    (
+        { children, theme = 'light', dir = 'ltr', translations = enUS, asChild = false },
+        forwardedRef: ForwardedRef<HTMLDivElement>,
+    ) => {
+        const Comp = asChild ? Slot : 'div';
 
-    const contextValue = useMemo(
-        () => ({
-            theme,
-            dir,
-            translations,
-        }),
-        [dir, theme, translations],
-    );
+        const contextValue = useMemo(
+            () => ({
+                theme,
+                dir,
+                translations,
+            }),
+            [dir, theme, translations],
+        );
 
-    return (
-        <ThemeContext.Provider value={contextValue}>
-            <Comp dir={dir} className={`${styles[theme]} fondue-theme-provider`}>
-                {children}
-            </Comp>
-        </ThemeContext.Provider>
-    );
-};
+        return (
+            <ThemeContext.Provider value={contextValue}>
+                <Comp ref={forwardedRef} dir={dir} className={`${styles[theme]} fondue-theme-provider`}>
+                    {children}
+                </Comp>
+            </ThemeContext.Provider>
+        );
+    },
+);
+
+ThemeProvider.displayName = 'ThemeProvider';


### PR DESCRIPTION
Forward the `ref` inside the `ThemeProvider` by wrapping it in `forwardRef`
This prevents an error to be thrown in Radix UIs presence component. 

Fixes the issue reported in #2700