### PR TITLE
feat(Table): add 'hidden' prop to table header

### DIFF
--- a/.changeset/all-weeks-grin.md
+++ b/.changeset/all-weeks-grin.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat(Table): add 'hidden' prop to table header

--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -188,6 +188,30 @@ export const Basic: Story = {
     ),
 };
 
+export const HiddenHeader: Story = {
+    name: 'Hidden header (accessible)',
+    render: ({ ...args }) => (
+        <Table.Root {...args}>
+            <Table.Header hidden>
+                <Table.Row>
+                    <Table.HeaderCell>Name</Table.HeaderCell>
+                    <Table.HeaderCell>Role</Table.HeaderCell>
+                    <Table.HeaderCell>Last Seen</Table.HeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {TABLE_DATA.map((user) => (
+                    <Table.Row key={user.id}>
+                        <Table.RowCell>{user.name}</Table.RowCell>
+                        <Table.RowCell>{user.role}</Table.RowCell>
+                        <Table.RowCell>{user.lastSeen}</Table.RowCell>
+                    </Table.Row>
+                ))}
+            </Table.Body>
+        </Table.Root>
+    ),
+};
+
 export const SmallText: Story = {
     render: ({ ...args }) => (
         <Table.Root {...args} fontSize="small">

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -165,15 +165,30 @@ type TableHeaderProps = {
      * @default false
      */
     sticky?: boolean;
+    /**
+     * Whether the header should be visually hidden while remaining accessible to screen readers.
+     *
+     * Unlike not rendering the header (or using `display: none`), the header stays in the
+     * accessibility tree, so screen readers still announce the column headers for each cell.
+     * @default false
+     */
+    hidden?: boolean;
     children: ReactNode;
     'aria-label'?: string;
     'aria-busy'?: boolean;
 };
 
 export const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
-    ({ sticky = false, children, 'aria-label': ariaLabel, 'aria-busy': ariaBusy }, ref) => {
+    ({ sticky = false, hidden = false, children, 'aria-label': ariaLabel, 'aria-busy': ariaBusy }, ref) => {
         return (
-            <thead ref={ref} className={styles.header} data-sticky={sticky} aria-label={ariaLabel} aria-busy={ariaBusy}>
+            <thead
+                ref={ref}
+                className={styles.header}
+                data-sticky={sticky}
+                data-hidden={hidden}
+                aria-label={ariaLabel}
+                aria-busy={ariaBusy}
+            >
                 {children}
             </thead>
         );

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -127,6 +127,25 @@
         z-index: 2;
         background-color: var(--table-sticky-background-color, var(--color-surface-default));
     }
+
+    // Visually hide the header while keeping it in the accessibility tree so screen
+    // readers still announce the column headers. Avoids `display: none` / `visibility:
+    // hidden`, which would remove the header from the accessibility tree.
+    &[data-hidden='true'] {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        // `clip-path` is the modern technique; `clip` is kept as a fallback for older engines.
+        // Non-zero (1px) dimensions are intentional: zero dimensions with `overflow: hidden`
+        // can drop the element from the accessibility tree.
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+        border: 0;
+    }
 }
 
 .headerCell {
@@ -259,6 +278,12 @@
     &:last-child {
         padding-inline-end: sizeToken.get(2);
     }
+}
+
+// When the header is visually hidden it contributes no top border, leaving the table
+// looking like it floats. Restore the top line on the first body row's cells.
+.table:not([data-no-border='true']):has(.header[data-hidden='true']) .body .row:first-child .rowCell {
+    border-top: 1px solid var(--color-line-subtle);
 }
 
 .headerCell,

--- a/packages/components/src/components/Table/styles/table.module.scss
+++ b/packages/components/src/components/Table/styles/table.module.scss
@@ -128,9 +128,8 @@
         background-color: var(--table-sticky-background-color, var(--color-surface-default));
     }
 
-    // Visually hide the header while keeping it in the accessibility tree so screen
-    // readers still announce the column headers. Avoids `display: none` / `visibility:
-    // hidden`, which would remove the header from the accessibility tree.
+    // Visually hide the header while keeping it in the accessibility tree
+    // so screen readers still announce the column headers.
     &[data-hidden='true'] {
         position: absolute;
         width: 1px;
@@ -138,9 +137,6 @@
         padding: 0;
         margin: -1px;
         overflow: hidden;
-        // `clip-path` is the modern technique; `clip` is kept as a fallback for older engines.
-        // Non-zero (1px) dimensions are intentional: zero dimensions with `overflow: hidden`
-        // can drop the element from the accessibility tree.
         clip: rect(0, 0, 0, 0);
         clip-path: inset(50%);
         white-space: nowrap;


### PR DESCRIPTION
This allows to hide the header fields in a way it does not break accessibility.