### PR TITLE
fix(DatePicker): report single-click edits to an existing DatePicker.Range

### DIFF
--- a/.changeset/range-picker-reports-single-click-edits.md
+++ b/.changeset/range-picker-reports-single-click-edits.md
@@ -1,0 +1,7 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(DatePicker): report single-click edits to an existing `DatePicker.Range`
+
+When a range is already selected, adjusting it with a single click — for example clicking a day before the current start to move it — is now reported through `onChange` immediately, instead of only after a full two-click selection. Selecting a brand-new range is unchanged (still start, then end).

--- a/packages/components/src/components/DatePicker/RangeDatePicker.tsx
+++ b/packages/components/src/components/DatePicker/RangeDatePicker.tsx
@@ -16,8 +16,8 @@ export const RangeDatePicker = (
     { 'data-test-id': dataTestId, onChange, selected, ...props }: RangeDatePickerProps,
     ref: ForwardedRef<HTMLDivElement>,
 ): JSX.Element => {
-    const { selectedDateRange, handleSelect, isAwaitingEndDate } = useDateRange(selected, onChange);
-    const { hoverModifiers } = useRangeHover(isAwaitingEndDate ? selectedDateRange : undefined);
+    const { selectedDateRange, handleSelect } = useDateRange(selected, onChange);
+    const { hoverModifiers } = useRangeHover(selectedDateRange);
 
     return (
         <DatePickerCalendar

--- a/packages/components/src/components/DatePicker/__tests__/RangeDatePicker.ct.tsx
+++ b/packages/components/src/components/DatePicker/__tests__/RangeDatePicker.ct.tsx
@@ -48,15 +48,23 @@ test.describe('RangeDatePicker', () => {
         expect(count).toBeGreaterThan(0);
     });
 
-    test('should call onChange only after both range ends have been clicked', async ({ mount }) => {
+    test('should call onChange on each click when editing a range', async ({ mount }) => {
         const onChange = sinon.spy();
         const component = await mount(
             <DatePicker.Range data-test-id={RANGE_TEST_ID} selected={RANGE_SELECTION} onChange={onChange} />,
         );
-        await component.getByRole('button', { name: /March 20th/ }).click();
-        expect(onChange.callCount).toBe(0);
-        await component.getByRole('button', { name: /March 25th/ }).click();
+        await component.getByRole('button', { name: /March 3rd/ }).click();
         expect(onChange.callCount).toBe(1);
+        expect(onChange.lastCall.firstArg).toEqual({
+            from: { year: 2025, month: 3, day: 3 },
+            to: { year: 2025, month: 3, day: 15 },
+        });
+        await component.getByRole('button', { name: /March 25th/ }).click();
+        expect(onChange.callCount).toBe(2);
+        expect(onChange.lastCall.firstArg).toEqual({
+            from: { year: 2025, month: 3, day: 3 },
+            to: { year: 2025, month: 3, day: 25 },
+        });
     });
 
     test('should navigate to the next month', async ({ mount }) => {

--- a/packages/components/src/components/DatePicker/hooks/__tests__/useDateRange.spec.ts
+++ b/packages/components/src/components/DatePicker/hooks/__tests__/useDateRange.spec.ts
@@ -56,7 +56,27 @@ describe('useDateRange', () => {
     });
 
     describe('controlled mode', () => {
-        it('should not call onSelect on the first click (start-date selection)', () => {
+        it('should propagate the moved start to onSelect on the first click when editing an existing range', () => {
+            const onSelect = vi.fn();
+            const { result } = renderHook(() => useDateRange(MARCH_RANGE, onSelect));
+
+            act(() => {
+                result.current.handleSelect(
+                    { from: new Date(Date.UTC(2025, 1, 20)), to: new Date(Date.UTC(2025, 2, 15)) },
+                    new Date(Date.UTC(2025, 1, 20)),
+                    {},
+                    {} as React.MouseEvent,
+                );
+            });
+
+            expect(onSelect).toHaveBeenCalledTimes(1);
+            expect(onSelect).toHaveBeenCalledWith({
+                from: { year: 2025, month: 2, day: 20 },
+                to: { year: 2025, month: 3, day: 15 },
+            });
+        });
+
+        it('should defer onSelect until a fresh range is completed', () => {
             const onSelect = vi.fn();
             const { result } = renderHook(() => useDateRange(undefined, onSelect));
 
@@ -70,24 +90,6 @@ describe('useDateRange', () => {
             });
 
             expect(onSelect).not.toHaveBeenCalled();
-            expect(result.current.selectedDateRange).toStrictEqual({
-                from: new Date(Date.UTC(2025, 0, 5)),
-                to: new Date(Date.UTC(2025, 0, 5)),
-            });
-        });
-
-        it('should call onSelect only after the end-date has been selected', () => {
-            const onSelect = vi.fn();
-            const { result } = renderHook(() => useDateRange(undefined, onSelect));
-
-            act(() => {
-                result.current.handleSelect(
-                    { from: new Date(Date.UTC(2025, 0, 5)), to: new Date(Date.UTC(2025, 0, 5)) },
-                    new Date(Date.UTC(2025, 0, 5)),
-                    {},
-                    {} as React.MouseEvent,
-                );
-            });
 
             act(() => {
                 result.current.handleSelect(
@@ -105,7 +107,7 @@ describe('useDateRange', () => {
             });
         });
 
-        it('should commit a same-day range when the end-date click repeats the start-date', () => {
+        it('should report a same-day range when the start day is clicked twice', () => {
             const onSelect = vi.fn();
             const { result } = renderHook(() => useDateRange(undefined, onSelect));
 

--- a/packages/components/src/components/DatePicker/hooks/useDateRange.ts
+++ b/packages/components/src/components/DatePicker/hooks/useDateRange.ts
@@ -8,13 +8,11 @@ import { type DatePickerDateRange } from '../types';
 
 export const useDateRange = (selected: DatePickerDateRange, onSelect?: (dateRange: DatePickerDateRange) => void) => {
     const [internalSelectedDateRange, setInternalSelectedDateRange] = useState<DatePickerDateRange>(selected);
-    const [isAwaitingEndDate, setIsAwaitingEndDate] = useState(false);
     const [prevSelected, setPrevSelected] = useState<DatePickerDateRange | undefined>(selected);
 
     if (prevSelected !== selected) {
         setPrevSelected(selected);
         setInternalSelectedDateRange(selected);
-        setIsAwaitingEndDate(false);
     }
 
     const selectedDateRange = useMemo(() => {
@@ -28,19 +26,17 @@ export const useDateRange = (selected: DatePickerDateRange, onSelect?: (dateRang
             return;
         }
 
+        const hasExistingSelection = internalSelectedDateRange !== undefined;
+
         setInternalSelectedDateRange(dateRange);
 
-        if (isAwaitingEndDate) {
-            setIsAwaitingEndDate(false);
+        if (hasExistingSelection) {
             onSelect?.(dateRange);
-        } else {
-            setIsAwaitingEndDate(true);
         }
     };
 
     return {
         selectedDateRange,
         handleSelect,
-        isAwaitingEndDate,
     };
 };


### PR DESCRIPTION
> Created by the [`auto-bugfix`](https://github.com/Frontify/engineering-skills#installation) plugin. Engineer review required before merge.

`DatePicker.Range` never passed a single-click change to an *already-selected* range through `onChange`: it suppressed the callback until a two-click range completed, but visually doesn't indicate that the selection is uncomplete — so moving just the start date and pressing **Apply**/**Save** silently keeps the old range. This fixes `useDateRange` to call `onChange` on every click **once a selection already exists**, so adjusting an existing range propagates immediately. Selecting a brand-new range is deliberately unchanged — it still takes two clicks (start, then end), so no consumer of the fresh-selection flow is affected. Mechanically, the `isAwaitingEndDate` gesture flag is replaced by a presence predicate (`hasExistingSelection`), splitting behaviour between editing an existing range (report each click) and building a new one (two-click).

**Source**: [DAMCRE-177](https://linear.app/frontify/issue/DAMCRE-177/datepicker-variantrange-prevents-changing-the-filter-by-clicking-just)

## How to reproduce

1. Open a `DatePicker.Range` that already has a range selected, backed by an Apply/Save button (e.g. the `InFlyout` story, or any date-range filter).
2. Click one day before the current start to move it.
3. Press Apply/Save.

**Without this fix:** the calendar shows the moved start, but `onChange` never fires for that single click, so Apply/Save commits the old range — the edit is lost.

**With this fix:** that single click reports `{ from: <new start>, to: <existing end> }` to `onChange` immediately, so Apply/Save commits the edited range. (A brand-new range still takes two clicks.)

## Verification

- `TZ=UTC vitest run src/components/DatePicker` → 51 passed (51)
- `playwright test RangeDatePicker.ct --project=chromium` → 12 passed
- `oxlint` (changed files) → exit 0
- `oxfmt --check` (changed files) → clean
- `tsgo --noEmit` → clean

<details>
<summary>Original auto-bugfix description (for traceability)</summary>

`DatePicker.Range` only reported a date-range change after a full two-click range was completed, so changing an already-selected range with a single click (for example moving just the start date) looked applied in the calendar but was never passed to `onChange` — pressing **Apply**/**Save** kept the old range. With this change the range picker reports every selection change, so a single click is applied as expected.

**Source**: [DAMCRE-177](https://linear.app/frontify/issue/DAMCRE-177/datepicker-variantrange-prevents-changing-the-filter-by-clicking-just)

## How to reproduce

1. Open a `DatePicker.Range` that already has a range selected, backed by an Apply/Save button (e.g. the `InFlyout` story, or any date-range filter).
2. Click a single day before the current start date to move the start.
3. Press Apply/Save.

**Without this fix:** the calendar shows the new start, but `onChange` never fires for that single click, so the committed range is unchanged — the edit is silently lost.

**With this fix:** the single click reports `{ from: <new start>, to: <existing end> }` to `onChange` immediately, so Apply/Save commits the edited range.

<details>
<summary>Implementation details</summary>

### Intent

When the selection changes in `DatePicker.Range`, the component reports the current selection through `onChange`, so the calendar and the consumer's committed value stay in sync.
Source of intent: bug report (DAMCRE-177) + the design system's documented Save pattern (`DatePicker.stories.tsx` `InFlyout`).

### What was fixed

`useDateRange.ts` — removed the `isAwaitingEndDate` gate so `handleSelect` calls `onSelect` on every completed range instead of only on the second click. Before → after: the first click of a gesture is now reported, where it was previously swallowed.

### Why this approach

The `isAwaitingEndDate` suppression lived entirely inside `useDateRange`, so that hook is the terminus. Fixing one level higher (`RangeDatePicker` or the consumer) was rejected: `DatePicker.Range` is a shared, published component whose only consumers are external, so a call-site workaround would leave every other consumer broken. The fix shape is removal of a special-case branch — it deletes the suppression and returns `handleSelect` to the same shape as its sibling `useSingleDate.handleSelect`, adding no defensive logic.

### Lesson encoded

**Layer:** test-class
**Where:** `useDateRange.spec.ts` (unit) and `RangeDatePicker.ct.tsx` (real react-day-picker via Playwright)
**Prevents:** a selection change in `DatePicker.Range` that updates the calendar but is not reported through `onChange`.

### Verification

- `TZ=UTC vitest run src/components/DatePicker` → 51 passed (51)
- `playwright test RangeDatePicker.ct --project=chromium` → 12 passed
- `oxlint` (changed files) → exit 0
- `tsgo --noEmit` → clean (no errors)

</details>

</details>