### PR TITLE
feat(Dropdown): Expose onCloseAutoFocus on Dropdown.Content

### DIFF
--- a/.changeset/many-squids-invent.md
+++ b/.changeset/many-squids-invent.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+Expose onCloseAutoFocus on Dropdown.Content

--- a/packages/components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.stories.tsx
@@ -469,6 +469,26 @@ export const OnEscapeKeyDown: Story = {
     ),
 };
 
+export const OnCloseAutoFocus: Story = {
+    render: ({ ...args }) => (
+        <Dropdown.Root {...args}>
+            <Dropdown.Trigger>
+                <Button>Trigger</Button>
+            </Dropdown.Trigger>
+            <Dropdown.Content
+                onCloseAutoFocus={(event) => {
+                    event.preventDefault();
+                    alert('Trigger focus restoration was suppressed.');
+                }}
+            >
+                <Dropdown.Item onSelect={() => {}}>Item 1</Dropdown.Item>
+                <Dropdown.Item onSelect={() => {}}>Item 2</Dropdown.Item>
+                <Dropdown.Item onSelect={() => {}}>Item 3</Dropdown.Item>
+            </Dropdown.Content>
+        </Dropdown.Root>
+    ),
+};
+
 export const PreventCloseOnEscape: Story = {
     render: ({ ...args }) => (
         <Dropdown.Root {...args}>

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -108,6 +108,14 @@ export type DropdownContentProps = {
      * Event handler called when the escape key is pressed.
      */
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
+    /**
+     * Event handler called when focus is about to be moved back to the trigger after the dropdown closes.
+     * Call `event.preventDefault()` to suppress the trigger restore for this particular close — useful
+     * when focus needs to be redirected per close path rather than uniformly (for example, restoring on
+     * Escape but redirecting elsewhere on item selection). Fires after `preventTriggerFocusOnClose` is
+     * applied.
+     */
+    onCloseAutoFocus?: (event: Event) => void;
 };
 
 const SPACING_MAP: Record<DropdownSpacing, number> = {
@@ -131,6 +139,7 @@ export const DropdownContent = (
         viewportCollisionPadding = 'compact',
         forceMount = false,
         onEscapeKeyDown,
+        onCloseAutoFocus,
         'data-test-id': dataTestId = 'fondue-dropdown-content',
     }: DropdownContentProps,
     ref: ForwardedRef<HTMLDivElement>,
@@ -186,6 +195,7 @@ export const DropdownContent = (
                         if (preventTriggerFocusOnClose) {
                             event.preventDefault();
                         }
+                        onCloseAutoFocus?.(event);
                     }}
                     forceMount={forceMount || undefined}
                 >

--- a/packages/components/src/components/Dropdown/__tests__/Dropdown.ct.tsx
+++ b/packages/components/src/components/Dropdown/__tests__/Dropdown.ct.tsx
@@ -630,6 +630,32 @@ test('should open dropdown when clicking on icon inside trigger with forceMount'
     await expect(content).not.toBeVisible();
 });
 
+test('should call onCloseAutoFocus when the dropdown closes', async ({ mount, page }) => {
+    const onCloseAutoFocus = sinon.spy();
+    const component = await mount(
+        <Dropdown.Root>
+            <Dropdown.Trigger>
+                <Button data-test-id={DROPDOWN_TRIGGER_TEST_ID}>Trigger</Button>
+            </Dropdown.Trigger>
+            <Dropdown.Content data-test-id={DROPDOWN_CONTENT_TEST_ID} onCloseAutoFocus={onCloseAutoFocus}>
+                <Dropdown.Item onSelect={() => {}}>Item 1</Dropdown.Item>
+            </Dropdown.Content>
+        </Dropdown.Root>,
+    );
+
+    await expect(component).toBeVisible();
+    await page.getByTestId(DROPDOWN_TRIGGER_TEST_ID).focus();
+    await page.keyboard.press('Enter');
+    const content = page.getByTestId(DROPDOWN_CONTENT_TEST_ID);
+    await expect(content).toBeVisible();
+    await content.getByRole('menuitem').first().focus();
+
+    expect(onCloseAutoFocus.callCount).toBe(0);
+    await page.keyboard.press('Escape');
+    await expect(content).not.toBeVisible();
+    expect(onCloseAutoFocus.callCount).toBe(1);
+});
+
 test('should call onEscapeKeyDown when escape is pressed', async ({ mount, page }) => {
     const onEscapeKeyDown = sinon.spy();
     const component = await mount(


### PR DESCRIPTION
## Summary

Forward the `onCloseAutoFocus` callback from `Dropdown.Content` through to `RadixDropdown.Content`, so consumers can decide per close event whether to suppress the default trigger-focus restoration. The existing `preventTriggerFocusOnClose` boolean stays as a convenience shortcut.

## Motivating consumer case

A consumer dropdown has two close paths that want opposite behaviors:

- Escape (or outside click): restore focus to the trigger — standard menu-close behavior, important for keyboard accessibility.
- Item-select: suppress trigger restore — focus is being moved elsewhere (e.g. to a newly-rendered field), and a flash through the trigger first is jarring.

With only the boolean, picking either default leaves the other path broken.

Setting `preventTriggerFocusOnClose={true}` makes item-select clean but sacrifices Escape restoration; leaving it false flashes focus through the trigger before the consumer's redirect.

## Compatibility

Additive. Existing consumers of `preventTriggerFocusOnClose` are unchanged. Consumers who need finer control opt in to `onCloseAutoFocus` directly.
