### PR TITLE
feat: use @property to reduce generated styles

### DIFF
--- a/.changeset/curly-pens-peel.md
+++ b/.changeset/curly-pens-peel.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat: refactor layout component styles to utilize @property, which leads to less generated styles

--- a/packages/components/src/components/Box/styles/box.module.scss
+++ b/packages/components/src/components/Box/styles/box.module.scss
@@ -6,15 +6,12 @@
 $properties: (display);
 $allProperties: list.join($properties, layout.$layoutProperties);
 
+@include layout.register-properties($allProperties);
+
 .root {
     box-sizing: border-box;
 
     @include layout.responsive-properties($allProperties);
 
-    // Default values
-    @each $property in $allProperties {
-        @include layout.responsive-default-value($property, initial);
-    }
-
-    @include layout.responsive-default-value(display, block);
+    --display: block;
 }

--- a/packages/components/src/components/Flex/styles/flex.module.scss
+++ b/packages/components/src/components/Flex/styles/flex.module.scss
@@ -6,15 +6,13 @@
 $properties: (display, flex-direction, align-items, justify-content, flex-wrap, gap, gap-x, gap-y);
 $allProperties: list.join($properties, layout.$layoutProperties);
 
+@include layout.register-properties($allProperties);
+
 .root {
     box-sizing: border-box;
 
     @include layout.responsive-properties($allProperties);
 
-    // Default values
-    @each $property in $allProperties {
-        @include layout.responsive-default-value($property, initial);
-    }
-    @include layout.responsive-default-value(display, flex);
-    @include layout.responsive-default-value(flex-direction, row);
+    --display: flex;
+    --flex-direction: row;
 }

--- a/packages/components/src/components/Grid/styles/grid.module.scss
+++ b/packages/components/src/components/Grid/styles/grid.module.scss
@@ -17,19 +17,16 @@ $properties: (
 
 $allProperties: list.join($properties, layout.$layoutProperties);
 
+@include layout.register-properties($allProperties);
+
 .root {
     box-sizing: border-box;
 
     @include layout.responsive-properties($allProperties);
 
-    // Default values
-    @each $property in $allProperties {
-        @include layout.responsive-default-value($property, initial);
-    }
-
-    @include layout.responsive-default-value(display, grid);
-    @include layout.responsive-default-value(align-items, stretch);
-    @include layout.responsive-default-value(justify-items, start);
-    @include layout.responsive-default-value(grid-template-columns, minmax(0, 1fr));
-    @include layout.responsive-default-value(grid-template-rows, none);
+    --display: grid;
+    --align-items: stretch;
+    --justify-items: start;
+    --grid-template-columns: minmax(0, 1fr);
+    --grid-template-rows: none;
 }

--- a/packages/components/src/components/Section/styles/section.module.scss
+++ b/packages/components/src/components/Section/styles/section.module.scss
@@ -6,14 +6,12 @@
 $properties: (display);
 $allProperties: list.join($properties, layout.$layoutProperties);
 
+@include layout.register-properties($allProperties);
+
 .root {
     box-sizing: border-box;
 
     @include layout.responsive-properties($allProperties);
 
-    // Default values
-    @each $property in $allProperties {
-        @include layout.responsive-default-value($property, initial);
-    }
-    @include layout.responsive-default-value(display, block);
+    --display: block;
 }

--- a/packages/components/src/helpers/layout.module.scss
+++ b/packages/components/src/helpers/layout.module.scss
@@ -1,8 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-@use "sass:list";
-@use "sass:map";
-@use "sass:meta";
+@use 'sass:list';
 $screens: (
     base: 0px,
     xs: 390px,
@@ -43,6 +41,22 @@ $layoutProperties: (
     min-height,
     max-height
 );
+
+@mixin register-properties($additional-properties: ()) {
+    @each $property in $additional-properties {
+        @property --#{$property} {
+            syntax: '*';
+            inherits: false;
+        }
+
+        @each $breakpoint, $_min-width in $screens {
+            @property --#{$breakpoint}-#{$property} {
+                syntax: '*';
+                inherits: false;
+            }
+        }
+    }
+}
 
 @mixin responsive-properties($additional-properties: ()) {
     @each $property in $additional-properties {
@@ -219,39 +233,6 @@ $layoutProperties: (
         }
         @if list.index($additional-properties, 'justify-items') {
             justify-items: var(--#{$breakpoint}-justify-items-computed);
-        }
-    }
-}
-
-/**
- * Apply default values for a property for all breakpoints if the value isn't a list or set the default value per breakpoint if you pass a list.
- */
-@mixin responsive-default-value($property, $value) {
-    @if meta.type-of($value) == map {
-        @each $breakpoint, $_value in $screens {
-            $value-at-breakpoint: map.get($value, $breakpoint);
-
-            @if ($value-at-breakpoint == null) {
-                @error 'Value for "#{$property}" at breakpoint "#{$breakpoint}" is not defined.';
-            }
-
-            & {
-                --#{$breakpoint}-#{$property}: $value-at-breakpoint;
-            }
-
-            @if $breakpoint == base {
-                --#{$property}: $value-at-breakpoint;
-            }
-        }
-    } @else {
-        & {
-            --#{$property}: #{$value};
-        }
-
-        @each $breakpoint, $min-width in $screens {
-            & {
-                --#{$breakpoint}-#{$property}: var(--#{$breakpoint}-#{$property}, #{$value});
-            }
         }
     }
 }

--- a/packages/components/src/helpers/layout.module.scss
+++ b/packages/components/src/helpers/layout.module.scss
@@ -48,9 +48,17 @@ $layoutProperties: (
             syntax: '*';
             inherits: false;
         }
+        @property --#{$property}-computed {
+            syntax: '*';
+            inherits: false;
+        }
 
         @each $breakpoint, $_min-width in $screens {
             @property --#{$breakpoint}-#{$property} {
+                syntax: '*';
+                inherits: false;
+            }
+            @property --#{$breakpoint}-#{$property}-computed {
                 syntax: '*';
                 inherits: false;
             }


### PR DESCRIPTION
Every layout compoent used to ship ~254 declarations on its .root rule, mostly from a loop that emitted `--<bp>-<prop>: var(--<bp>-<prop>, initial)` for each prop × breakpoint. 

Because custom properties inherit by default, every descendant of a <Flex> accumulated all of them in its computed style.
This contributes to the DevTools' Styles panel becoming laggy inside any Flex tree.

 That self-referential pattern existed only to block ancestor `<Flex>` from leaking their responsive vars (`--md-display`, etc.) into nested layout components. CSS now has a cleaner way to say that: register the vars with `@property { inherits: false }` once globally instead of re-declaring them on every instance.

**What changed**
- New `register-properties` mixin in `layout.module.scss` that emits `@property` rules for each layout var with inherits: false.
- Dropped the per-instance `@each ... initial` loop in `Flex` / `Box` / `Grid` / `Section`.
- Replaced `responsive-default-value(display, flex)` (which expanded to 8 declarations) with a single `--display: flex` as the existing cascade chain in responsive-properties already propagates it through every breakpoint.
- Removed the now-unused `responsive-default-value` mixin.

**Results**

- Flex `.root` base-rule declarations: 254 → 108.
- Descendants now inherit zero layout vars (the actual cause of the DevTools lag).
- No public API change. Single-value and responsive-map props (`display={{ md: 'block' }}`) work the same way. Confirmed via the existing Playwright CT tests that check `direction={{ base: 'row', md: 'column' }}` at `base` and `lg` viewports.

**Note: A big part of this change was written by 🤖Claude🤖**