### PR TITLE
feat: add notice alignment option top 

### DIFF
--- a/.changeset/shy-rice-roll.md
+++ b/.changeset/shy-rice-roll.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat: add alignContent Variant to the Notice component

--- a/packages/components/src/components/Notice/Notice.stories.tsx
+++ b/packages/components/src/components/Notice/Notice.stories.tsx
@@ -166,6 +166,21 @@ export const SizeLarge: Story = {
     ),
 };
 
+export const AlignContentTop: Story = {
+    args: { alignContent: 'top', onDismiss: action('onDismiss') },
+    render: (args) => (
+        <Notice {...args} icon={<IconInfo size="16" />}>
+            This is a notice with much longer content to demonstrate top alignment. The icon, action, and dismiss button
+            stay aligned to the top of the notice while the message text wraps across multiple lines. Long content is
+            used to demonstrate how the component handles text wrapping. Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </Notice>
+    ),
+};
+
 export const AllVariants: Story = {
     render: (args) => (
         <div className="tw-flex tw-flex-col tw-gap-4">

--- a/packages/components/src/components/Notice/Notice.tsx
+++ b/packages/components/src/components/Notice/Notice.tsx
@@ -13,6 +13,8 @@ type NoticeEmphasis = 'default' | 'strong' | 'weak';
 
 type NoticeSize = 'medium' | 'large';
 
+type NoticeAlignContent = 'center' | 'top';
+
 export type NoticeProps = {
     /**
      * @default 'default'
@@ -26,6 +28,11 @@ export type NoticeProps = {
      * @default 'medium'
      */
     size?: NoticeSize;
+    /**
+     * Vertical alignment of the notice's contents
+     * @default 'center'
+     */
+    alignContent?: NoticeAlignContent;
     /**
      * Leading icon element
      */
@@ -62,6 +69,7 @@ export const Notice = ({
     variant = 'default',
     emphasis = 'default',
     size = 'medium',
+    alignContent = 'center',
     icon,
     action,
     onDismiss,
@@ -76,6 +84,7 @@ export const Notice = ({
             data-variant={variant}
             data-emphasis={emphasis}
             data-size={size}
+            data-align-content={alignContent}
             data-test-id={dataTestId}
             className={[styles.root, className].filter(Boolean).join(' ')}
             role="status"

--- a/packages/components/src/components/Notice/styles/notice.module.scss
+++ b/packages/components/src/components/Notice/styles/notice.module.scss
@@ -32,6 +32,10 @@
     display: flex;
     align-items: center;
     border-radius: var(--border-radius-medium);
+
+    &[data-align-content='top'] {
+        align-items: flex-start;
+    }
     transition:
         background-color 250ms,
         color 250ms;

--- a/packages/components/src/components/Notice/tests/Notice.ct.tsx
+++ b/packages/components/src/components/Notice/tests/Notice.ct.tsx
@@ -114,6 +114,22 @@ test('should apply large size', async ({ mount }) => {
     await expect(notice).toHaveAttribute('data-size', 'large');
 });
 
+test('should apply center alignContent by default', async ({ mount }) => {
+    const component = await mount(<Notice data-test-id="notice-root">{NOTICE_TEXT}</Notice>);
+    const notice = component.getByTestId('notice-root');
+    await expect(notice).toHaveAttribute('data-align-content', 'center');
+});
+
+test('should apply top alignContent', async ({ mount }) => {
+    const component = await mount(
+        <Notice data-test-id="notice-root" alignContent="top">
+            {NOTICE_TEXT}
+        </Notice>,
+    );
+    const notice = component.getByTestId('notice-root');
+    await expect(notice).toHaveAttribute('data-align-content', 'top');
+});
+
 test('should render icon when provided', async ({ mount }) => {
     const component = await mount(<Notice icon={<IconInfo data-testid="test-icon" size="16" />}>{NOTICE_TEXT}</Notice>);
     await expect(component.locator('svg')).toBeVisible();


### PR DESCRIPTION
- add prop `alignContent` to the notice component to set the alignment of the content
- add story
- add test case