### PR TITLE
fix: card hover border inset and small aspect ratio

### DIFF
--- a/.changeset/card-border-and-small-banner.md
+++ b/.changeset/card-border-and-small-banner.md
@@ -1,0 +1,7 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(Card): keep the border in place on hover, show the banner border over images, and make the small banner square its images
+
+Hovering a card no longer shifts the border outward by a pixel — it stays in the banner's position and simply extends down around the rest of the card. The banner border is now visible whether or not the banner has an image. The small banner uses a 3:1 aspect ratio so that a banner split into three images shows each one as a square.

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -185,6 +185,7 @@ export const SmallBannerWithImages: Story = {
                 <Card.Banner size="small">
                     <Card.BannerImage src="https://picsum.photos/seed/col1/300/200" alt="Image 1" />
                     <Card.BannerImage src="https://picsum.photos/seed/col2/300/200" alt="Image 2" />
+                    <Card.BannerImage src="https://picsum.photos/seed/col3/300/200" alt="Image 3" />
                 </Card.Banner>
 
                 <Card.Title>[Collection name]</Card.Title>

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -4,24 +4,41 @@
 @use '../../../utilities/sizeToken.module.scss';
 @use '../../../utilities/transitions.module.scss';
 
-// Mixin for card state variants (default, hover, selected, hover+selected)
+// Mixin for card state variants (default, hover, selected, hover+selected).
+//
+// Both the whole-card border and the banner border are drawn as inset box-shadows
+// on `::after` overlays (see `.root::after` / `.banner::after`). Drawing them inset
+// at the same position keeps the border on the inside of the card: it never changes
+// the card's outer size and the top/side segment does not move between states, so on
+// hover the border simply extends down around the rest of the card. The overlays also
+// paint above the banner image, so the banner border stays visible with or without one.
 @mixin card-state(
-    $root-border-color: transparent,
+    $card-border-color: transparent,
     $root-bg: null,
-    $box-shadow: none,
+    $card-ring: null,
     $banner-border-color: transparent,
     $banner-border-radius: 0
 ) {
-    border-color: $root-border-color;
-    box-shadow: $box-shadow;
-
     @if $root-bg {
         background-color: var(--color-#{$root-bg});
     }
 
+    &::after {
+        @if $card-ring {
+            box-shadow:
+                inset 0 0 0 1px $card-border-color,
+                $card-ring;
+        } @else {
+            box-shadow: inset 0 0 0 1px $card-border-color;
+        }
+    }
+
     & .banner {
-        box-shadow: inset 0 0 0 1px $banner-border-color;
         border-radius: $banner-border-radius;
+    }
+
+    & .banner::after {
+        box-shadow: inset 0 0 0 1px $banner-border-color;
     }
 }
 
@@ -62,11 +79,22 @@
     grid-template-rows: auto minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto) minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto);
     border-radius: var(--border-radius-large);
     box-sizing: border-box;
-    border: var(--border-width-default) solid transparent;
     background-color: var(--color-surface-default);
     overflow: hidden;
     outline: none;
-    @include transitions.transition((background-color, border-color, box-shadow));
+    @include transitions.transition((background-color));
+
+    // Whole-card border overlay. Painted above the banner/image and flush with the card's
+    // edge so it shares the banner border's position — no size change, no halo around it.
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: 2;
+        border-radius: inherit;
+        pointer-events: none;
+        @include transitions.transition-box-shadow;
+    }
 
     &:not(:has(> .banner)) {
         background-color: var(--color-surface-dim);
@@ -90,7 +118,7 @@
         &:hover,
         &:has([data-state='open']) {
             @include card-state(
-                $root-border-color: var(--color-line-subtle),
+                $card-border-color: var(--color-line-subtle),
                 $root-bg: 'surface-hover'
             );
         }
@@ -98,9 +126,9 @@
         // Selected state
         &[data-selected='true'] {
             @include card-state(
-                $root-border-color: var(--color-line-strong),
+                $card-border-color: var(--color-line-strong),
                 $root-bg: 'surface-dim',
-                $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
+                $card-ring: inset 0 0 0 2px var(--color-interactive-default)
             );
         }
 
@@ -108,9 +136,9 @@
         &[data-selected='true']:hover,
         &[data-selected='true']:has([data-state='open']) {
             @include card-state(
-                $root-border-color: var(--color-interactive-default),
+                $card-border-color: var(--color-interactive-default),
                 $root-bg: 'surface-hover',
-                $box-shadow: inset 0 0 0 1px var(--color-interactive-default)
+                $card-ring: inset 0 0 0 2px var(--color-interactive-default)
             );
         }
 
@@ -173,6 +201,18 @@
     background-color: var(--color-surface-dim);
     pointer-events: none;
     @include transitions.transition-colors;
+
+    // Banner border overlay. Painted above the image (and inheriting the banner radius)
+    // so the border stays visible whether or not the banner has an image.
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        border-radius: inherit;
+        pointer-events: none;
+        @include transitions.transition-box-shadow;
+    }
 
     .root[data-interactive='true']:hover &:has(> .bannerIcon),
     .root[data-interactive='true']:has([data-state='open']) &:has(> .bannerIcon) {

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -4,34 +4,35 @@
 @use '../../../utilities/sizeToken.module.scss';
 @use '../../../utilities/transitions.module.scss';
 
+// Border overlay shared by the whole card and the banner. Painted above the
+// banner/image so the border stays visible over an image; its box-shadow is set per
+// state in card-state.
+@mixin border-overlay($z-index) {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: $z-index;
+    border-radius: inherit;
+    pointer-events: none;
+    @include transitions.transition-box-shadow;
+}
+
 // Mixin for card state variants (default, hover, selected, hover+selected).
-@mixin card-state(
-    $card-border-color: transparent,
-    $root-bg: null,
-    $card-ring: null,
-    $banner-border-color: transparent,
-    $banner-border-radius: 0
-) {
+@mixin card-state($card-shadow: none, $root-bg: null, $banner-shadow: none, $banner-radius: 0) {
     @if $root-bg {
         background-color: var(--color-#{$root-bg});
     }
 
     &::after {
-        @if $card-ring {
-            box-shadow:
-                inset 0 0 0 1px $card-border-color,
-                $card-ring;
-        } @else {
-            box-shadow: inset 0 0 0 1px $card-border-color;
-        }
+        box-shadow: $card-shadow;
     }
 
     & .banner {
-        border-radius: $banner-border-radius;
+        border-radius: $banner-radius;
     }
 
     & .banner::after {
-        box-shadow: inset 0 0 0 1px $banner-border-color;
+        box-shadow: $banner-shadow;
     }
 }
 
@@ -78,13 +79,7 @@
     @include transitions.transition((background-color));
 
     &::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        z-index: 2;
-        border-radius: inherit;
-        pointer-events: none;
-        @include transitions.transition-box-shadow;
+        @include border-overlay($z-index: 2);
     }
 
     &:not(:has(> .banner)) {
@@ -93,8 +88,8 @@
 
     // Default state
     @include card-state(
-        $banner-border-color: var(--color-line-subtle),
-        $banner-border-radius: var(--border-radius-large)
+        $banner-shadow: inset 0 0 0 1px var(--color-line-subtle),
+        $banner-radius: var(--border-radius-large)
     );
 
     // Interactive cards only
@@ -109,7 +104,7 @@
         &:hover,
         &:has([data-state='open']) {
             @include card-state(
-                $card-border-color: var(--color-line-subtle),
+                $card-shadow: inset 0 0 0 1px var(--color-line-subtle),
                 $root-bg: 'surface-hover'
             );
         }
@@ -117,9 +112,8 @@
         // Selected state
         &[data-selected='true'] {
             @include card-state(
-                $card-border-color: var(--color-line-strong),
-                $root-bg: 'surface-dim',
-                $card-ring: inset 0 0 0 2px var(--color-interactive-default)
+                $card-shadow: (inset 0 0 0 1px var(--color-line-strong), inset 0 0 0 2px var(--color-interactive-default)),
+                $root-bg: 'surface-dim'
             );
         }
 
@@ -127,9 +121,8 @@
         &[data-selected='true']:hover,
         &[data-selected='true']:has([data-state='open']) {
             @include card-state(
-                $card-border-color: var(--color-interactive-default),
-                $root-bg: 'surface-hover',
-                $card-ring: inset 0 0 0 2px var(--color-interactive-default)
+                $card-shadow: (inset 0 0 0 1px var(--color-interactive-default), inset 0 0 0 2px var(--color-interactive-default)),
+                $root-bg: 'surface-hover'
             );
         }
 
@@ -194,13 +187,7 @@
     @include transitions.transition-colors;
 
     &::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        border-radius: inherit;
-        pointer-events: none;
-        @include transitions.transition-box-shadow;
+        @include border-overlay($z-index: 1);
     }
 
     .root[data-interactive='true']:hover &:has(> .bannerIcon),

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -5,13 +5,6 @@
 @use '../../../utilities/transitions.module.scss';
 
 // Mixin for card state variants (default, hover, selected, hover+selected).
-//
-// Both the whole-card border and the banner border are drawn as inset box-shadows
-// on `::after` overlays (see `.root::after` / `.banner::after`). Drawing them inset
-// at the same position keeps the border on the inside of the card: it never changes
-// the card's outer size and the top/side segment does not move between states, so on
-// hover the border simply extends down around the rest of the card. The overlays also
-// paint above the banner image, so the banner border stays visible with or without one.
 @mixin card-state(
     $card-border-color: transparent,
     $root-bg: null,
@@ -84,8 +77,6 @@
     outline: none;
     @include transitions.transition((background-color));
 
-    // Whole-card border overlay. Painted above the banner/image and flush with the card's
-    // edge so it shares the banner border's position — no size change, no halo around it.
     &::after {
         content: '';
         position: absolute;
@@ -202,8 +193,6 @@
     pointer-events: none;
     @include transitions.transition-colors;
 
-    // Banner border overlay. Painted above the image (and inheriting the banner radius)
-    // so the border stays visible whether or not the banner has an image.
     &::after {
         content: '';
         position: absolute;
@@ -223,7 +212,6 @@
         background-color: var(--color-surface-active);
     }
 
-    // 3:1 so that a banner split into 3 equal-width images yields square images.
     &[data-size='small'] {
         aspect-ratio: 3 / 1;
     }

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -223,8 +223,9 @@
         background-color: var(--color-surface-active);
     }
 
+    // 3:1 so that a banner split into 3 equal-width images yields square images.
     &[data-size='small'] {
-        aspect-ratio: 9 / 4;
+        aspect-ratio: 3 / 1;
     }
 
     &[data-size='large'] {


### PR DESCRIPTION
### Card border & small banner fixes

A few visual problems with the Card component, mostly around the banner and how the border behaves:

The border jumps when you hover. When you have a banner without an image, the banner has its own border. Hovering the card is supposed to put a border around the whole card — but right now the banner's border disappears and the card's border shows up in a slightly different spot. Because the banner sits inside the card, it ends up looking 1px smaller, so on a quick hover the border seems to shift/grow by a pixel instead of just smoothly extending down around the rest of the card. It should feel like the existing border simply expands to the bottom, without anything getting bigger.

The banner border is missing when there's an image. The banner border only shows up when the banner has no image. As soon as you put an image in, the border is gone.

The small banner doesn't make square images. The small banner was designed so that when you put three images in it, each one shows up as a square. With the current proportions that doesn't happen — the images come out the wrong shape.

🎥 Loom walkthrough: [https://www.loom.com/share/666fa256dc8c48da957524e029ce8d1c](https://www.loom.com/share/666fa256dc8c48da957524e029ce8d1c)