### PR TITLE
feat: card primitives web app gaps

### DIFF
--- a/.changeset/card-action-data-attributes.md
+++ b/.changeset/card-action-data-attributes.md
@@ -1,0 +1,9 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Card.Action): forward arbitrary `data-*` attributes
+
+`Card.Action` now spreads unknown props (notably `data-*` attributes, e.g. an
+analytics or onboarding-tour selector) onto the rendered element, so consumers
+no longer need an extra wrapper to carry them.

--- a/.changeset/card-banner-image-padding.md
+++ b/.changeset/card-banner-image-padding.md
@@ -1,0 +1,11 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Card.BannerImage): add a `padding` prop
+
+`Card.BannerImage` now accepts `padding="none" | "small" | "medium" | "large"`
+(none by default; small 12px, medium 24px, large 32px). Padding is applied
+inside the banner and pairs best with `fit="contain"`, giving previews such as
+logos or icons breathing room without dropping out of the component. Backward
+compatible — existing images default to `none`.

--- a/.changeset/card-banner-tone.md
+++ b/.changeset/card-banner-tone.md
@@ -4,9 +4,8 @@
 
 feat(Card.Banner): add a `tone` prop
 
-`Card.Banner` now accepts `tone="dim" | "active" | "inverted"`. `inverted`
-renders the dark drop-target state (near-black background, white icon), while
-`dim`/`active` pin the background and opt out of the implicit hover/active
-background shift that otherwise applies when a `Card.BannerIcon` is nested.
-Leaving `tone` unset preserves the previous behavior, so existing consumers are
-unaffected.
+`Card.Banner` now accepts `tone="dim" | "inverted"`. `inverted` renders the dark
+drop-target state (near-black background, white icon), while `dim` pins the
+background and opts out of the implicit hover/active background shift that
+otherwise applies when a `Card.BannerIcon` is nested. Leaving `tone` unset
+preserves the previous behavior, so existing consumers are unaffected.

--- a/.changeset/card-banner-tone.md
+++ b/.changeset/card-banner-tone.md
@@ -1,0 +1,12 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Card.Banner): add a `tone` prop
+
+`Card.Banner` now accepts `tone="dim" | "active" | "inverted"`. `inverted`
+renders the dark drop-target state (near-black background, white icon), while
+`dim`/`active` pin the background and opt out of the implicit hover/active
+background shift that otherwise applies when a `Card.BannerIcon` is nested.
+Leaving `tone` unset preserves the previous behavior, so existing consumers are
+unaffected.

--- a/.changeset/card-root-classname.md
+++ b/.changeset/card-root-classname.md
@@ -1,0 +1,9 @@
+---
+"@frontify/fondue-components": minor
+---
+
+feat(Card.Root): forward `className`
+
+`Card.Root` now forwards a `className` onto its root element, merged after the
+internal styles. This enables layout hooks such as Tailwind's `group` (e.g. to
+drive `group-hover:` styles on descendants) without an extra wrapper element.

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import {
+    IconArrowAlignDown,
     IconCog,
     IconDotsVertical,
     IconExclamationMarkTriangle,
@@ -33,6 +34,8 @@ import {
     CardThumbnailIcon,
     CardThumbnailImage,
     CardTitle,
+    type CardBannerFit,
+    type CardBannerImagePadding,
 } from './Card';
 
 type Story = StoryObj<typeof meta>;
@@ -78,6 +81,15 @@ const singleCardDecorators: Story['decorators'] = [
         </div>
     ),
 ];
+
+// Inline SVG used as an <img> source, so the padding story shows breathing room
+// around a logo-like graphic (a logo/icon library preview) without a network request.
+const LOGO_ICON_DATA_URI = `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#4c43d6"><path d="M12 2 3 7v10l9 5 9-5V7zm0 2.31L18.18 8 12 11.69 5.82 8zM5 9.7l6 3.58v6.32l-6-3.33zm14 0v6.57l-6 3.33v-6.32z"/></svg>',
+)}`;
+
+// The padding story exposes interactive controls for `padding` and `fit`.
+type BannerImagePaddingControls = { padding: CardBannerImagePadding; fit: CardBannerFit };
 
 export const Default: Story = {
     decorators: singleCardDecorators,
@@ -175,25 +187,43 @@ export const WithBadges: Story = {
     },
 };
 
-export const BannerImageWithPadding: Story = {
-    decorators: singleCardDecorators,
-    render: () => {
+export const BannerImageWithPadding: StoryObj<BannerImagePaddingControls> = {
+    decorators: [
+        (Story) => (
+            <div style={{ width: 280 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        padding: 'medium',
+        fit: 'contain',
+    },
+    argTypes: {
+        padding: {
+            control: 'select',
+            options: ['none', 'small', 'medium', 'large'],
+            description: 'Inner padding between the image and the banner edges (small 12px, medium 24px, large 32px).',
+        },
+        fit: {
+            control: 'inline-radio',
+            options: ['cover', 'contain'],
+            description: 'How the image fits the banner. Padding pairs best with `contain`.',
+        },
+    },
+    render: ({ padding, fit }) => {
         const [selected, setSelected] = useState(false);
 
         return (
             <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
                 <Card.Banner>
-                    {/* Padding gives a logo/icon preview breathing room. Pairs with fit="contain". */}
-                    <Card.BannerImage
-                        src="https://picsum.photos/seed/logo-lib/200/200"
-                        alt="Logo preview"
-                        fit="contain"
-                        padding="medium"
-                    />
+                    {/* Padding gives a logo/icon preview breathing room. Pairs with fit="contain".
+                        Use the Controls panel to change `padding` and `fit` live. */}
+                    <Card.BannerImage src={LOGO_ICON_DATA_URI} alt="Logo preview" fit={fit} padding={padding} />
                 </Card.Banner>
 
                 <Card.Title>[Logo asset]</Card.Title>
-                <Card.Description>SVG · 24px padding</Card.Description>
+                <Card.Description>{`padding="${padding}" · fit="${fit}"`}</Card.Description>
 
                 <Card.Action>
                     <Card.ActionButton aria-label="More actions">
@@ -274,10 +304,11 @@ export const BannerToneInverted: Story = {
 
         return (
             <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
-                {/* tone="inverted" renders the drop-target state: dark banner + white icon. */}
+                {/* tone="inverted" renders the drop-target state: dark banner + white icon.
+                    The icon inherits the white (on-primary) color automatically. */}
                 <Card.Banner tone="inverted">
                     <Card.BannerIcon>
-                        <IconFolder size={32} />
+                        <IconArrowAlignDown size={32} />
                     </Card.BannerIcon>
                 </Card.Banner>
 
@@ -295,28 +326,67 @@ export const BannerToneInverted: Story = {
 };
 
 export const BannerToneDim: Story = {
-    decorators: singleCardDecorators,
+    name: 'BannerTone dim (hover to compare)',
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'The effect of `tone="dim"` only shows on hover. A tone-less banner that contains a ' +
+                    '`Card.BannerIcon` brightens to `surface-hover` when the interactive card is hovered; ' +
+                    '`tone="dim"` pins `surface-dim` and opts out of that shift. Hover each card to compare.',
+            },
+        },
+    },
     render: () => {
-        const [selected, setSelected] = useState(false);
+        const [selectedDefault, setSelectedDefault] = useState(false);
+        const [selectedDim, setSelectedDim] = useState(false);
 
         return (
-            <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
-                {/* tone="dim" pins surface-dim, opting out of the implicit hover/active shift. */}
-                <Card.Banner tone="dim">
-                    <Card.BannerIcon>
-                        <IconImageStack size={32} />
-                    </Card.BannerIcon>
-                </Card.Banner>
+            <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+                <div style={{ width: 280 }}>
+                    <Card.Root
+                        href="#"
+                        selected={selectedDefault}
+                        onSelect={() => setSelectedDefault((s) => !s)}
+                    >
+                        {/* No tone: the banner background brightens on hover. */}
+                        <Card.Banner>
+                            <Card.BannerIcon>
+                                <IconImageStack size={32} />
+                            </Card.BannerIcon>
+                        </Card.Banner>
 
-                <Card.Title>[Collection name]</Card.Title>
-                <Card.Description>Background stays dim on hover</Card.Description>
+                        <Card.Title>Default (no tone)</Card.Title>
+                        <Card.Description>Hover → banner brightens</Card.Description>
 
-                <Card.Action>
-                    <Card.ActionButton aria-label="More actions">
-                        <IconDotsVertical size={20} />
-                    </Card.ActionButton>
-                </Card.Action>
-            </Card.Root>
+                        <Card.Action>
+                            <Card.ActionButton aria-label="More actions">
+                                <IconDotsVertical size={20} />
+                            </Card.ActionButton>
+                        </Card.Action>
+                    </Card.Root>
+                </div>
+
+                <div style={{ width: 280 }}>
+                    <Card.Root href="#" selected={selectedDim} onSelect={() => setSelectedDim((s) => !s)}>
+                        {/* tone="dim" pins surface-dim, opting out of the implicit hover/active shift. */}
+                        <Card.Banner tone="dim">
+                            <Card.BannerIcon>
+                                <IconImageStack size={32} />
+                            </Card.BannerIcon>
+                        </Card.Banner>
+
+                        <Card.Title>tone=&quot;dim&quot;</Card.Title>
+                        <Card.Description>Hover → banner stays dim</Card.Description>
+
+                        <Card.Action>
+                            <Card.ActionButton aria-label="More actions">
+                                <IconDotsVertical size={20} />
+                            </Card.ActionButton>
+                        </Card.Action>
+                    </Card.Root>
+                </div>
+            </div>
         );
     },
 };

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -82,14 +82,104 @@ const singleCardDecorators: Story['decorators'] = [
     ),
 ];
 
-// Inline SVG used as an <img> source, so the padding story shows breathing room
-// around a logo-like graphic (a logo/icon library preview) without a network request.
+// Inline SVG logo used as the padded image source, so the story has no network dependency.
 const LOGO_ICON_DATA_URI = `data:image/svg+xml,${encodeURIComponent(
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#4c43d6"><path d="M12 2 3 7v10l9 5 9-5V7zm0 2.31L18.18 8 12 11.69 5.82 8zM5 9.7l6 3.58v6.32l-6-3.33zm14 0v6.57l-6 3.33v-6.32z"/></svg>',
 )}`;
 
-// The padding story exposes interactive controls for `padding` and `fit`.
 type BannerImagePaddingControls = { padding: CardBannerImagePadding; fit: CardBannerFit };
+
+// Story bodies are extracted into named components so `useState` runs inside a React component.
+const BannerImagePaddingDemo = ({ padding, fit }: BannerImagePaddingControls) => {
+    const [selected, setSelected] = useState(false);
+
+    return (
+        <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
+            <Card.Banner>
+                <Card.BannerImage src={LOGO_ICON_DATA_URI} alt="Logo preview" fit={fit} padding={padding} />
+            </Card.Banner>
+
+            <Card.Title>[Logo asset]</Card.Title>
+            <Card.Description>{`padding="${padding}" · fit="${fit}"`}</Card.Description>
+
+            <Card.Action>
+                <Card.ActionButton aria-label="More actions">
+                    <IconDotsVertical size={20} />
+                </Card.ActionButton>
+            </Card.Action>
+        </Card.Root>
+    );
+};
+
+const BannerToneInvertedDemo = () => {
+    const [selected, setSelected] = useState(false);
+
+    return (
+        <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
+            <Card.Banner tone="inverted">
+                <Card.BannerIcon>
+                    <IconArrowAlignDown size={32} />
+                </Card.BannerIcon>
+            </Card.Banner>
+
+            <Card.Title>[Drop files here]</Card.Title>
+            <Card.Description>Release to move into folder</Card.Description>
+
+            <Card.Action>
+                <Card.ActionButton aria-label="More actions">
+                    <IconDotsVertical size={20} />
+                </Card.ActionButton>
+            </Card.Action>
+        </Card.Root>
+    );
+};
+
+const BannerToneDimComparison = () => {
+    const [selectedDefault, setSelectedDefault] = useState(false);
+    const [selectedDim, setSelectedDim] = useState(false);
+
+    return (
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+            <div style={{ width: 280 }}>
+                <Card.Root href="#" selected={selectedDefault} onSelect={() => setSelectedDefault((s) => !s)}>
+                    <Card.Banner>
+                        <Card.BannerIcon>
+                            <IconImageStack size={32} />
+                        </Card.BannerIcon>
+                    </Card.Banner>
+
+                    <Card.Title>Default (no tone)</Card.Title>
+                    <Card.Description>Hover → banner brightens</Card.Description>
+
+                    <Card.Action>
+                        <Card.ActionButton aria-label="More actions">
+                            <IconDotsVertical size={20} />
+                        </Card.ActionButton>
+                    </Card.Action>
+                </Card.Root>
+            </div>
+
+            <div style={{ width: 280 }}>
+                <Card.Root href="#" selected={selectedDim} onSelect={() => setSelectedDim((s) => !s)}>
+                    <Card.Banner tone="dim">
+                        <Card.BannerIcon>
+                            <IconImageStack size={32} />
+                        </Card.BannerIcon>
+                    </Card.Banner>
+
+                    <Card.Title>tone=&quot;dim&quot;</Card.Title>
+                    <Card.Description>Hover → banner stays dim</Card.Description>
+
+                    <Card.Action>
+                        <Card.ActionButton aria-label="More actions">
+                            <IconDotsVertical size={20} />
+                        </Card.ActionButton>
+                    </Card.Action>
+                </Card.Root>
+            </div>
+        </div>
+    );
+};
 
 export const Default: Story = {
     decorators: singleCardDecorators,
@@ -211,28 +301,7 @@ export const BannerImageWithPadding: StoryObj<BannerImagePaddingControls> = {
             description: 'How the image fits the banner. Padding pairs best with `contain`.',
         },
     },
-    render: ({ padding, fit }) => {
-        const [selected, setSelected] = useState(false);
-
-        return (
-            <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
-                <Card.Banner>
-                    {/* Padding gives a logo/icon preview breathing room. Pairs with fit="contain".
-                        Use the Controls panel to change `padding` and `fit` live. */}
-                    <Card.BannerImage src={LOGO_ICON_DATA_URI} alt="Logo preview" fit={fit} padding={padding} />
-                </Card.Banner>
-
-                <Card.Title>[Logo asset]</Card.Title>
-                <Card.Description>{`padding="${padding}" · fit="${fit}"`}</Card.Description>
-
-                <Card.Action>
-                    <Card.ActionButton aria-label="More actions">
-                        <IconDotsVertical size={20} />
-                    </Card.ActionButton>
-                </Card.Action>
-            </Card.Root>
-        );
-    },
+    render: (args) => <BannerImagePaddingDemo {...args} />,
 };
 
 export const SmallBannerWithImages: Story = {
@@ -299,30 +368,7 @@ export const SmallBannerWithIcon: Story = {
 
 export const BannerToneInverted: Story = {
     decorators: singleCardDecorators,
-    render: () => {
-        const [selected, setSelected] = useState(false);
-
-        return (
-            <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
-                {/* tone="inverted" renders the drop-target state: dark banner + white icon.
-                    The icon inherits the white (on-primary) color automatically. */}
-                <Card.Banner tone="inverted">
-                    <Card.BannerIcon>
-                        <IconArrowAlignDown size={32} />
-                    </Card.BannerIcon>
-                </Card.Banner>
-
-                <Card.Title>[Drop files here]</Card.Title>
-                <Card.Description>Release to move into folder</Card.Description>
-
-                <Card.Action>
-                    <Card.ActionButton aria-label="More actions">
-                        <IconDotsVertical size={20} />
-                    </Card.ActionButton>
-                </Card.Action>
-            </Card.Root>
-        );
-    },
+    render: () => <BannerToneInvertedDemo />,
 };
 
 export const BannerToneDim: Story = {
@@ -337,58 +383,7 @@ export const BannerToneDim: Story = {
             },
         },
     },
-    render: () => {
-        const [selectedDefault, setSelectedDefault] = useState(false);
-        const [selectedDim, setSelectedDim] = useState(false);
-
-        return (
-            <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-                <div style={{ width: 280 }}>
-                    <Card.Root
-                        href="#"
-                        selected={selectedDefault}
-                        onSelect={() => setSelectedDefault((s) => !s)}
-                    >
-                        {/* No tone: the banner background brightens on hover. */}
-                        <Card.Banner>
-                            <Card.BannerIcon>
-                                <IconImageStack size={32} />
-                            </Card.BannerIcon>
-                        </Card.Banner>
-
-                        <Card.Title>Default (no tone)</Card.Title>
-                        <Card.Description>Hover → banner brightens</Card.Description>
-
-                        <Card.Action>
-                            <Card.ActionButton aria-label="More actions">
-                                <IconDotsVertical size={20} />
-                            </Card.ActionButton>
-                        </Card.Action>
-                    </Card.Root>
-                </div>
-
-                <div style={{ width: 280 }}>
-                    <Card.Root href="#" selected={selectedDim} onSelect={() => setSelectedDim((s) => !s)}>
-                        {/* tone="dim" pins surface-dim, opting out of the implicit hover/active shift. */}
-                        <Card.Banner tone="dim">
-                            <Card.BannerIcon>
-                                <IconImageStack size={32} />
-                            </Card.BannerIcon>
-                        </Card.Banner>
-
-                        <Card.Title>tone=&quot;dim&quot;</Card.Title>
-                        <Card.Description>Hover → banner stays dim</Card.Description>
-
-                        <Card.Action>
-                            <Card.ActionButton aria-label="More actions">
-                                <IconDotsVertical size={20} />
-                            </Card.ActionButton>
-                        </Card.Action>
-                    </Card.Root>
-                </div>
-            </div>
-        );
-    },
+    render: () => <BannerToneDimComparison />,
 };
 
 export const BannerIconWithThumbnail: Story = {

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -175,6 +175,36 @@ export const WithBadges: Story = {
     },
 };
 
+export const BannerImageWithPadding: Story = {
+    decorators: singleCardDecorators,
+    render: () => {
+        const [selected, setSelected] = useState(false);
+
+        return (
+            <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
+                <Card.Banner>
+                    {/* Padding gives a logo/icon preview breathing room. Pairs with fit="contain". */}
+                    <Card.BannerImage
+                        src="https://picsum.photos/seed/logo-lib/200/200"
+                        alt="Logo preview"
+                        fit="contain"
+                        padding="medium"
+                    />
+                </Card.Banner>
+
+                <Card.Title>[Logo asset]</Card.Title>
+                <Card.Description>SVG · 24px padding</Card.Description>
+
+                <Card.Action>
+                    <Card.ActionButton aria-label="More actions">
+                        <IconDotsVertical size={20} />
+                    </Card.ActionButton>
+                </Card.Action>
+            </Card.Root>
+        );
+    },
+};
+
 export const SmallBannerWithImages: Story = {
     decorators: singleCardDecorators,
     render: () => {
@@ -227,6 +257,60 @@ export const SmallBannerWithIcon: Story = {
                         <IconCog size={20} />
                     </Card.ActionButton>
                 </Card.Action>
+                <Card.Action>
+                    <Card.ActionButton aria-label="More actions">
+                        <IconDotsVertical size={20} />
+                    </Card.ActionButton>
+                </Card.Action>
+            </Card.Root>
+        );
+    },
+};
+
+export const BannerToneInverted: Story = {
+    decorators: singleCardDecorators,
+    render: () => {
+        const [selected, setSelected] = useState(false);
+
+        return (
+            <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
+                {/* tone="inverted" renders the drop-target state: dark banner + white icon. */}
+                <Card.Banner tone="inverted">
+                    <Card.BannerIcon>
+                        <IconFolder size={32} />
+                    </Card.BannerIcon>
+                </Card.Banner>
+
+                <Card.Title>[Drop files here]</Card.Title>
+                <Card.Description>Release to move into folder</Card.Description>
+
+                <Card.Action>
+                    <Card.ActionButton aria-label="More actions">
+                        <IconDotsVertical size={20} />
+                    </Card.ActionButton>
+                </Card.Action>
+            </Card.Root>
+        );
+    },
+};
+
+export const BannerToneDim: Story = {
+    decorators: singleCardDecorators,
+    render: () => {
+        const [selected, setSelected] = useState(false);
+
+        return (
+            <Card.Root href="#" selected={selected} onSelect={() => setSelected((s) => !s)}>
+                {/* tone="dim" pins surface-dim, opting out of the implicit hover/active shift. */}
+                <Card.Banner tone="dim">
+                    <Card.BannerIcon>
+                        <IconImageStack size={32} />
+                    </Card.BannerIcon>
+                </Card.Banner>
+
+                <Card.Title>[Collection name]</Card.Title>
+                <Card.Description>Background stays dim on hover</Card.Description>
+
                 <Card.Action>
                     <Card.ActionButton aria-label="More actions">
                         <IconDotsVertical size={20} />

--- a/packages/components/src/components/Card/Card.ts
+++ b/packages/components/src/components/Card/Card.ts
@@ -16,9 +16,11 @@ import {
     type CardBannerFit,
     type CardBannerIconProps,
     type CardBannerIconVariant,
+    type CardBannerImagePadding,
     type CardBannerImageProps,
     type CardBannerProps,
     type CardBannerSize,
+    type CardBannerTone,
 } from './CardBanner';
 import {
     CardBadges,
@@ -56,9 +58,11 @@ export type {
     CardBannerFit,
     CardBannerIconProps,
     CardBannerIconVariant,
+    CardBannerImagePadding,
     CardBannerImageProps,
     CardBannerProps,
     CardBannerSize,
+    CardBannerTone,
     CardDescriptionProps,
     CardRootProps,
     CardThumbnailIconProps,

--- a/packages/components/src/components/Card/CardAction.tsx
+++ b/packages/components/src/components/Card/CardAction.tsx
@@ -4,17 +4,22 @@ import { forwardRef, type ComponentProps, type ForwardedRef, type MouseEventHand
 
 import styles from './styles/card.module.scss';
 
+/**
+ * Wraps a single action in the card's action area. Any extra props — notably
+ * `data-*` attributes (e.g. an analytics/onboarding-tour selector) — are
+ * forwarded to the underlying `<div>`, so consumers don't need an extra wrapper.
+ */
 export type CardActionProps = {
     'data-test-id'?: string;
     children?: ReactNode;
-};
+} & Omit<ComponentProps<'div'>, 'children' | 'ref' | 'className'>;
 
 export const CardAction = (
-    { 'data-test-id': dataTestId = 'fondue-card-action', children }: CardActionProps,
+    { 'data-test-id': dataTestId = 'fondue-card-action', children, ...rest }: CardActionProps,
     ref: ForwardedRef<HTMLDivElement>,
 ) => {
     return (
-        <div ref={ref} className={styles.action} data-test-id={dataTestId}>
+        <div ref={ref} className={styles.action} data-test-id={dataTestId} {...rest}>
             {children}
         </div>
     );

--- a/packages/components/src/components/Card/CardBanner.tsx
+++ b/packages/components/src/components/Card/CardBanner.tsx
@@ -7,6 +7,31 @@ import styles from './styles/card.module.scss';
 
 export type CardBannerSize = 'small' | 'large';
 export type CardBannerFit = 'cover' | 'contain';
+/**
+ * Inner padding applied to a banner image, giving the preview breathing room
+ * inside the banner (e.g. logo or icon libraries).
+ *
+ * - `none` – no padding (default)
+ * - `small` – 12px
+ * - `medium` – 24px
+ * - `large` – 32px
+ */
+export type CardBannerImagePadding = 'none' | 'small' | 'medium' | 'large';
+
+/**
+ * Background tone of the banner.
+ *
+ * - `dim` – pins `surface-dim` (the resting default) and opts out of the
+ *   implicit hover/active background shift that otherwise kicks in when a
+ *   `Card.BannerIcon` is nested.
+ * - `active` – pins `surface-active`.
+ * - `inverted` – near-black background (`primary-default`) with a white icon,
+ *   for states like a folder drop target.
+ *
+ * When omitted, the banner keeps its legacy behavior: `surface-dim` at rest,
+ * shifting to hover/active surfaces on interaction when a `Card.BannerIcon` is present.
+ */
+export type CardBannerTone = 'dim' | 'active' | 'inverted';
 
 export type CardBannerProps = {
     'data-test-id'?: string;
@@ -15,15 +40,21 @@ export type CardBannerProps = {
      * @default 'large'
      */
     size?: CardBannerSize;
+    /**
+     * Pins the banner background, overriding the implicit hover/active shift
+     * applied when a `Card.BannerIcon` is nested. Leave unset to keep the
+     * default behavior.
+     */
+    tone?: CardBannerTone;
     children?: ReactNode;
 };
 
 export const CardBanner = (
-    { 'data-test-id': dataTestId = 'fondue-card-banner', size = 'large', children }: CardBannerProps,
+    { 'data-test-id': dataTestId = 'fondue-card-banner', size = 'large', tone, children }: CardBannerProps,
     ref: ForwardedRef<HTMLDivElement>,
 ) => {
     return (
-        <div ref={ref} className={styles.banner} data-test-id={dataTestId} data-size={size}>
+        <div ref={ref} className={styles.banner} data-test-id={dataTestId} data-size={size} data-tone={tone}>
             {children}
             <div
                 className={styles.selectionIndicator}
@@ -53,14 +84,35 @@ export type CardBannerImageProps = {
      * @default 'cover'
      */
     fit?: CardBannerFit;
+    /**
+     * Inner padding between the image and the banner edges, giving the preview
+     * breathing room (e.g. logo or icon libraries). Pairs best with `fit="contain"`,
+     * which lets the padded image scale down without cropping.
+     * @default 'none'
+     */
+    padding?: CardBannerImagePadding;
 };
 
 export const CardBannerImage = (
-    { 'data-test-id': dataTestId = 'fondue-card-banner-image', src, alt = '', fit = 'cover' }: CardBannerImageProps,
+    {
+        'data-test-id': dataTestId = 'fondue-card-banner-image',
+        src,
+        alt = '',
+        fit = 'cover',
+        padding = 'none',
+    }: CardBannerImageProps,
     ref: ForwardedRef<HTMLImageElement>,
 ) => {
     return (
-        <img ref={ref} className={styles.bannerImage} data-test-id={dataTestId} data-fit={fit} src={src} alt={alt} />
+        <img
+            ref={ref}
+            className={styles.bannerImage}
+            data-test-id={dataTestId}
+            data-fit={fit}
+            data-padding={padding}
+            src={src}
+            alt={alt}
+        />
     );
 };
 CardBannerImage.displayName = 'Card.BannerImage';

--- a/packages/components/src/components/Card/CardBanner.tsx
+++ b/packages/components/src/components/Card/CardBanner.tsx
@@ -24,14 +24,13 @@ export type CardBannerImagePadding = 'none' | 'small' | 'medium' | 'large';
  * - `dim` – pins `surface-dim` (the resting default) and opts out of the
  *   implicit hover/active background shift that otherwise kicks in when a
  *   `Card.BannerIcon` is nested.
- * - `active` – pins `surface-active`.
  * - `inverted` – near-black background (`primary-default`) with a white icon,
  *   for states like a folder drop target.
  *
  * When omitted, the banner keeps its legacy behavior: `surface-dim` at rest,
  * shifting to hover/active surfaces on interaction when a `Card.BannerIcon` is present.
  */
-export type CardBannerTone = 'dim' | 'active' | 'inverted';
+export type CardBannerTone = 'dim' | 'inverted';
 
 export type CardBannerProps = {
     'data-test-id'?: string;

--- a/packages/components/src/components/Card/CardRoot.tsx
+++ b/packages/components/src/components/Card/CardRoot.tsx
@@ -24,6 +24,12 @@ import styles from './styles/card.module.scss';
 type CardRootBaseProps = {
     'data-test-id'?: string;
     /**
+     * Additional class name(s) merged onto the card's root element. Useful for
+     * layout hooks such as Tailwind's `group` (e.g. to drive `group-hover:`
+     * styles on descendants). Merged after the internal styles.
+     */
+    className?: string;
+    /**
      * Called when the pointer enters the card.
      */
     onMouseEnter?: MouseEventHandler<HTMLDivElement>;
@@ -94,6 +100,7 @@ export const CardRoot = (
         'data-test-id': dataTestId = 'fondue-card',
         'aria-label': ariaLabel,
         'aria-describedby': ariaDescribedby,
+        className = '',
         selected = false,
         href,
         onNavigate,
@@ -152,7 +159,7 @@ export const CardRoot = (
     return (
         <div
             ref={ref}
-            className={styles.root}
+            className={[styles.root, className].filter(Boolean).join(' ')}
             data-test-id={dataTestId}
             data-interactive={isClickable}
             data-selectable={isSelectable}

--- a/packages/components/src/components/Card/__tests__/Card.ct.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.ct.tsx
@@ -8,6 +8,24 @@ import { Card } from '../Card';
 
 const CARD_TEST_ID = 'test-card';
 
+// 1x1 transparent gif, so the image element lays out without a network request.
+const TRANSPARENT_GIF = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
+// Resolves a CSS custom property to its computed value (e.g. a token color or
+// spacing length) using a throwaway probe element, mirroring readBorder below.
+const resolveToken = (locator: Locator, property: 'color' | 'width', cssVariable: string) =>
+    locator.evaluate(
+        (_element, { property, cssVariable }) => {
+            const probe = document.createElement('span');
+            probe.style.setProperty(property, `var(${cssVariable})`);
+            document.body.append(probe);
+            const value = getComputedStyle(probe).getPropertyValue(property);
+            probe.remove();
+            return value;
+        },
+        { property, cssVariable },
+    );
+
 const readBorder = (card: Locator) =>
     card.evaluate((element: Element) => {
         const probe = document.createElement('span');
@@ -70,4 +88,88 @@ test('should not render the card border when not selected', async ({ mount }) =>
     const { boxShadow } = await readBorder(card);
 
     expect(boxShadow).toBe('none');
+});
+
+test('should apply inner padding to a padded banner image', async ({ mount }) => {
+    const wrapper = await mount(
+        <Card.Root data-test-id={CARD_TEST_ID}>
+            <Card.Banner>
+                <Card.BannerImage data-test-id="banner-image" src={TRANSPARENT_GIF} alt="" fit="contain" padding="medium" />
+            </Card.Banner>
+        </Card.Root>,
+    );
+    const image = wrapper.getByTestId('banner-image');
+
+    // `medium` maps to --spacing-large (24px) by value, not the same-named token.
+    const expectedPadding = await resolveToken(image, 'width', '--spacing-large');
+    expect(await image.evaluate((element) => getComputedStyle(element).paddingTop)).toBe(expectedPadding);
+    expect(await image.evaluate((element) => getComputedStyle(element).objectFit)).toBe('contain');
+});
+
+test('should render the inverted banner tone with a dark background and light icon', async ({ mount }) => {
+    const wrapper = await mount(
+        <Card.Root data-test-id={CARD_TEST_ID}>
+            <Card.Banner data-test-id="banner" tone="inverted">
+                <Card.BannerIcon data-test-id="banner-icon">
+                    <svg />
+                </Card.BannerIcon>
+            </Card.Banner>
+        </Card.Root>,
+    );
+    const banner = wrapper.getByTestId('banner');
+    const icon = wrapper.getByTestId('banner-icon');
+
+    const expectedBackground = await resolveToken(banner, 'color', '--color-primary-default');
+    const expectedIconColor = await resolveToken(icon, 'color', '--color-primary-on-primary');
+
+    expect(await banner.evaluate((element) => getComputedStyle(element).backgroundColor)).toBe(expectedBackground);
+    expect(await icon.evaluate((element) => getComputedStyle(element).color)).toBe(expectedIconColor);
+});
+
+test('should keep the dim banner tone on hover instead of the implicit shift', async ({ mount }) => {
+    const wrapper = await mount(
+        <RouterProvider navigate={() => {}} useHref={(path) => path}>
+            <Card.Root data-test-id={CARD_TEST_ID} href="/page" aria-label="Card">
+                <Card.Banner data-test-id="banner" tone="dim">
+                    <Card.BannerIcon>
+                        <svg />
+                    </Card.BannerIcon>
+                </Card.Banner>
+            </Card.Root>
+        </RouterProvider>,
+    );
+    const banner = wrapper.getByTestId('banner');
+    const expectedDim = await resolveToken(banner, 'color', '--color-surface-dim');
+
+    await wrapper.getByTestId(CARD_TEST_ID).hover();
+
+    // Pinned tone opts out of the surface-hover shift that a tone-less banner gets.
+    // Poll past the banner's color transition before asserting the settled value.
+    await expect
+        .poll(() => banner.evaluate((element) => getComputedStyle(element).backgroundColor))
+        .toBe(expectedDim);
+});
+
+test('should still shift an un-toned banner background on hover', async ({ mount }) => {
+    const wrapper = await mount(
+        <RouterProvider navigate={() => {}} useHref={(path) => path}>
+            <Card.Root data-test-id={CARD_TEST_ID} href="/page" aria-label="Card">
+                <Card.Banner data-test-id="banner">
+                    <Card.BannerIcon>
+                        <svg />
+                    </Card.BannerIcon>
+                </Card.Banner>
+            </Card.Root>
+        </RouterProvider>,
+    );
+    const banner = wrapper.getByTestId('banner');
+    const expectedHover = await resolveToken(banner, 'color', '--color-surface-hover');
+
+    await wrapper.getByTestId(CARD_TEST_ID).hover();
+
+    // Backward-compatibility guard: without `tone`, the legacy hover shift remains.
+    // Poll past the banner's color transition before asserting the settled value.
+    await expect
+        .poll(() => banner.evaluate((element) => getComputedStyle(element).backgroundColor))
+        .toBe(expectedHover);
 });

--- a/packages/components/src/components/Card/__tests__/Card.spec.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.spec.tsx
@@ -357,6 +357,19 @@ describe('Card Component', () => {
         expect(image.dataset.fit).toBe('contain');
     });
 
+    it('should merge a forwarded className onto the root element', () => {
+        render(
+            <Card.Root data-test-id={CARD_TEST_ID} className="group custom-class">
+                <Card.Title>{CARD_TITLE_TEXT}</Card.Title>
+            </Card.Root>,
+        );
+        const root = screen.getByTestId(CARD_TEST_ID);
+        expect(root).toHaveClass('group');
+        expect(root).toHaveClass('custom-class');
+        // Internal styles are preserved alongside the forwarded class.
+        expect(root.className.split(' ').length).toBeGreaterThan(2);
+    });
+
     it('should not set a data-tone on the banner by default', () => {
         render(
             <Card.Root>

--- a/packages/components/src/components/Card/__tests__/Card.spec.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.spec.tsx
@@ -357,6 +357,22 @@ describe('Card Component', () => {
         expect(image.dataset.fit).toBe('contain');
     });
 
+    it('should forward arbitrary data-* attributes on Card.Action', () => {
+        render(
+            <Card.Root>
+                <Card.Action data-test-id="action" data-intercom-tour-selector="set-action-button">
+                    <Card.ActionButton aria-label="Settings">
+                        <svg />
+                    </Card.ActionButton>
+                </Card.Action>
+            </Card.Root>,
+        );
+        expect(screen.getByTestId('action')).toHaveAttribute(
+            'data-intercom-tour-selector',
+            'set-action-button',
+        );
+    });
+
     it('should merge a forwarded className onto the root element', () => {
         render(
             <Card.Root data-test-id={CARD_TEST_ID} className="group custom-class">

--- a/packages/components/src/components/Card/__tests__/Card.spec.tsx
+++ b/packages/components/src/components/Card/__tests__/Card.spec.tsx
@@ -331,6 +331,58 @@ describe('Card Component', () => {
         expect(navigateStub).not.toHaveBeenCalled();
     });
 
+    it('should default the banner image to no padding and cover fit', () => {
+        render(
+            <Card.Root>
+                <Card.Banner>
+                    <Card.BannerImage data-test-id="img" src="/a.png" alt="A" />
+                </Card.Banner>
+            </Card.Root>,
+        );
+        const image = screen.getByTestId('img');
+        expect(image.dataset.padding).toBe('none');
+        expect(image.dataset.fit).toBe('cover');
+    });
+
+    it('should expose the padding and fit on the banner image as data attributes', () => {
+        render(
+            <Card.Root>
+                <Card.Banner>
+                    <Card.BannerImage data-test-id="img" src="/a.png" alt="A" fit="contain" padding="medium" />
+                </Card.Banner>
+            </Card.Root>,
+        );
+        const image = screen.getByTestId('img');
+        expect(image.dataset.padding).toBe('medium');
+        expect(image.dataset.fit).toBe('contain');
+    });
+
+    it('should not set a data-tone on the banner by default', () => {
+        render(
+            <Card.Root>
+                <Card.Banner data-test-id="banner">
+                    <Card.BannerIcon>
+                        <svg />
+                    </Card.BannerIcon>
+                </Card.Banner>
+            </Card.Root>,
+        );
+        expect(screen.getByTestId('banner').dataset.tone).toBeUndefined();
+    });
+
+    it('should expose the banner tone as a data attribute when set', () => {
+        render(
+            <Card.Root>
+                <Card.Banner data-test-id="banner" tone="inverted">
+                    <Card.BannerIcon>
+                        <svg />
+                    </Card.BannerIcon>
+                </Card.Banner>
+            </Card.Root>,
+        );
+        expect(screen.getByTestId('banner').dataset.tone).toBe('inverted');
+    });
+
     it('should allow tabbing through interactive elements', async () => {
         const handleSelect = vi.fn();
         renderWithRouter(

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -207,10 +207,6 @@
         background-color: var(--color-surface-dim);
     }
 
-    &[data-tone='active'] {
-        background-color: var(--color-surface-active);
-    }
-
     &[data-tone='inverted'] {
         background-color: var(--color-primary-default);
     }

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -190,13 +190,29 @@
         @include border-overlay($z-index: 1);
     }
 
-    .root[data-interactive='true']:hover &:has(> .bannerIcon),
-    .root[data-interactive='true']:has([data-state='open']) &:has(> .bannerIcon) {
+    // Implicit hover/active shift when a BannerIcon is nested. Skipped once a
+    // `tone` is set (data-tone present), so consumers can pin the background.
+    .root[data-interactive='true']:hover &:not([data-tone]):has(> .bannerIcon),
+    .root[data-interactive='true']:has([data-state='open']) &:not([data-tone]):has(> .bannerIcon) {
         background-color: var(--color-surface-hover);
     }
 
-    .root[data-interactive='true']:active &:has(> .bannerIcon) {
+    .root[data-interactive='true']:active &:not([data-tone]):has(> .bannerIcon) {
         background-color: var(--color-surface-active);
+    }
+
+    // Explicit background tones. These pin the background and (for `inverted`)
+    // flip the nested icon color — see the .bannerIcon rules below.
+    &[data-tone='dim'] {
+        background-color: var(--color-surface-dim);
+    }
+
+    &[data-tone='active'] {
+        background-color: var(--color-surface-active);
+    }
+
+    &[data-tone='inverted'] {
+        background-color: var(--color-primary-default);
     }
 
     &[data-size='small'] {
@@ -212,6 +228,7 @@
     flex: 1;
     min-width: 0;
     display: block;
+    box-sizing: border-box;
 
     & + & {
         border-left: 1px solid var(--color-line-subtle);
@@ -223,6 +240,21 @@
 
     &[data-fit='contain'] {
         object-fit: contain;
+    }
+
+    // Inner padding tokens. Mapped by value to the design spec
+    // (small 12px, medium 24px, large 32px), not by matching spacing-token names
+    // (--spacing-medium is 16px). Pairs best with data-fit='contain'.
+    &[data-padding='small'] {
+        padding: var(--spacing-small);
+    }
+
+    &[data-padding='medium'] {
+        padding: var(--spacing-large);
+    }
+
+    &[data-padding='large'] {
+        padding: var(--spacing-x-large);
     }
 }
 
@@ -243,6 +275,14 @@
     .root[data-interactive='true']:hover &,
     .root[data-interactive='true']:has([data-state='open']) & {
         color: var(--color-primary-default);
+    }
+
+    // Inverted banner tone forces a white icon on the dark background, winning
+    // over the hover and semantic-variant colors below.
+    .banner[data-tone='inverted'] &,
+    .root[data-interactive='true']:hover .banner[data-tone='inverted'] &,
+    .root[data-interactive='true']:has([data-state='open']) .banner[data-tone='inverted'] & {
+        color: var(--color-primary-on-primary);
     }
 
     &[data-variant='primary'] {


### PR DESCRIPTION
## Summary

Closes API gaps in the `Card.*` primitives surfaced while web-app rebuilds its library asset/folder cards on Fondue. Five backward-compatible additions across `Card.Banner`, `Card.BannerImage`, `Card.Root`, and `Card.Action` — no breaking changes; every new prop defaults to today's behavior.

## 🎨 Design
[Figma](https://www.figma.com/design/vYLXkUhWGHIpEftV1zTpqI/Patterns-v1.0?node-id=7210-22163&t=iG9yJalGVwFrMeSR-11)

## What changed

| Primitive | Change |
|---|---|
| **`Card.BannerImage`** | New `padding` prop (`none` \| `small` \| `medium` \| `large`; `none` by default). Applies inner padding so logo/icon previews get breathing room; pairs with `fit="contain"`. |
| **`Card.Banner`** | New `tone` prop (`dim` \| `inverted`). `inverted` = dark drop-target state (near-black bg + white icon); `dim` pins `surface-dim` and opts out of the implicit hover/active shift. Unset = previous behavior. |
| **`Card.Root`** | Forwards `className` (merged after internal styles) — enables Tailwind `group` / `group-hover:` without an extra wrapper. |
| **`Card.Action`** | Spreads arbitrary `data-*` (and other unknown) props onto the element — e.g. an Intercom/analytics selector — no wrapper needed. |

## Design decisions & trade-offs

- **Dark state lives on `Card.Banner`, not `Card.BannerIcon`.** Background is a banner concern, so a single `tone="inverted"` sets the dark background *and* auto-flips the nested icon to `on-primary` (white). This also resolves the "don't auto-change background" friction: setting any `tone` pins the background and disables the implicit `:has(> .bannerIcon)` hover shift.
- **Padding tokens mapped by value, not name.** `--spacing-medium` is 16px, but the spec wants `medium = 24px`, so `small/medium/large` → `--spacing-small`/`--spacing-large`/`--spacing-x-large` (12/24/32px). Documented in the SCSS.
