### PR TITLE
fix(RTE): mentions are not working in the start position

### DIFF
--- a/.changeset/new-numbers-strive.md
+++ b/.changeset/new-numbers-strive.md
@@ -1,0 +1,5 @@
+---
+"@frontify/fondue-rte": patch
+---
+
+fix(RTE): mentions are not working in the start position

--- a/packages/rte/src/components/RichTextEditor/Plugins/MentionPlugin/MentionCombobox/MentionCombobox.tsx
+++ b/packages/rte/src/components/RichTextEditor/Plugins/MentionPlugin/MentionCombobox/MentionCombobox.tsx
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type ComboboxProps } from '@udecode/plate-combobox';
-import { getPluginOptions, useEditorRef } from '@udecode/plate-core';
-import { ELEMENT_MENTION, type MentionPlugin, getMentionOnSelectItem } from '@udecode/plate-mention';
-
-import { MentionComboboxItem } from '@components/RichTextEditor/Plugins/MentionPlugin/MentionCombobox/MentionComboboxItem';
 import { Combobox } from '@components/RichTextEditor/components/ComboBox/Combobox';
+import { MentionComboboxItem } from '@components/RichTextEditor/Plugins/MentionPlugin/MentionCombobox/MentionComboboxItem';
+import { type ComboboxProps, comboboxActions } from '@udecode/plate-combobox';
+import { getPluginOptions, useEditorRef } from '@udecode/plate-core';
+import { ELEMENT_MENTION, type MentionPlugin, findMentionInput, getMentionOnSelectItem } from '@udecode/plate-mention';
+import { getRange } from '@udecode/slate';
 
 export function MentionCombobox({
     pluginKey = ELEMENT_MENTION,
@@ -23,11 +23,16 @@ export function MentionCombobox({
             id={id}
             trigger={trigger!}
             controlled
-            onSelectItem={(_, item) =>
+            onSelectItem={(_, item) => {
+                const mentionInput = findMentionInput(editor, { at: [] });
+                if (mentionInput) {
+                    comboboxActions.targetRange(getRange(editor, mentionInput[1]));
+                }
+
                 getMentionOnSelectItem({
                     key: pluginKey,
-                })(editor, item)
-            }
+                })(editor, item);
+            }}
             onRenderItem={MentionComboboxItem}
             {...props}
         />

--- a/packages/rte/src/components/RichTextEditor/components/ComboBox/Combobox.tsx
+++ b/packages/rte/src/components/RichTextEditor/components/ComboBox/Combobox.tsx
@@ -53,7 +53,7 @@ export function ComboboxContent(props: ComboboxContentProps) {
 
     return (
         <Popover.Root open>
-            <Popover.PopoverAnchor virtualRef={createVirtualRef(editor, targetRange ?? undefined)} />
+            <Popover.PopoverAnchor virtualRef={createVirtualRef(editor, editor.selection ?? targetRange ?? undefined)} />
 
             <Popover.Portal container={portalElement}>
                 <Popover.Content


### PR DESCRIPTION
Fixes this bug:

1. type something in the RTE
2. move cursor to first position (beginning of text)
3. type "@" to open up the mentions
4. ??? Nothing happened

Root cause: 
When "@" is triggered at the start of a block, slate inserts an empty text node after the combobox has already stored its targetRange, so that stored range becomes stale. Basically a bug in the RTE itself.