### PR TITLE
fix(Table): sticky column borders should be the same colors as the other borders

### DIFF
--- a/.changeset/busy-nights-invent.md
+++ b/.changeset/busy-nights-invent.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(Table): sticky column border color should be the same as the other borders

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -40,7 +40,7 @@
         &[data-has-horizontal-overflow='true'] {
             .headerCell:first-child,
             .rowCell:first-child {
-                border-inline-end: 1px solid var(--line-color);
+                border-inline-end: 1px solid var(--color-line-subtle);
             }
         }
     }
@@ -58,7 +58,7 @@
         &[data-has-horizontal-overflow='true'] {
             .headerCell:first-child,
             .rowCell:first-child {
-                border-inline-end: 1px solid var(--line-color);
+                border-inline-end: 1px solid var(--color-line-subtle);
             }
         }
     }
@@ -75,7 +75,7 @@
         &[data-has-horizontal-overflow='true'] {
             .headerCell:last-child,
             .rowCell:last-child {
-                border-inline-start: 1px solid var(--line-color);
+                border-inline-start: 1px solid var(--color-line-subtle);
             }
         }
     }


### PR DESCRIPTION
We've got this bug submitted by a designer that is related to a table and we figured the issue stems from inside Fondue.

It looks like the sticky columns have a border that is of a different color compared to the other ones:
<img width="216" height="836" alt="image" src="https://github.com/user-attachments/assets/c7145018-3721-4aee-9176-ba8bad2c55be" />

