### PR TITLE
fix: add types for css exports

### DIFF
--- a/.changeset/tidy-toes-remain.md
+++ b/.changeset/tidy-toes-remain.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue": patch
+---
+
+fix: add missing type definitions for style exports

--- a/packages/fondue/charts.vite.config.ts
+++ b/packages/fondue/charts.vite.config.ts
@@ -3,8 +3,13 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+import { cssTypesPlugin } from './scripts/cssTypesPlugin';
+
 export default defineConfig({
-    plugins: [dts({ insertTypesEntry: true, exclude: ['**/*.stories.tsx'], include: 'src/subpackages/charts.ts' })],
+    plugins: [
+        dts({ insertTypesEntry: true, exclude: ['**/*.stories.tsx'], include: 'src/subpackages/charts.ts' }),
+        cssTypesPlugin(),
+    ],
     build: {
         lib: {
             entry: 'src/subpackages/charts.ts',

--- a/packages/fondue/components.vite.config.ts
+++ b/packages/fondue/components.vite.config.ts
@@ -3,8 +3,13 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+import { cssTypesPlugin } from './scripts/cssTypesPlugin';
+
 export default defineConfig({
-    plugins: [dts({ insertTypesEntry: true, exclude: ['**/*.stories.tsx'], include: 'src/subpackages/components.ts' })],
+    plugins: [
+        dts({ insertTypesEntry: true, exclude: ['**/*.stories.tsx'], include: 'src/subpackages/components.ts' }),
+        cssTypesPlugin(),
+    ],
     build: {
         lib: {
             entry: 'src/subpackages/components.ts',

--- a/packages/fondue/package.json
+++ b/packages/fondue/package.json
@@ -29,7 +29,10 @@
             "require": "./dist/packages/components/fondue-components.umd.cjs",
             "import": "./dist/packages/components/fondue-components.js"
         },
-        "./components/styles": "./dist/packages/components/style.css",
+        "./components/styles": {
+            "types": "./dist/packages/components/style.css.d.ts",
+            "default": "./dist/packages/components/style.css"
+        },
         "./components/locales": {
             "types": "./dist/packages/locales/index.d.ts",
             "import": "./dist/packages/locales/index.js"
@@ -53,22 +56,37 @@
             "require": "./dist/packages/rte/fondue-rte.umd.cjs",
             "import": "./dist/packages/rte/fondue-rte.js"
         },
-        "./rte/styles": "./dist/packages/rte/style.css",
+        "./rte/styles": {
+            "types": "./dist/packages/rte/style.css.d.ts",
+            "default": "./dist/packages/rte/style.css"
+        },
         "./sdk": {
             "types": "./dist/packages/sdk/sdk.d.ts",
             "import": "./dist/packages/sdk/fondue-sdk.js"
         },
-        "./charts/styles": "./dist/packages/charts/style.css",
+        "./charts/styles": {
+            "types": "./dist/packages/charts/style.css.d.ts",
+            "default": "./dist/packages/charts/style.css"
+        },
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.umd.js",
             "import": "./dist/index.es.js"
         },
-        "./styles": "./dist/style.css",
-        "./tokens/base": "./dist/packages/tokens/css/base.css",
+        "./styles": {
+            "types": "./dist/style.css.d.ts",
+            "default": "./dist/style.css"
+        },
+        "./tokens/base": {
+            "types": "./dist/packages/tokens/css/base.css.d.ts",
+            "default": "./dist/packages/tokens/css/base.css"
+        },
         "./tokens/tailwind": "./dist/packages/tokens/tailwind/tailwind.config.js",
         "./legacyTokens/tailwind": "./dist/legacyTokens.tailwind.config.js",
-        "./legacyTokens/base": "./dist/packages/tokens/css/deprecatedBaseTokens.css",
+        "./legacyTokens/base": {
+            "types": "./dist/packages/tokens/css/deprecatedBaseTokens.css.d.ts",
+            "default": "./dist/packages/tokens/css/deprecatedBaseTokens.css"
+        },
         "./legacyTokens/tools/replaceLegacyTokens": "./dist/packages/tokens/legacy/tools/replaceLegacyTokens.ts",
         "./dist/*": "./dist/*"
     },

--- a/packages/fondue/rte.vite.config.ts
+++ b/packages/fondue/rte.vite.config.ts
@@ -3,12 +3,15 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+import { cssTypesPlugin } from './scripts/cssTypesPlugin';
+
 export default defineConfig({
     plugins: [
         dts({
             tsconfigPath: './tsconfig.rte.json',
             insertTypesEntry: true,
         }),
+        cssTypesPlugin(),
     ],
     build: {
         lib: {

--- a/packages/fondue/scripts/cssTypesPlugin.ts
+++ b/packages/fondue/scripts/cssTypesPlugin.ts
@@ -1,0 +1,23 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import fg from 'fast-glob';
+import type { Plugin } from 'vite';
+
+export function cssTypesPlugin(): Plugin {
+    let outDir = '';
+    return {
+        name: 'fondue-css-types',
+        apply: 'build',
+        configResolved(config) {
+            outDir = resolve(config.root, config.build.outDir);
+        },
+        closeBundle() {
+            const cssFiles = fg.sync('**/*.css', { cwd: outDir, absolute: true });
+            for (const file of cssFiles) {
+                writeFileSync(`${file}.d.ts`, 'export {};\n');
+            }
+        },
+    };
+}

--- a/packages/fondue/scripts/cssTypesPlugin.ts
+++ b/packages/fondue/scripts/cssTypesPlugin.ts
@@ -2,8 +2,9 @@
 
 import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+
 import fg from 'fast-glob';
-import type { Plugin } from 'vite';
+import { type Plugin } from 'vite';
 
 export function cssTypesPlugin(): Plugin {
     let outDir = '';

--- a/packages/fondue/tokens.vite.config.ts
+++ b/packages/fondue/tokens.vite.config.ts
@@ -3,6 +3,8 @@
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
+import { cssTypesPlugin } from './scripts/cssTypesPlugin';
+
 export default defineConfig({
     plugins: [
         viteStaticCopy({
@@ -13,6 +15,7 @@ export default defineConfig({
                 },
             ],
         }),
+        cssTypesPlugin(),
     ],
     build: {
         lib: {

--- a/packages/fondue/vite.config.ts
+++ b/packages/fondue/vite.config.ts
@@ -7,6 +7,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import tsConfigPaths from 'vite-tsconfig-paths';
 
 import { dependencies as dependenciesMap, peerDependencies as peerDependenciesMap } from './package.json';
+import { cssTypesPlugin } from './scripts/cssTypesPlugin';
 
 const peerDependencies = Object.keys(peerDependenciesMap);
 const dependencies = Object.keys(dependenciesMap);
@@ -36,6 +37,7 @@ export default defineConfig({
                 },
             ],
         }),
+        cssTypesPlugin(),
     ],
     build: {
         lib: {


### PR DESCRIPTION
Consumers on TypeScript ≥ 5.6 with moduleResolution: "bundler" (or node16 / nodenext) hit ts(2882) when side-effect importing Fondue's CSS subpaths

The CSS-only entries in exports were declared as shortcut strings with no types condition. Under strict exports-aware resolution, TS requires a resolvable declaration at the resolved path and won't fall back to ambient declare module '*.css' shims

- added a vite plugin to emit a type shim next to each exported css file
- adjusted exports in package.json