### PR TITLE
fix(Card): restore the border on the selected state

### DIFF
--- a/.changeset/card-selected-border.md
+++ b/.changeset/card-selected-border.md
@@ -1,0 +1,7 @@
+---
+"@frontify/fondue-components": patch
+---
+
+fix(Card): restore the border on the selected state
+
+A selected card (and a selected card on hover) lost its border. The selected border now shows again, using the `color-line-strong` value from the design.

--- a/packages/components/src/components/Card/__tests__/Card.ct.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.ct.tsx
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { expect, type Locator, test } from '@playwright/experimental-ct-react';
+import { expect, test } from '@playwright/experimental-ct-react';
+import { type Locator } from '@playwright/test';
 
 import { RouterProvider } from '../../RouterProvider/RouterProvider';
 import { Card } from '../Card';

--- a/packages/components/src/components/Card/__tests__/Card.ct.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.ct.tsx
@@ -1,0 +1,72 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { expect, type Locator, test } from '@playwright/experimental-ct-react';
+
+import { RouterProvider } from '../../RouterProvider/RouterProvider';
+import { Card } from '../Card';
+
+const CARD_TEST_ID = 'test-card';
+
+const readBorder = (card: Locator) =>
+    card.evaluate((element: Element) => {
+        const probe = document.createElement('span');
+        probe.style.color = 'var(--color-line-strong)';
+        document.body.append(probe);
+        const expectedColor = getComputedStyle(probe).color;
+        probe.remove();
+
+        return {
+            boxShadow: getComputedStyle(element, '::after').boxShadow,
+            expectedColor,
+        };
+    });
+
+test('should render the border on the selected state', async ({ mount }) => {
+    const wrapper = await mount(
+        <RouterProvider navigate={() => {}} useHref={(path) => path}>
+            <Card.Root data-test-id={CARD_TEST_ID} href="/page" onSelect={() => {}} selected aria-label="Card">
+                <Card.Title>Card title</Card.Title>
+            </Card.Root>
+        </RouterProvider>,
+    );
+    const card = wrapper.getByTestId(CARD_TEST_ID);
+    await expect(card).toHaveAttribute('data-selected', 'true');
+
+    const { boxShadow, expectedColor } = await readBorder(card);
+
+    expect(boxShadow).not.toBe('none');
+    expect(boxShadow).toContain(expectedColor);
+});
+
+test('should keep the border on the selected state while hovered', async ({ mount }) => {
+    const wrapper = await mount(
+        <RouterProvider navigate={() => {}} useHref={(path) => path}>
+            <Card.Root data-test-id={CARD_TEST_ID} href="/page" onSelect={() => {}} selected aria-label="Card">
+                <Card.Title>Card title</Card.Title>
+            </Card.Root>
+        </RouterProvider>,
+    );
+    const card = wrapper.getByTestId(CARD_TEST_ID);
+    await card.hover();
+
+    const { boxShadow, expectedColor } = await readBorder(card);
+
+    expect(boxShadow).not.toBe('none');
+    expect(boxShadow).toContain(expectedColor);
+});
+
+test('should not render the card border when not selected', async ({ mount }) => {
+    const wrapper = await mount(
+        <RouterProvider navigate={() => {}} useHref={(path) => path}>
+            <Card.Root data-test-id={CARD_TEST_ID} href="/page" onSelect={() => {}} selected={false} aria-label="Card">
+                <Card.Title>Card title</Card.Title>
+            </Card.Root>
+        </RouterProvider>,
+    );
+    const card = wrapper.getByTestId(CARD_TEST_ID);
+    await expect(card).toHaveAttribute('data-selected', 'false');
+
+    const { boxShadow } = await readBorder(card);
+
+    expect(boxShadow).toBe('none');
+});

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -112,7 +112,7 @@
         // Selected state
         &[data-selected='true'] {
             @include card-state(
-                $card-shadow: (inset 0 0 0 1px var(--color-line-strong), inset 0 0 0 2px var(--color-interactive-default)),
+                $card-shadow: inset 0 0 0 1px var(--color-line-strong),
                 $root-bg: 'surface-dim'
             );
         }
@@ -121,7 +121,7 @@
         &[data-selected='true']:hover,
         &[data-selected='true']:has([data-state='open']) {
             @include card-state(
-                $card-shadow: (inset 0 0 0 1px var(--color-interactive-default), inset 0 0 0 2px var(--color-interactive-default)),
+                $card-shadow: inset 0 0 0 1px var(--color-line-strong),
                 $root-bg: 'surface-hover'
             );
         }


### PR DESCRIPTION
### Selected card lost its border

When you select a card, it's supposed to get a border to show it's selected — and the same when you hover a card that's already selected. Right now that border isn't there at all: selecting a card (or hovering a selected one) leaves it with no border, so there's no clear indication that it's the selected one.

This brings the selected border back, using the color-line-strong value from the design.