### PR TITLE
fix: adjust path to type file

### DIFF
--- a/.changeset/slow-pants-bake.md
+++ b/.changeset/slow-pants-bake.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix: adjust path to sdk type file

--- a/packages/fondue/package.json
+++ b/packages/fondue/package.json
@@ -55,7 +55,7 @@
         },
         "./rte/styles": "./dist/packages/rte/style.css",
         "./sdk": {
-            "types": "./dist/packages/sdk/fondue-sdk.d.ts",
+            "types": "./dist/packages/sdk/sdk.d.ts",
             "import": "./dist/packages/sdk/fondue-sdk.js"
         },
         "./charts/styles": "./dist/packages/charts/style.css",


### PR DESCRIPTION
Adjust the path to the generated type definitions file