### PR TITLE
fix: use padding-inline instead of text-indent

### DIFF
--- a/.changeset/cuddly-berries-say.md
+++ b/.changeset/cuddly-berries-say.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix: use padding-inline instead of text-indent, as it causes a bug in firefox 151

--- a/packages/components/src/components/TextInput/styles/text.module.scss
+++ b/packages/components/src/components/TextInput/styles/text.module.scss
@@ -64,7 +64,7 @@
     // Remove text-indent and border-radius from input and placeholder when there's a left slot
     &:has(.slot:not([data-name='right'])) {
         .input {
-            text-indent: 0px;
+            padding-inline-start: 0;
             border-start-start-radius: 0px;
             border-end-start-radius: 0px;
         }
@@ -77,7 +77,7 @@
     // Remove text-indent and border-radius from input and placeholder when there's a left slot
     &:has(.slot:not([data-name='right'])) {
         .input {
-            text-indent: 0px;
+            padding-inline-start: 0;
             border-start-start-radius: 0px;
             border-end-start-radius: 0px;
         }
@@ -94,7 +94,7 @@
     display: flex;
     align-items: center;
     text-align: inherit;
-    text-indent: sizeToken.get(3);
+    padding-inline-start: sizeToken.get(3);
     outline: 2px solid transparent;
     outline-offset: 2px;
     border-radius: calc(var(--border-radius-medium) - var(--border-width-default));
@@ -125,6 +125,7 @@
     &[readonly] {
         cursor: text;
         color: var(--color-primary-default);
+        padding-inline-start: 0;
         text-indent: 0px;
     }
 


### PR DESCRIPTION
In firefox 151 `text-indent` is not displaying correctly

Migrating to `padding-inline-start` to avoid the bug

