### PR TITLE
chore: mark legacy asset input deprecated

### DIFF
--- a/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.stories.tsx
@@ -8,10 +8,10 @@ import { EXAMPLE_IMAGES, MIXED_ASSETS } from './example-assets';
 
 /**
  ### *Legacy component warning*
- #### This is a unmaintained legacy component. It will be deprecated and replaced with a new component in an upcoming release.
+ #### This is a deprecated component. It will be removed in the next major version.
  */
 export default {
-    title: 'Legacy Components/Asset Input',
+    title: 'Deprecated/Asset Input',
     component: AssetInput,
     tags: ['autodocs'],
     argTypes: {

--- a/packages/fondue/src/components/AssetInput/AssetInput.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetInput.tsx
@@ -17,6 +17,9 @@ type BaseAsset = {
     name: string;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type ImageAsset = {
     type: 'image' | 'logo';
     name: string;
@@ -45,14 +48,27 @@ type IconAsset = BaseAsset & {
     size?: undefined;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type UploadSource = { source: 'upload'; sourceName?: undefined };
+
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type LibrarySource = { source: 'library'; sourceName: string };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export enum AssetInputSize {
     Small = 'Small',
     Large = 'Large',
 }
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetType =
     | (ImageAsset & UploadSource)
     | (ImageAsset & LibrarySource)
@@ -61,6 +77,9 @@ export type AssetType =
     | (OtherAsset & UploadSource)
     | (OtherAsset & LibrarySource);
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputProps = {
     assets?: AssetType[];
     size: AssetInputSize;
@@ -75,6 +94,9 @@ export type AssetInputProps = {
     acceptFileType?: string;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const AssetInput = ({
     assets = [],
     numberOfLocations = 1,

--- a/packages/fondue/src/components/AssetInput/AssetThumbnail.tsx
+++ b/packages/fondue/src/components/AssetInput/AssetThumbnail.tsx
@@ -26,6 +26,9 @@ const getIconSizeClassNames = (size: AssetInputSize, isMultiAsset: boolean) => {
     }
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const AssetThumbnail = ({
     asset,
     size,

--- a/packages/fondue/src/components/AssetInput/MultiAssetPreview/MultiAssetPreview.tsx
+++ b/packages/fondue/src/components/AssetInput/MultiAssetPreview/MultiAssetPreview.tsx
@@ -13,12 +13,18 @@ import { type AssetType } from '../AssetInput';
 
 import { SelectedAssetsThumbnail } from './SelectedAssetsThumbnail';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type MultiAssetPreviewProps = {
     numberOfLocations: number;
     assets: AssetType[];
     onClick: () => void;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const MultiAssetPreview = ({ numberOfLocations, assets, onClick }: MultiAssetPreviewProps): ReactElement => {
     const buttonRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps } = useButton({ onPress: onClick }, buttonRef);

--- a/packages/fondue/src/components/AssetInput/MultiAssetPreview/SelectedAssetsThumbnail.tsx
+++ b/packages/fondue/src/components/AssetInput/MultiAssetPreview/SelectedAssetsThumbnail.tsx
@@ -12,6 +12,9 @@ import { type MultiAssetPreviewProps } from './MultiAssetPreview';
 const isImageAsset = (asset: AssetType): asset is ImageAsset & LibrarySource =>
     asset.type === 'image' || asset.type === 'logo';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const SelectedAssetsThumbnail = ({ assets }: Pick<MultiAssetPreviewProps, 'assets'>): ReactElement => {
     const assetslength = assets.length;
     const previewAssets = assets.slice(0, 4);

--- a/packages/fondue/src/components/AssetInput/SingleAsset/AssetSubline.tsx
+++ b/packages/fondue/src/components/AssetInput/SingleAsset/AssetSubline.tsx
@@ -10,6 +10,9 @@ import { type SelectedAssetProps } from './SelectedAsset';
 type AssetSublineProps = Pick<AssetInputProps, 'isLoading' | 'hideSize' | 'hideExtension'> &
     Pick<SelectedAssetProps, 'asset'>;
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const AssetSubline = ({
     asset,
     isLoading = false,

--- a/packages/fondue/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/packages/fondue/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -21,6 +21,9 @@ import { AssetThumbnail } from '../AssetThumbnail';
 import { AssetSubline } from './AssetSubline';
 import { SpinningCircle } from './SpinningCircle';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type SelectedAssetProps = Pick<
     AssetInputProps,
     'actions' | 'isLoading' | 'size' | 'hideSize' | 'hideExtension'

--- a/packages/fondue/src/components/AssetInput/SingleAsset/SpinningCircle.tsx
+++ b/packages/fondue/src/components/AssetInput/SingleAsset/SpinningCircle.tsx
@@ -6,6 +6,9 @@ import { merge } from '@utilities/merge';
 
 import { type AssetInputProps, AssetInputSize } from '../AssetInput';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const SpinningCircle = ({ size }: Pick<AssetInputProps, 'size'>): ReactElement => (
     <svg
         className={merge(['tw-animate-spin', size === AssetInputSize.Large ? 'tw-w-16 tw-h-16' : 'tw-w-5 tw-h-5'])}

--- a/packages/fondue/src/components/AssetInput/asset-input-actions.tsx
+++ b/packages/fondue/src/components/AssetInput/asset-input-actions.tsx
@@ -5,6 +5,9 @@ import { IconArrowCircleUp, IconArrowOutExternal, IconCrop, IconCross, IconImage
 import { type ActionMenuBlock } from '@components/ActionMenu/ActionMenu';
 import { MenuItemStyle } from '@components/MenuItem/types';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const assetInputActions = [
     {
         id: 'block1',

--- a/packages/fondue/src/components/AssetInput/example-assets.tsx
+++ b/packages/fondue/src/components/AssetInput/example-assets.tsx
@@ -4,6 +4,9 @@ import { IconIcon } from '@frontify/fondue-icons';
 
 import { type AssetType } from './AssetInput';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const EXAMPLE_IMAGES: AssetType[] = [
     {
         name: 'foo1',
@@ -51,6 +54,9 @@ export const EXAMPLE_IMAGES: AssetType[] = [
     },
 ];
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export const MIXED_ASSETS: AssetType[] = [
     ...EXAMPLE_IMAGES.slice(0, 2),
     {

--- a/packages/fondue/src/components/AssetInput/types.ts
+++ b/packages/fondue/src/components/AssetInput/types.ts
@@ -2,12 +2,18 @@
 
 import { type FocusEvent, type HTMLAttributes, type MouseEvent, type ReactElement, type ReactNode } from 'react';
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export enum AssetInputMenuItemContentSize {
     XSmall = 'XSmall',
     Small = 'Small',
     Large = 'Large',
 }
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputMenuItemContentProps = {
     title?: ReactNode;
     decorator?: ReactElement;
@@ -17,17 +23,27 @@ export type AssetInputMenuItemContentProps = {
     children?: ReactNode;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export enum AssetInputMenuItemStyle {
     Primary = 'Primary',
     Danger = 'Danger',
     Warning = 'Warning',
 }
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export enum AssetInputSelectionIndicatorIcon {
     Check = 'Check',
     CaretRight = 'CaretRight',
     None = 'None',
 }
+
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputMenuItemProps = {
     style?: AssetInputMenuItemStyle;
     disabled?: boolean;
@@ -48,19 +64,31 @@ export type AssetInputMenuItemProps = {
     'data-test-id'?: string;
 } & AssetInputMenuItemContentProps;
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputMenuItemType = AssetInputMenuItemProps & {
     id: string | number;
     link?: string;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputMenuDefaultItemType = AssetInputMenuItemType & { onClick: () => void };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputMenuSwitchItemType = AssetInputMenuItemType & {
     onClick: (switchValue: boolean) => void;
     type: 'switch';
     initialValue: boolean;
 };
 
+/**
+ * @deprecated Use `AssetInput` from `@frontify/fondue/components` instead.
+ */
 export type AssetInputMenuBlock = {
     id: string;
     menuItems: (AssetInputMenuDefaultItemType | AssetInputMenuSwitchItemType)[];


### PR DESCRIPTION
- Add deprecation comments to legacy asset input
- Move the story into the folder with deprecated components