### PR TITLE
fix(Tooltip): close when the pointer enters an iframe

### DIFF
--- a/.changeset/tooltip-iframe-stuck.md
+++ b/.changeset/tooltip-iframe-stuck.md
@@ -1,0 +1,11 @@
+---
+'@frontify/fondue-components': patch
+---
+
+fix(Tooltip): close when the pointer enters an iframe
+
+The tooltip could get stuck open when moving the pointer from the trigger or
+its content into an iframe (e.g. a platform app), because the parent document
+stops receiving pointer events and Radix never fires the close. The tooltip now
+closes when the pointer enters an iframe or when an iframe gains focus, working
+around [radix-ui/primitives#3394](https://github.com/radix-ui/primitives/issues/3394).

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import * as RadixTooltip from '@radix-ui/react-tooltip';
-import { forwardRef, type ForwardedRef, type ReactElement, type ReactNode } from 'react';
+import { forwardRef, useEffect, type ForwardedRef, type ReactElement, type ReactNode } from 'react';
+
+import { useControllableState } from '#/hooks/useControllableState';
 
 import { ThemeProvider, useFondueTheme } from '../ThemeProvider/ThemeProvider';
 
@@ -25,9 +27,47 @@ export type TooltipRootProps = {
 };
 
 export const TooltipRoot = ({ children, enterDelay = 700, open, onOpenChange }: TooltipRootProps) => {
+    const [isOpen, setIsOpen] = useControllableState({
+        prop: open,
+        defaultProp: false,
+        onChange: onOpenChange,
+    });
+
+    // Workaround for https://github.com/radix-ui/primitives/issues/3394:
+    // When the pointer moves from the trigger or tooltip content into an iframe (e.g. a platform
+    // app), the parent document stops receiving pointer events, so Radix never closes the tooltip
+    // and it stays "stuck". We detect the pointer entering an iframe (the last event the parent
+    // document receives is a `pointerover` targeting the iframe element) and the iframe gaining
+    // focus (which blurs the parent window) and close the tooltip ourselves in those cases.
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handlePointerOver = (event: PointerEvent) => {
+            if (event.target instanceof HTMLIFrameElement) {
+                setIsOpen(false);
+            }
+        };
+
+        const handleWindowBlur = () => {
+            if (document.activeElement instanceof HTMLIFrameElement) {
+                setIsOpen(false);
+            }
+        };
+
+        document.addEventListener('pointerover', handlePointerOver);
+        window.addEventListener('blur', handleWindowBlur);
+
+        return () => {
+            document.removeEventListener('pointerover', handlePointerOver);
+            window.removeEventListener('blur', handleWindowBlur);
+        };
+    }, [isOpen, setIsOpen]);
+
     return (
         <RadixTooltip.Provider>
-            <RadixTooltip.Root delayDuration={enterDelay} open={open} onOpenChange={onOpenChange}>
+            <RadixTooltip.Root delayDuration={enterDelay} open={isOpen} onOpenChange={setIsOpen}>
                 {children}
             </RadixTooltip.Root>
         </RadixTooltip.Provider>

--- a/packages/components/src/components/Tooltip/__tests__/Tooltip.ct.tsx
+++ b/packages/components/src/components/Tooltip/__tests__/Tooltip.ct.tsx
@@ -373,3 +373,28 @@ test('should submit form when clicking TooltipTrigger with a Button type submit 
     await trigger.click();
     expect(onSubmit.callCount).toBe(1);
 });
+
+test('should close when the pointer enters an iframe', async ({ mount, page }) => {
+    const component = await mount(
+        <Tooltip.Root enterDelay={0}>
+            <Tooltip.Trigger data-test-id={TOOLTIP_TRIGGER_TEST_ID}>
+                <Button>Hover over me!</Button>
+            </Tooltip.Trigger>
+            <Tooltip.Content data-test-id={TOOLTIP_CONTENT_TEST_ID}>{TOOLTIP_TEXT}</Tooltip.Content>
+        </Tooltip.Root>,
+    );
+    const tooltipContent = page.getByTestId(TOOLTIP_CONTENT_TEST_ID);
+    await expect(component).toBeVisible();
+    await component.getByTestId(TOOLTIP_TRIGGER_TEST_ID).hover();
+    await expect(tooltipContent).toBeVisible();
+
+    // Simulate the pointer entering an iframe: the parent document receives a `pointerover`
+    // event targeting the iframe element and then stops receiving further pointer events.
+    await page.evaluate(() => {
+        const iframe = document.createElement('iframe');
+        document.body.append(iframe);
+        iframe.dispatchEvent(new PointerEvent('pointerover', { bubbles: true }));
+    });
+
+    await expect(tooltipContent).toBeHidden();
+});


### PR DESCRIPTION
The tooltip could get stuck open when moving the pointer from the trigger or its content into an iframe (e.g. a platform app). Once the pointer is over the iframe, the parent document stops receiving pointer events, so Radix never fires the close and the tooltip lingers. This is an upstream Radix bug ([radix-ui/primitives#3394](https://github.com/radix-ui/primitives/issues/3394)).

`Tooltip.Root` now manages its open state via `useControllableState` and closes the tooltip when it detects the pointer entering an iframe (`pointerover` targeting an `<iframe>` — the last event the parent document receives) or an iframe gaining focus (which blurs the parent window). The listeners are only attached while the tooltip is open.

Added a component test covering the pointer-enters-iframe case.