### PR TITLE
feat(Accordion): add sticky flag to make headers sticky in ScrollArea

### DIFF
--- a/.changeset/social-states-write.md
+++ b/.changeset/social-states-write.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Accordion): add sticky flag to make headers sticky in ScrollArea

--- a/packages/components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/components/Accordion/Accordion.stories.tsx
@@ -5,7 +5,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { action } from 'storybook/actions';
 
-import { Badge, Button, ColorPicker, Dropdown, Flex, Flyout } from '#/index';
+import { Badge, Button, ColorPicker, Dropdown, Flex, Flyout, ScrollArea } from '#/index';
 
 import { Accordion, AccordionContent, AccordionHeader, AccordionItem, AccordionRoot } from './Accordion';
 
@@ -220,6 +220,84 @@ export const Default: Story = {
                     </Accordion.Content>
                 </Accordion.Item>
             </Accordion.Root>
+        );
+    },
+};
+
+export const InScrollArea: Story = {
+    args: {
+        sticky: true,
+        defaultValue: ['accordion-test-0', 'accordion-test-1', 'accordion-test-2'],
+    },
+    render: (args) => {
+        return (
+            <ScrollArea maxHeight={300} maxWidth={600}>
+                <Accordion.Root {...args}>
+                    <Accordion.Item value="accordion-test-0">
+                        <Accordion.Header>
+                            <Flex gap={2} align="center">
+                                <IconIcon size="20" />
+                                Item with icon
+                            </Flex>
+                        </Accordion.Header>
+                        <Accordion.Content divider>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam
+                            et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+                            Lorem ipsum dolor sit amet.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-1">
+                        <Accordion.Header>
+                            With action slot
+                            <Accordion.Slot name="action">
+                                <Button size="small" emphasis="default">
+                                    Click Me
+                                </Button>
+                            </Accordion.Slot>
+                        </Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam
+                            et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+                            Lorem ipsum dolor sit amet.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-2">
+                        <Accordion.Header>Item three</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-3">
+                        <Accordion.Header>Item four</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-4">
+                        <Accordion.Header>Item five</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-5">
+                        <Accordion.Header>Item six</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+                </Accordion.Root>
+            </ScrollArea>
         );
     },
 };

--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -46,6 +46,12 @@ export type AccordionRootProps = {
      */
     padding?: AccordionPadding;
     /**
+     * When `true`, each `Accordion.Header` becomes sticky and pins to the top of the nearest
+     * scrolling ancestor (e.g. a `ScrollArea`) while its item is in view.
+     * @default false
+     */
+    sticky?: boolean;
+    /**
      * Callback function that is called when the value of the accordion changes.
      */
     onValueChange?: (value: string[]) => void;
@@ -61,6 +67,7 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
             disabled,
             value,
             padding = 'large',
+            sticky = false,
             onValueChange,
         }: AccordionRootProps,
         ref: ForwardedRef<HTMLDivElement>,
@@ -76,6 +83,7 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
                 value={value}
                 data-border={border}
                 data-accordion-padding={padding}
+                data-sticky={sticky}
                 onValueChange={onValueChange}
             >
                 {children}

--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -9,7 +9,6 @@ import {
     isValidElement,
     useCallback,
     useContext,
-    useEffect,
     useMemo,
     useRef,
     type ForwardedRef,
@@ -20,7 +19,6 @@ import {
 import styles from './styles/accordion.module.scss';
 
 type AccordionRootContextValue = {
-    sticky: boolean;
     registerItem: (value: string, element: HTMLDivElement | null) => void;
 };
 
@@ -49,11 +47,28 @@ const restoreScrollForClosingItem = (itemEl: HTMLElement) => {
     const containerRect = scrollContainer.getBoundingClientRect();
     const delta = itemRect.top - containerRect.top;
 
-    // Only adjust if the item is scrolled above (or exactly at) the top of the
-    // scroll container — i.e. its header is currently pinned in sticky state.
-    if (delta < 0) {
-        scrollContainer.scrollTo({ top: scrollContainer.scrollTop + delta, behavior: 'smooth' });
+    if (delta >= 0) {
+        return;
     }
+
+    const contentEl = itemEl.querySelector<HTMLElement>(`:scope > .${styles.accordionContent}`);
+    const startHeight = contentEl?.offsetHeight ?? 0;
+
+    if (!contentEl || startHeight === 0) {
+        scrollContainer.scrollTop = scrollContainer.scrollTop + delta;
+        return;
+    }
+
+    const startTop = scrollContainer.scrollTop;
+    const step = () => {
+        const currentHeight = contentEl.offsetHeight;
+        const progress = Math.min(Math.max(1 - currentHeight / startHeight, 0), 1);
+        scrollContainer.scrollTop = startTop + delta * progress;
+        if (currentHeight > 0 && progress < 1) {
+            requestAnimationFrame(step);
+        }
+    };
+    requestAnimationFrame(step);
 };
 
 type AccordionPadding = 'none' | 'small' | 'medium' | 'large';
@@ -115,7 +130,7 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
         ref: ForwardedRef<HTMLDivElement>,
     ) => {
         const itemsRef = useRef<Map<string, HTMLDivElement>>(new Map());
-        const previousValueRef = useRef<string[]>(value ?? defaultValue ?? []);
+        const uncontrolledValueRef = useRef<string[]>(defaultValue ?? []);
 
         const registerItem = useCallback((itemValue: string, element: HTMLDivElement | null) => {
             if (element) {
@@ -125,38 +140,32 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
             }
         }, []);
 
-        const contextValue = useMemo<AccordionRootContextValue>(
-            () => ({ sticky, registerItem }),
-            [sticky, registerItem],
-        );
+        const contextValue = useMemo<AccordionRootContextValue>(() => ({ registerItem }), [registerItem]);
 
-        const handleValueChange = (newValue: string[]) => {
-            if (sticky) {
-                const previous = previousValueRef.current;
-                for (const closedValue of previous) {
-                    if (newValue.includes(closedValue)) {
-                        continue;
-                    }
+        const handleValueChange = useCallback(
+            (newValue: string[]) => {
+                if (sticky) {
+                    const previous = value ?? uncontrolledValueRef.current;
+                    for (const closedValue of previous) {
+                        if (newValue.includes(closedValue)) {
+                            continue;
+                        }
 
-                    const itemEl = itemsRef.current.get(closedValue);
+                        const itemEl = itemsRef.current.get(closedValue);
 
-                    if (itemEl) {
-                        restoreScrollForClosingItem(itemEl);
+                        if (itemEl) {
+                            restoreScrollForClosingItem(itemEl);
+                        }
                     }
                 }
-            }
 
-            if (value === undefined) {
-                previousValueRef.current = newValue;
-            }
-            onValueChange?.(newValue);
-        };
-
-        useEffect(() => {
-            if (value !== undefined) {
-                previousValueRef.current = value;
-            }
-        }, [value]);
+                if (value === undefined) {
+                    uncontrolledValueRef.current = newValue;
+                }
+                onValueChange?.(newValue);
+            },
+            [sticky, value, onValueChange],
+        );
 
         return (
             <AccordionRootContext.Provider value={contextValue}>

--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -4,15 +4,57 @@ import { IconCaretDown } from '@frontify/fondue-icons';
 import * as RadixAccordion from '@radix-ui/react-accordion';
 import {
     Children,
+    createContext,
     forwardRef,
     isValidElement,
+    useCallback,
+    useContext,
+    useEffect,
     useMemo,
+    useRef,
     type ForwardedRef,
     type MouseEventHandler,
     type ReactNode,
 } from 'react';
 
 import styles from './styles/accordion.module.scss';
+
+type AccordionRootContextValue = {
+    sticky: boolean;
+    registerItem: (value: string, element: HTMLDivElement | null) => void;
+};
+
+const AccordionRootContext = createContext<AccordionRootContextValue | null>(null);
+AccordionRootContext.displayName = 'AccordionRootContext';
+
+const findScrollableAncestor = (element: HTMLElement): HTMLElement | null => {
+    let current: HTMLElement | null = element.parentElement;
+    while (current) {
+        const { overflowY } = window.getComputedStyle(current);
+        if ((overflowY === 'auto' || overflowY === 'scroll') && current.scrollHeight > current.clientHeight) {
+            return current;
+        }
+        current = current.parentElement;
+    }
+    return null;
+};
+
+const restoreScrollForClosingItem = (itemEl: HTMLElement) => {
+    const scrollContainer = findScrollableAncestor(itemEl);
+    if (!scrollContainer) {
+        return;
+    }
+
+    const itemRect = itemEl.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const delta = itemRect.top - containerRect.top;
+
+    // Only adjust if the item is scrolled above (or exactly at) the top of the
+    // scroll container — i.e. its header is currently pinned in sticky state.
+    if (delta < 0) {
+        scrollContainer.scrollTo({ top: scrollContainer.scrollTop + delta, behavior: 'smooth' });
+    }
+};
 
 type AccordionPadding = 'none' | 'small' | 'medium' | 'large';
 
@@ -72,22 +114,68 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
         }: AccordionRootProps,
         ref: ForwardedRef<HTMLDivElement>,
     ) => {
+        const itemsRef = useRef<Map<string, HTMLDivElement>>(new Map());
+        const previousValueRef = useRef<string[]>(value ?? defaultValue ?? []);
+
+        const registerItem = useCallback((itemValue: string, element: HTMLDivElement | null) => {
+            if (element) {
+                itemsRef.current.set(itemValue, element);
+            } else {
+                itemsRef.current.delete(itemValue);
+            }
+        }, []);
+
+        const contextValue = useMemo<AccordionRootContextValue>(
+            () => ({ sticky, registerItem }),
+            [sticky, registerItem],
+        );
+
+        const handleValueChange = (newValue: string[]) => {
+            if (sticky) {
+                const previous = previousValueRef.current;
+                for (const closedValue of previous) {
+                    if (newValue.includes(closedValue)) {
+                        continue;
+                    }
+
+                    const itemEl = itemsRef.current.get(closedValue);
+
+                    if (itemEl) {
+                        restoreScrollForClosingItem(itemEl);
+                    }
+                }
+            }
+
+            if (value === undefined) {
+                previousValueRef.current = newValue;
+            }
+            onValueChange?.(newValue);
+        };
+
+        useEffect(() => {
+            if (value !== undefined) {
+                previousValueRef.current = value;
+            }
+        }, [value]);
+
         return (
-            <RadixAccordion.Root
-                ref={ref}
-                className={styles.root}
-                data-test-id={dataTestId}
-                defaultValue={defaultValue}
-                disabled={disabled}
-                type="multiple"
-                value={value}
-                data-border={border}
-                data-accordion-padding={padding}
-                data-sticky={sticky}
-                onValueChange={onValueChange}
-            >
-                {children}
-            </RadixAccordion.Root>
+            <AccordionRootContext.Provider value={contextValue}>
+                <RadixAccordion.Root
+                    ref={ref}
+                    className={styles.root}
+                    data-test-id={dataTestId}
+                    defaultValue={defaultValue}
+                    disabled={disabled}
+                    type="multiple"
+                    value={value}
+                    data-border={border}
+                    data-accordion-padding={padding}
+                    data-sticky={sticky}
+                    onValueChange={handleValueChange}
+                >
+                    {children}
+                </RadixAccordion.Root>
+            </AccordionRootContext.Provider>
         );
     },
 );
@@ -116,9 +204,24 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
         { 'data-test-id': dataTestId = 'fondue-accordion-item', children, disabled, value }: AccordionItemProps,
         ref: ForwardedRef<HTMLDivElement>,
     ) => {
+        const rootContext = useContext(AccordionRootContext);
+        const registerItem = rootContext?.registerItem;
+
+        const setRefs = useCallback(
+            (element: HTMLDivElement | null) => {
+                registerItem?.(value, element);
+                if (typeof ref === 'function') {
+                    ref(element);
+                } else if (ref) {
+                    ref.current = element;
+                }
+            },
+            [registerItem, ref, value],
+        );
+
         return (
             <RadixAccordion.Item
-                ref={ref}
+                ref={setRefs}
                 className={styles.accordionItem}
                 value={value}
                 onPointerDown={(event) => {

--- a/packages/components/src/components/Accordion/styles/accordion.module.scss
+++ b/packages/components/src/components/Accordion/styles/accordion.module.scss
@@ -25,6 +25,10 @@
         border-bottom: var(--border-width-default) solid var(--color-line-subtle);
         border-top: var(--border-width-default) solid var(--color-line-subtle);
     }
+
+    &[data-sticky='true'] {
+        isolation: isolate;
+    }
 }
 
 .accordionItem {
@@ -59,6 +63,14 @@
             grid-area: actions;
             grid-row: 1;
         }
+    }
+
+    .root[data-sticky='true'] & {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background-color: var(--color-surface-default);
+        box-shadow: 0 1px 0 var(--color-line-subtle);
     }
 }
 
@@ -129,6 +141,14 @@
 
     &[data-item-divider='true'] > div {
         border-top: var(--border-width-default) solid var(--color-line-subtle);
+        padding-top: var(--accordion-vertical-padding);
+    }
+
+    .root[data-sticky='true'] &[data-item-divider='true'] > div {
+        border-top-color: transparent;
+    }
+
+    .root[data-sticky='true'] & > div {
         padding-top: var(--accordion-vertical-padding);
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `sticky` prop on `Accordion.Root`. When enabled, each `Accordion.Header` pins to the top of the nearest scrolling ancestor (e.g. a `ScrollArea`) while its item is in view, then is pushed out by the next item's header — the classic sticky-section-header pattern.

```tsx
<ScrollArea maxHeight={300}>
    <Accordion.Root sticky>
        <Accordion.Item value="…">
            <Accordion.Header>…</Accordion.Header>
            <Accordion.Content>…</Accordion.Content>
        </Accordion.Item>
        {/* … */}
    </Accordion.Root>
</ScrollArea>
```

Default is `false`, so existing usages are unchanged.

<img width="625" height="407" alt="2026-05-11 14 15 10" src="https://github.com/user-attachments/assets/86bbd257-9ce7-47d4-a064-99e59649e34a" />



