### PR TITLE
fix: align triggers with content and fix layout shift on active change

### DIFF
--- a/.changeset/lemon-frogs-draw.md
+++ b/.changeset/lemon-frogs-draw.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix: align tab trigger with content

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -14,8 +14,6 @@ import {
     type ReactNode,
 } from 'react';
 
-import { useControllableState } from '#/hooks/useControllableState';
-
 import { Button } from '../Button/Button';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { useFondueTheme } from '../ThemeProvider/ThemeProvider';
@@ -23,6 +21,8 @@ import { useFondueTheme } from '../ThemeProvider/ThemeProvider';
 import { useTabTriggers } from './hooks/useTabTriggers';
 import styles from './styles/tabs.module.scss';
 import { type TabTrigger } from './types';
+
+import { useControllableState } from '#/hooks/useControllableState';
 
 export type TabsRootProps = {
     id?: string;
@@ -142,7 +142,10 @@ export const TabsRoot = (
                                 className={styles.trigger}
                                 ref={trigger.ref}
                             >
-                                {trigger.element}
+                                <span className={styles.triggerLabel}>
+                                    <span className={styles.triggerLabelActive}>{trigger.element}</span>
+                                    <span className={styles.triggerLabelInactive}>{trigger.element}</span>
+                                </span>
                             </RadixTabs.Trigger>
                         ))}
                     </RadixTabs.List>

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -14,6 +14,8 @@ import {
     type ReactNode,
 } from 'react';
 
+import { useControllableState } from '#/hooks/useControllableState';
+
 import { Button } from '../Button/Button';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { useFondueTheme } from '../ThemeProvider/ThemeProvider';
@@ -21,8 +23,6 @@ import { useFondueTheme } from '../ThemeProvider/ThemeProvider';
 import { useTabTriggers } from './hooks/useTabTriggers';
 import styles from './styles/tabs.module.scss';
 import { type TabTrigger } from './types';
-
-import { useControllableState } from '#/hooks/useControllableState';
 
 export type TabsRootProps = {
     id?: string;

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -143,7 +143,9 @@ export const TabsRoot = (
                                 ref={trigger.ref}
                             >
                                 <span className={styles.triggerLabel}>
-                                    <span className={styles.triggerLabelActive}>{trigger.element}</span>
+                                    <span className={styles.triggerLabelActive} aria-hidden="true">
+                                        {trigger.element}
+                                    </span>
                                     <span className={styles.triggerLabelInactive}>{trigger.element}</span>
                                 </span>
                             </RadixTabs.Trigger>

--- a/packages/components/src/components/Tabs/__tests__/Tabs.ct.tsx
+++ b/packages/components/src/components/Tabs/__tests__/Tabs.ct.tsx
@@ -54,8 +54,9 @@ test('should rerender when the trigger content changes', async ({ mount }) => {
         </Tabs.Root>,
     );
     const component = wrapper.getByTestId(TABS_ROOT_TEST_ID);
-    await expect(component.getByText('First Tab')).toBeVisible();
-    await expect(component.getByText('Swapped Tab')).not.toBeVisible();
+    const firstTrigger = component.getByTestId(FIRST_TAB_TRIGGER_TEST_ID);
+    await expect(firstTrigger).toContainText('First Tab');
+    await expect(firstTrigger).not.toContainText('Swapped Tab');
 
     await wrapper.update(
         <Tabs.Root data-test-id={TABS_ROOT_TEST_ID}>
@@ -69,8 +70,8 @@ test('should rerender when the trigger content changes', async ({ mount }) => {
             </Tabs.Tab>
         </Tabs.Root>,
     );
-    await expect(component.getByText('First Tab')).not.toBeVisible();
-    await expect(component.getByText('Swapped Tab')).toBeVisible();
+    await expect(firstTrigger).not.toContainText('First Tab');
+    await expect(firstTrigger).toContainText('Swapped Tab');
 });
 
 test('should render with default tab active', async ({ mount }) => {

--- a/packages/components/src/components/Tabs/styles/tabs.module.scss
+++ b/packages/components/src/components/Tabs/styles/tabs.module.scss
@@ -26,8 +26,8 @@ $radius-without-border: calc(var(--border-radius-medium) - var(--border-width-de
             width: 100%;
             display: flex;
             align-items: center;
-            padding-inline-start: sizeToken.get(3);
-            padding-inline-end: sizeToken.get(3);
+            padding-inline-start: sizeToken.get(1);
+            padding-inline-end: sizeToken.get(1);
             gap: sizeToken.get(2);
             border-bottom: 1px solid var(--color-line-subtle);
             box-sizing: border-box;
@@ -40,7 +40,6 @@ $radius-without-border: calc(var(--border-radius-medium) - var(--border-width-de
             margin: sizeToken.get(2);
             display: flex;
             align-items: center;
-            gap: sizeToken.get(1);
 
             & {
                 @include focusStyle.focus-outline;
@@ -58,8 +57,15 @@ $radius-without-border: calc(var(--border-radius-medium) - var(--border-width-de
 
             &[data-state='active'] {
                 color: var(--color-primary-default);
-                font-weight: 500;
             }
+        }
+
+        .triggerLabelActive {
+            font-weight: 500;
+        }
+
+        .triggerLabelInactive {
+            font-weight: 400;
         }
 
         .activeIndicator {
@@ -71,7 +77,7 @@ $radius-without-border: calc(var(--border-radius-medium) - var(--border-width-de
             bottom: 0;
             inset-inline-start: 0;
             width: 0;
-            margin-inline-start: sizeToken.get(3);
+            margin-inline-start: sizeToken.get(1);
 
             & {
                 @include transitions.transition;
@@ -190,6 +196,54 @@ $radius-without-border: calc(var(--border-radius-medium) - var(--border-width-de
 
     &[data-size='large'] {
         height: sizeToken.get(14);
+    }
+}
+
+// Render both active (bold) and inactive (regular) labels and cross-fade them.
+// The active label sits in flow and reserves the wider bold width, so switching
+// state does not cause a layout shift.
+.triggerLabel {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: sizeToken.get(1);
+}
+
+.triggerLabelActive {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: sizeToken.get(1);
+    opacity: 0;
+    transition-timing-function: ease-in;
+
+    & {
+        @include transitions.transition-opacity;
+    }
+
+    .trigger[data-state='active'] & {
+        opacity: 1;
+        transition-timing-function: ease-out;
+    }
+}
+
+.triggerLabelInactive {
+    position: absolute;
+    inset: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: sizeToken.get(1);
+    opacity: 1;
+    transition-timing-function: ease-out;
+
+    & {
+        @include transitions.transition-opacity;
+    }
+
+    .trigger[data-state='active'] & {
+        opacity: 0;
+        transition-timing-function: ease-in;
     }
 }
 


### PR DESCRIPTION
This PR fixes two issues:

- The Tab triggers for `variant=default` are now aligned with the left edge of the content

- The labels in the triggers caused a layout shift when switching active state, as the bold text has a different width.
  - It now two overlaying labels with different font weights and toggle between them. The same concept is already used in `SegmentedControls`
  
 Fixes FP-212