### PR TITLE
feat: adjust spacing variant "tight" on orderable list

### DIFF
--- a/.changeset/breezy-houses-make.md
+++ b/.changeset/breezy-houses-make.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat: adjust tight spacing on orderable list

--- a/packages/components/src/components/OrderableList/styles/orderable-list.module.scss
+++ b/packages/components/src/components/OrderableList/styles/orderable-list.module.scss
@@ -12,7 +12,7 @@
     }
 
     &[data-spacing='tight'] {
-        gap: var(--spacing-xx-small);
+        gap: var(--spacing-x-small);
     }
     &[data-spacing='compact'] {
         gap: var(--spacing-small);


### PR DESCRIPTION
- Adjust spacing option `tight` to be `8px` instead of `4px`