### PR TITLE
chore(OrderableList): adjust gap between icon and handle; no opacity on disabled border

### DIFF
--- a/.changeset/shiny-dots-read.md
+++ b/.changeset/shiny-dots-read.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+chore: adjust gap between icon and handle; no opacity on disabled border

--- a/.changeset/shiny-dots-read.md
+++ b/.changeset/shiny-dots-read.md
@@ -3,4 +3,4 @@
 "@frontify/fondue": patch
 ---
 
-chore: adjust gap between icon and handle; no opacity on disabled border
+chore(OrderableList): adjust gap between icon and handle; no opacity on disabled border

--- a/packages/components/src/components/OrderableList/__tests__/OrderableList.ct.tsx
+++ b/packages/components/src/components/OrderableList/__tests__/OrderableList.ct.tsx
@@ -279,8 +279,8 @@ test.describe('OrderableList', () => {
                 </OrderableList.Root>,
             );
 
-            const item = component.locator(`[data-test-id="${ITEM_TEST_ID}"]`);
-            await expect(item).toHaveCSS('opacity', '0.5');
+            const content = component.locator(`[data-test-id="${ITEM_TEST_ID}"] > div[tabindex="0"]`);
+            await expect(content).toHaveCSS('opacity', '0.5');
         });
 
         test('should not be draggable from content area when disabled', async ({ mount, page }) => {

--- a/packages/components/src/components/OrderableList/styles/orderable-list.module.scss
+++ b/packages/components/src/components/OrderableList/styles/orderable-list.module.scss
@@ -39,6 +39,10 @@
         .actions {
             padding: var(--spacing-x-small) var(--spacing-small);
         }
+
+        .actions:has(+ .dragHandle) {
+            padding-right: 0;
+        }
     }
     &[data-padding='none'] {
         .content,
@@ -66,8 +70,13 @@
     }
 
     &[data-disabled] {
-        opacity: 0.5;
         cursor: default;
+
+        .content,
+        .actions,
+        .dragHandle {
+            opacity: 0.5;
+        }
 
         .handle {
             cursor: default;


### PR DESCRIPTION
Adjust gap between icon and handle.

Before:
<img width="152" height="219" alt="Screenshot 2026-05-29 at 08 11 10" src="https://github.com/user-attachments/assets/ba8cf201-685b-4916-9ae7-0c00c158564d" />

After:
<img width="139" height="197" alt="Screenshot 2026-05-29 at 08 11 18" src="https://github.com/user-attachments/assets/615b718b-3a6c-4fc6-9def-6a7cafda7b92" />


No opacity for disabled borders:

Before:
<img width="222" height="73" alt="Screenshot 2026-05-29 at 08 12 08" src="https://github.com/user-attachments/assets/f0d100cb-81d9-4398-a02c-175a4a192ad3" />

After:
<img width="189" height="70" alt="Screenshot 2026-05-29 at 08 12 16" src="https://github.com/user-attachments/assets/52560aae-9bbd-48f7-b0f2-76cedb53b50f" />
