### PR TITLE
feat(Table): add stickyBackgroundColor prop

### DIFF
--- a/.changeset/sour-poems-agree.md
+++ b/.changeset/sour-poems-agree.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-components": patch
+---
+
+feat(Table): add stickyBackgroundColor prop

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -651,6 +651,55 @@ export const StickyAllDirections: Story = {
     ),
 };
 
+export const StickyWithCustomBackground: Story = {
+    name: 'Sticky With Custom Background Color',
+    args: {
+        stickyBackgroundColor: 'var(--color-surface-dim)',
+    },
+    render: ({ ...args }) => (
+        <Table.Root {...args}>
+            <Table.Header sticky>
+                <Table.Row>
+                    <Table.HeaderCell>Name</Table.HeaderCell>
+                    <Table.HeaderCell>Invited by</Table.HeaderCell>
+                    <Table.HeaderCell>Last seen</Table.HeaderCell>
+                    <Table.HeaderCell>Initial login</Table.HeaderCell>
+                    <Table.HeaderCell>Last login</Table.HeaderCell>
+                    <Table.HeaderCell>Actions</Table.HeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body firstColumnSticky lastColumnSticky>
+                {[...TABLE_DATA, ...TABLE_DATA, ...TABLE_DATA].map((user, index) => (
+                    <Table.Row key={`${user.email}-${index}`}>
+                        <Table.RowCell>
+                            <div className="tw-flex tw-items-center tw-gap-2">
+                                <div>
+                                    <div className="tw-font-medium">{user.name}</div>
+                                    <div className="tw-text-small tw-text-primary-on-primary">{user.email}</div>
+                                </div>
+                            </div>
+                        </Table.RowCell>
+                        <Table.RowCell>{user.invited}</Table.RowCell>
+                        <Table.RowCell>{user.lastSeen}</Table.RowCell>
+                        <Table.RowCell>{user.initialLogin}</Table.RowCell>
+                        <Table.RowCell>{user.lastLogin}</Table.RowCell>
+                        <Table.RowCell>
+                            <Flex gap="0.25rem">
+                                <Button size="small" aspect="square" emphasis="weak">
+                                    <IconPen size={16} />
+                                </Button>
+                                <Button variant="danger" size="small" aspect="square" emphasis="weak">
+                                    <IconTrashBin size={16} />
+                                </Button>
+                            </Flex>
+                        </Table.RowCell>
+                    </Table.Row>
+                ))}
+            </Table.Body>
+        </Table.Root>
+    ),
+};
+
 export const Interactive: Story = {
     render: ({ ...args }) => (
         <Table.Root {...args}>

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -51,6 +51,12 @@ type TableRootProps = {
      */
     gutter?: CSSProperties['borderSpacing'];
     /**
+     * Background color used by sticky parts (header, first column, last column).
+     *
+     * Accepts any CSS color value or token (e.g., `'#000'`, `'var(--color-surface-dim)'`)
+     */
+    stickyBackgroundColor?: CSSProperties['backgroundColor'];
+    /**
      * Whether header should stick to the top when scrolling
      * @deprecated Use `Table.Header sticky` prop instead. For sticky columns, use `Table.Body firstColumnSticky` or `lastColumnSticky` props
      */
@@ -65,7 +71,19 @@ type TableRootProps = {
     Pick<AriaAttributes, 'aria-multiselectable'>;
 
 export const TableRoot = forwardRef<HTMLTableElement, TableRootProps>(
-    ({ layout = 'auto', fontSize = 'medium', gutter = '0px', sticky, noBorder = false, children, ...props }, ref) => {
+    (
+        {
+            layout = 'auto',
+            fontSize = 'medium',
+            gutter = '0px',
+            stickyBackgroundColor,
+            sticky,
+            noBorder = false,
+            children,
+            ...props
+        },
+        ref,
+    ) => {
         const tableRef = useRef<HTMLTableElement>(null);
         const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false);
 
@@ -110,10 +128,12 @@ export const TableRoot = forwardRef<HTMLTableElement, TableRootProps>(
             <table
                 ref={tableRef}
                 className={styles.table}
-                style={{
-                    // @ts-expect-error CSS custom properties are not in CSSProperties type
-                    '--table-gutter': gutter,
-                }}
+                style={
+                    {
+                        '--table-gutter': gutter,
+                        '--table-sticky-background-color': stickyBackgroundColor,
+                    } as CSSProperties
+                }
                 data-layout={layout}
                 data-font-size={fontSize}
                 data-sticky-header={legacyStickyHeader}

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -13,7 +13,7 @@
     $sticky-base: (
         position: sticky,
         z-index: 1,
-        background-color: var(--color-surface-default),
+        background-color: var(--table-sticky-background-color, var(--color-surface-default)),
     );
 
     // Legacy support for deprecated data-sticky-header attribute
@@ -125,16 +125,7 @@
         position: sticky;
         top: 0;
         z-index: 2;
-        background-color: var(--color-surface-default);
-    }
-}
-
-.header {
-    &[data-sticky='true'] {
-        position: sticky;
-        top: 0;
-        z-index: 2;
-        background-color: var(--color-surface-default);
+        background-color: var(--table-sticky-background-color, var(--color-surface-default));
     }
 }
 


### PR DESCRIPTION
Add `stickyBackgroundColor` prop, based on this conversation:

https://frontify.slack.com/archives/C06D0LAQFB4/p1776848005826479

<img width="479" height="373" alt="image" src="https://github.com/user-attachments/assets/2f43387a-d5e0-4fe1-b7b7-37193453fa36" />
