### PR TITLE
fix(AssetInput): dropdown is cut off

### DIFF
--- a/.changeset/forty-dolphins-sleep.md
+++ b/.changeset/forty-dolphins-sleep.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix(AssetInput): replace `ActionMenu` with `Dropdown`

--- a/packages/fondue/.storybook/preview.tsx
+++ b/packages/fondue/.storybook/preview.tsx
@@ -2,6 +2,7 @@
 
 import '@frontify/fondue-tokens/legacy/tokens';
 import '@frontify/fondue-tokens/styles';
+import '@frontify/fondue-components/styles';
 
 import { Decorator } from '@storybook/react-vite';
 import '../src/styles.css';

--- a/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { AssetInput, type AssetInputProps, AssetInputSize } from './AssetInput';
 import { assetInputActions } from './asset-input-actions';
 import { EXAMPLE_IMAGES, MIXED_ASSETS } from './example-assets';
-import { type AssetInputMenuBlock, AssetInputMenuItemStyle, AssetInputMenuSwitchItemType } from './types';
+import { type AssetInputMenuBlock, AssetInputMenuItemStyle, type AssetInputMenuSwitchItemType } from './types';
 
 /**
  ### *Legacy component warning*

--- a/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
@@ -1,10 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { IconCrop, IconCross, IconEye, IconEyeOff, IconLockClosed, IconLockOpen } from '@frontify/fondue-icons';
 import { type Meta, type StoryFn } from '@storybook/react-vite';
+import { useState } from 'react';
 
 import { AssetInput, type AssetInputProps, AssetInputSize } from './AssetInput';
 import { assetInputActions } from './asset-input-actions';
 import { EXAMPLE_IMAGES, MIXED_ASSETS } from './example-assets';
+import { type AssetInputMenuBlock, AssetInputMenuItemStyle, AssetInputMenuSwitchItemType } from './types';
 
 /**
  ### *Legacy component warning*
@@ -115,6 +118,63 @@ export const Icon = Template.bind({});
 Icon.args = {
     assets: [MIXED_ASSETS[2]],
     actions: assetInputActions,
+};
+
+const ImageWithSwitchRender = () => {
+    const [locked, setLocked] = useState(false);
+    const [previewVisible, setPreviewVisible] = useState(true);
+
+    const actions: AssetInputMenuBlock[] = [
+        {
+            id: 'toggles',
+            ariaLabel: 'Toggles',
+            menuItems: [
+                {
+                    id: 'lock',
+                    title: locked ? 'Unlock asset' : 'Lock asset',
+                    decorator: locked ? <IconLockClosed /> : <IconLockOpen />,
+                    type: 'switch',
+                    initialValue: locked,
+                    onClick: (value: boolean) => setLocked(value),
+                } as AssetInputMenuSwitchItemType,
+                {
+                    id: 'preview',
+                    title: previewVisible ? 'Hide preview' : 'Show preview',
+                    decorator: previewVisible ? <IconEye /> : <IconEyeOff />,
+                    type: 'switch',
+                    initialValue: previewVisible,
+                    onClick: (value: boolean) => setPreviewVisible(value),
+                } as AssetInputMenuSwitchItemType,
+            ],
+        },
+        {
+            id: 'actions',
+            ariaLabel: 'Actions',
+            menuItems: [
+                {
+                    id: 'crop',
+                    title: 'Crop / Resize',
+                    decorator: <IconCrop />,
+                    onClick: () => undefined,
+                },
+                {
+                    id: 'remove',
+                    title: 'Remove',
+                    style: AssetInputMenuItemStyle.Danger,
+                    decorator: <IconCross />,
+                    onClick: () => undefined,
+                },
+            ],
+        },
+    ];
+
+    return <AssetInput assets={[EXAMPLE_IMAGES[0]]} actions={actions} size={AssetInputSize.Small} />;
+};
+
+export const ImageWithSwitch: StoryFn<AssetInputProps> = () => <ImageWithSwitchRender />;
+
+ImageWithSwitch.parameters = {
+    controls: { disable: true },
 };
 
 const multiAssetInputArgTypes = {

--- a/packages/fondue/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/packages/fondue/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -1,22 +1,24 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconCaretDown } from '@frontify/fondue-icons';
-import { useButton } from '@react-aria/button';
-import { FocusScope, useFocusRing } from '@react-aria/focus';
-import { useMenuTrigger } from '@react-aria/menu';
-import { DismissButton, useOverlay } from '@react-aria/overlays';
-import { mergeProps } from '@react-aria/utils';
-import { useMenuTriggerState } from '@react-stately/menu';
-import { AnimatePresence, motion } from 'motion/react';
-import { type ReactElement, useEffect, useRef, useState } from 'react';
+import '@frontify/fondue-components/styles';
 
-import { ActionMenu, type ActionMenuBlock } from '@components/ActionMenu/ActionMenu';
+import { Dropdown } from '@frontify/fondue-components';
+import { IconCaretDown } from '@frontify/fondue-icons';
+import { useFocusRing } from '@react-aria/focus';
+import { Fragment, type ReactElement, useState } from 'react';
+
 import { useMemoizedId } from '@hooks/useMemoizedId';
 import { FOCUS_STYLE } from '@utilities/focusStyle';
 import { merge } from '@utilities/merge';
 
 import { type AssetInputProps, AssetInputSize, type AssetType } from '../AssetInput';
 import { AssetThumbnail } from '../AssetThumbnail';
+import {
+    type AssetInputMenuBlock,
+    type AssetInputMenuDefaultItemType,
+    AssetInputMenuItemStyle,
+    type AssetInputMenuSwitchItemType,
+} from '../types';
 
 import { AssetSubline } from './AssetSubline';
 import { SpinningCircle } from './SpinningCircle';
@@ -28,6 +30,17 @@ export type SelectedAssetProps = Pick<
     asset: AssetType;
 };
 
+const matchTriggerWidth = (element: HTMLDivElement | null) => {
+    if (!element) {
+        return;
+    }
+    const TRIGGER_WIDTH = 'var(--radix-dropdown-menu-trigger-width)';
+
+    element.style.width = TRIGGER_WIDTH;
+    element.style.minWidth = TRIGGER_WIDTH;
+    element.style.maxWidth = TRIGGER_WIDTH;
+};
+
 export const SelectedAsset = ({
     asset,
     size,
@@ -37,41 +50,12 @@ export const SelectedAsset = ({
     hideExtension = false,
 }: Required<Omit<SelectedAssetProps, 'hideSize' | 'hideExtension'>> &
     Pick<SelectedAssetProps, 'hideSize' | 'hideExtension'>): ReactElement => {
-    const menuId = useMemoizedId();
     const labelId = useMemoizedId();
-    const buttonRef = useRef<HTMLButtonElement | null>(null);
-    const menuState = useMenuTriggerState({});
-    const { isOpen, focusStrategy } = menuState;
-    const { menuTriggerProps } = useMenuTrigger({}, menuState, buttonRef);
-    const { buttonProps } = useButton(menuTriggerProps, buttonRef);
+    const [isOpen, setIsOpen] = useState(false);
     const { isFocusVisible, focusProps } = useFocusRing();
-    const overlayRef = useRef<HTMLDivElement | null>(null);
-    const { overlayProps } = useOverlay(
-        { onClose: () => menuState.close(), shouldCloseOnBlur: true, isOpen, isDismissable: true },
-        overlayRef,
-    );
     const title = asset?.name || 'Your Asset';
 
-    const [flyoutWidth, setFlyoutWidth] = useState(0);
-
-    useEffect(() => {
-        let timer: ReturnType<typeof setTimeout> | null = null;
-        const calculateFlyoutWidth = () => {
-            const calculatedWidth = buttonRef.current?.getBoundingClientRect().width ?? 0;
-            timer = setTimeout(() => setFlyoutWidth(calculatedWidth), 0);
-        };
-        const resizeObserver = new ResizeObserver(calculateFlyoutWidth);
-        if (buttonRef.current) {
-            resizeObserver.observe(buttonRef.current);
-        }
-
-        return () => {
-            if (timer) {
-                clearTimeout(timer);
-            }
-            resizeObserver.disconnect();
-        };
-    }, []);
+    const blocks = (actions ?? []) as AssetInputMenuBlock[];
 
     return (
         <div
@@ -79,95 +63,112 @@ export const SelectedAsset = ({
             title={title}
             data-test-id="asset-single-input"
         >
-            <button
-                type="button"
-                {...mergeProps(buttonProps, focusProps)}
-                ref={buttonRef}
-                aria-labelledby={labelId}
-                className={merge([
-                    'tw-w-full tw-flex tw-border tw-rounded tw-overflow-hidden hover:tw-border-black-90 dark:hover:tw-border-black-40 focus-visible:tw-outline-none',
-                    isFocusVisible && FOCUS_STYLE,
-                    size === AssetInputSize.Large ? 'tw-h-[11.5rem] tw-flex-col' : 'tw-h-14',
-                    isOpen || isFocusVisible
-                        ? 'tw-border-black-90 dark:tw-border-black-10'
-                        : 'tw-border-black-20 dark:tw-border-black-80',
-                ])}
-            >
-                {isLoading && !asset && (
-                    <div
+            <Dropdown.Root open={isOpen} onOpenChange={setIsOpen}>
+                <Dropdown.Trigger>
+                    <button
+                        type="button"
+                        {...focusProps}
+                        aria-labelledby={labelId}
                         className={merge([
-                            'tw-flex tw-justify-center tw-items-center',
-                            size === AssetInputSize.Large ? 'tw-w-full tw-h-32' : 'tw-w-14 tw-h-full',
+                            'tw-w-full tw-flex tw-border tw-rounded tw-overflow-hidden hover:tw-border-black-90 dark:hover:tw-border-black-40 focus-visible:tw-outline-none',
+                            isFocusVisible && FOCUS_STYLE,
+                            size === AssetInputSize.Large ? 'tw-h-[11.5rem] tw-flex-col' : 'tw-h-14',
+                            isOpen || isFocusVisible
+                                ? 'tw-border-black-90 dark:tw-border-black-10'
+                                : 'tw-border-black-20 dark:tw-border-black-80',
                         ])}
                     >
-                        <SpinningCircle size={size} />
-                    </div>
-                )}
-                {asset && <AssetThumbnail asset={asset} size={size} isActive={isOpen || isFocusVisible} />}
-                <div
-                    className={merge([
-                        'tw-min-w-0 tw-max-w-full tw-flex tw-flex-auto tw-self-stretch tw-border-black-100 tw-border-opacity-25',
-                        size === AssetInputSize.Large ? 'tw-h-14 tw-border-t' : 'tw-h-full tw-border-l',
-                    ])}
-                >
-                    <div className="tw-min-w-0 tw-pr-3 tw-pl-4 tw-flex tw-flex-auto tw-flex-col tw-items-start tw-justify-center tw-h-full">
-                        <span
-                            id={labelId}
-                            className={merge([
-                                'tw-max-w-full tw-text-black-100 tw-text-s tw-truncate dark:tw-text-white',
-                                (isOpen || isFocusVisible) && 'tw-font-medium',
-                            ])}
-                        >
-                            {title}
-                        </span>
-                        <AssetSubline
-                            asset={asset}
-                            isLoading={isLoading}
-                            hideSize={hideSize}
-                            hideExtension={hideExtension}
-                        />
-                    </div>
-                    <div className="tw-p-4 tw-flex tw-flex-none tw-items-center tw-justify-center">
-                        <span
-                            className={merge([
-                                'tw-transition-transform',
-                                isOpen ? 'tw-rotate-180 tw-text-black-90' : 'tw-text-black-60',
-                            ])}
-                        >
-                            <IconCaretDown size={16} />
-                        </span>
-                    </div>
-                </div>
-            </button>
-
-            <AnimatePresence>
-                {isOpen && (
-                    <motion.div
-                        style={{
-                            width: flyoutWidth,
-                        }}
-                        className="tw-absolute tw-left-auto tw-w-full tw-overflow-hidden tw-box-border tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-20"
-                        data-test-id="asset-single-input-flyout"
-                        key={`asset-input-menu-${menuId}`}
-                        initial={{ height: 0 }}
-                        animate={{ height: 'auto' }}
-                        exit={{ height: 0 }}
-                        transition={{ ease: [0.04, 0.62, 0.23, 0.98], duration: 0.5 }}
-                    >
-                        <FocusScope restoreFocus>
-                            <div {...overlayProps} ref={overlayRef}>
-                                <DismissButton onDismiss={() => menuState.close()} />
-                                <ActionMenu
-                                    menuBlocks={actions as ActionMenuBlock[]}
-                                    focus={focusStrategy ?? undefined}
-                                    onClick={() => menuState.close()}
-                                />
-                                <DismissButton onDismiss={() => menuState.close()} />
+                        {isLoading && !asset && (
+                            <div
+                                className={merge([
+                                    'tw-flex tw-justify-center tw-items-center',
+                                    size === AssetInputSize.Large ? 'tw-w-full tw-h-32' : 'tw-w-14 tw-h-full',
+                                ])}
+                            >
+                                <SpinningCircle size={size} />
                             </div>
-                        </FocusScope>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+                        )}
+                        {asset && <AssetThumbnail asset={asset} size={size} isActive={isOpen || isFocusVisible} />}
+                        <div
+                            className={merge([
+                                'tw-min-w-0 tw-max-w-full tw-flex tw-flex-auto tw-self-stretch tw-border-black-100 tw-border-opacity-25',
+                                size === AssetInputSize.Large ? 'tw-h-14 tw-border-t' : 'tw-h-full tw-border-l',
+                            ])}
+                        >
+                            <div className="tw-min-w-0 tw-pr-3 tw-pl-4 tw-flex tw-flex-auto tw-flex-col tw-items-start tw-justify-center tw-h-full">
+                                <span
+                                    id={labelId}
+                                    className={merge([
+                                        'tw-max-w-full tw-text-black-100 tw-text-s tw-truncate dark:tw-text-white',
+                                        (isOpen || isFocusVisible) && 'tw-font-medium',
+                                    ])}
+                                >
+                                    {title}
+                                </span>
+                                <AssetSubline
+                                    asset={asset}
+                                    isLoading={isLoading}
+                                    hideSize={hideSize}
+                                    hideExtension={hideExtension}
+                                />
+                            </div>
+                            <div className="tw-p-4 tw-flex tw-flex-none tw-items-center tw-justify-center">
+                                <span
+                                    className={merge([
+                                        'tw-transition-transform',
+                                        isOpen ? 'tw-rotate-180 tw-text-black-90' : 'tw-text-black-60',
+                                    ])}
+                                >
+                                    <IconCaretDown size={16} />
+                                </span>
+                            </div>
+                        </div>
+                    </button>
+                </Dropdown.Trigger>
+                <Dropdown.Content ref={matchTriggerWidth} data-test-id="asset-single-input-flyout">
+                    {blocks.map((block) => (
+                        <Dropdown.Group key={block.id}>
+                            {block.menuItems.map((item) => {
+                                const isSwitch =
+                                    'type' in item && (item as AssetInputMenuSwitchItemType).type === 'switch';
+                                const emphasis = item.style === AssetInputMenuItemStyle.Danger ? 'danger' : 'default';
+                                const itemContent = (
+                                    <Fragment>
+                                        {item.decorator && <Dropdown.Slot name="left">{item.decorator}</Dropdown.Slot>}
+                                        <span>{item.title ?? item.children}</span>
+                                    </Fragment>
+                                );
+
+                                return (
+                                    <Dropdown.Item
+                                        key={item.id}
+                                        disabled={item.disabled}
+                                        emphasis={emphasis}
+                                        asChild={!!item.link}
+                                        onSelect={(event) => {
+                                            if (isSwitch) {
+                                                event.preventDefault();
+                                                const switchItem = item as AssetInputMenuSwitchItemType;
+                                                const itemElement = event.currentTarget as HTMLElement | null;
+                                                switchItem.onClick(!switchItem.initialValue);
+                                                queueMicrotask(() => {
+                                                    if (itemElement) {
+                                                        itemElement.dataset.showFocusRing = 'false';
+                                                    }
+                                                });
+                                                return;
+                                            }
+                                            (item as AssetInputMenuDefaultItemType).onClick?.();
+                                        }}
+                                    >
+                                        {item.link ? <a href={item.link}>{itemContent}</a> : itemContent}
+                                    </Dropdown.Item>
+                                );
+                            })}
+                        </Dropdown.Group>
+                    ))}
+                </Dropdown.Content>
+            </Dropdown.Root>
         </div>
     );
 };

--- a/packages/fondue/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/packages/fondue/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -1,7 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import '@frontify/fondue-components/styles';
-
 import { Dropdown } from '@frontify/fondue-components';
 import { IconCaretDown } from '@frontify/fondue-icons';
 import { useFocusRing } from '@react-aria/focus';


### PR DESCRIPTION
<img width="314" height="500" alt="image" src="https://github.com/user-attachments/assets/d0d6e5a3-2299-4dff-b4d9-5080fffb280c" />


As you can see in this screenshot, the `ActionMenu` deprecated component is not portaled and in an `overflow:hidden` container it gets cut off.

In this PR I replaced the `ActionMenu` and implemented the `Dropdown` component in place of it.


## Before

<img width="1402" height="328" alt="image" src="https://github.com/user-attachments/assets/1e6010cc-1988-4c84-aa48-3300de20e0e1" />


## After

<img width="1077" height="349" alt="image" src="https://github.com/user-attachments/assets/60e2cf69-86b5-49ee-b924-308d9a906b1a" />
