### PR TITLE
refactor(Textarea): replace resize handle with a custom element and adjust clearble icon position

### DIFF
--- a/.changeset/chubby-queens-invite.md
+++ b/.changeset/chubby-queens-invite.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+refactor(Textarea): replace resize handle with a custom element and adjust clearble icon position

--- a/packages/components/src/components/Textarea/Textarea.tsx
+++ b/packages/components/src/components/Textarea/Textarea.tsx
@@ -11,6 +11,7 @@ import {
     type FocusEventHandler,
     type ForwardedRef,
     type KeyboardEventHandler,
+    type PointerEventHandler,
     type ReactElement,
     type ReactNode,
     type SyntheticEvent,
@@ -153,6 +154,9 @@ export const TextareaRoot = (
 ) => {
     const ref = useRef<HTMLTextAreaElement>(null);
     const wasClicked = useRef(false);
+    const resizeState = useRef<{ startY: number; startHeight: number; minHeight: number; pointerId: number } | null>(
+        null,
+    );
 
     useSyncRefs<HTMLTextAreaElement>(ref, forwardedRef);
 
@@ -162,6 +166,44 @@ export const TextareaRoot = (
 
     const clear = () => {
         setValue('');
+    };
+
+    const handleResizeStart: PointerEventHandler<HTMLDivElement> = (event) => {
+        const textarea = ref.current;
+        if (!textarea) {
+            return;
+        }
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+
+        const computed = getComputedStyle(textarea);
+        const lineHeight = parseFloat(computed.lineHeight) || 0;
+        const paddingY = parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+        const borderY = parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
+
+        resizeState.current = {
+            startY: event.clientY,
+            startHeight: textarea.offsetHeight,
+            minHeight: lineHeight * rows + paddingY + borderY,
+            pointerId: event.pointerId,
+        };
+    };
+
+    const handleResizeMove: PointerEventHandler<HTMLDivElement> = (event) => {
+        const textarea = ref.current;
+        const state = resizeState.current;
+        if (!textarea || !state) {
+            return;
+        }
+        const newHeight = Math.max(state.minHeight, state.startHeight + event.clientY - state.startY);
+        textarea.style.height = `${newHeight}px`;
+    };
+
+    const handleResizeEnd: PointerEventHandler<HTMLDivElement> = (event) => {
+        if (resizeState.current) {
+            event.currentTarget.releasePointerCapture?.(resizeState.current.pointerId);
+            resizeState.current = null;
+        }
     };
 
     const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
@@ -261,6 +303,16 @@ export const TextareaRoot = (
                         </button>
                     )}
                 </div>
+            )}
+            {resizable && !disabled && (
+                <div
+                    className={styles.resizeHandle}
+                    data-test-id={`${dataTestId}-resize-handle`}
+                    onPointerDown={handleResizeStart}
+                    onPointerMove={handleResizeMove}
+                    onPointerUp={handleResizeEnd}
+                    aria-hidden="true"
+                />
             )}
             {children}
         </div>

--- a/packages/components/src/components/Textarea/Textarea.tsx
+++ b/packages/components/src/components/Textarea/Textarea.tsx
@@ -299,7 +299,7 @@ export const TextareaRoot = (
                     ))}
                     {clearable && (
                         <button className={styles.toolsButton} onClick={clear} disabled={disabled || readOnly}>
-                            <IconCross size={20} fill="currentColor" />
+                            <IconCross size={16} fill="currentColor" />
                         </button>
                     )}
                 </div>

--- a/packages/components/src/components/Textarea/__tests__/Textarea.ct.tsx
+++ b/packages/components/src/components/Textarea/__tests__/Textarea.ct.tsx
@@ -140,7 +140,8 @@ test('dragging the resize handle changes the textarea height', async ({ mount, p
     const textarea = wrapper.getByTestId(TEXTAREA_TEST_ID).locator('textarea');
     const handle = wrapper.getByTestId(`${TEXTAREA_TEST_ID}-resize-handle`);
 
-    const startHeight = (await textarea.boundingBox())?.height ?? 0;
+    const startBox = await textarea.boundingBox();
+    const startHeight = startBox?.height ?? 0;
     const handleBox = await handle.boundingBox();
     if (!handleBox) {
         throw new Error('resize handle not found');
@@ -151,7 +152,8 @@ test('dragging the resize handle changes the textarea height', async ({ mount, p
     await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2 + 80, { steps: 5 });
     await page.mouse.up();
 
-    const endHeight = (await textarea.boundingBox())?.height ?? 0;
+    const endBox = await textarea.boundingBox();
+    const endHeight = endBox?.height ?? 0;
     expect(endHeight).toBeGreaterThan(startHeight);
 });
 

--- a/packages/components/src/components/Textarea/__tests__/Textarea.ct.tsx
+++ b/packages/components/src/components/Textarea/__tests__/Textarea.ct.tsx
@@ -120,6 +120,41 @@ test('autosize functionality', async ({ mount }) => {
     await expect(component).toHaveAttribute('data-autosize', 'true');
 });
 
+test('render resize handle when resizable', async ({ mount }) => {
+    const wrapper = await mount(<Textarea data-test-id={TEXTAREA_TEST_ID} resizable />);
+    await expect(wrapper.getByTestId(`${TEXTAREA_TEST_ID}-resize-handle`)).toBeVisible();
+});
+
+test('no resize handle when not resizable', async ({ mount }) => {
+    const wrapper = await mount(<Textarea data-test-id={TEXTAREA_TEST_ID} />);
+    await expect(wrapper.getByTestId(`${TEXTAREA_TEST_ID}-resize-handle`)).toHaveCount(0);
+});
+
+test('no resize handle when disabled', async ({ mount }) => {
+    const wrapper = await mount(<Textarea data-test-id={TEXTAREA_TEST_ID} resizable disabled />);
+    await expect(wrapper.getByTestId(`${TEXTAREA_TEST_ID}-resize-handle`)).toHaveCount(0);
+});
+
+test('dragging the resize handle changes the textarea height', async ({ mount, page }) => {
+    const wrapper = await mount(<Textarea data-test-id={TEXTAREA_TEST_ID} resizable />);
+    const textarea = wrapper.getByTestId(TEXTAREA_TEST_ID).locator('textarea');
+    const handle = wrapper.getByTestId(`${TEXTAREA_TEST_ID}-resize-handle`);
+
+    const startHeight = (await textarea.boundingBox())?.height ?? 0;
+    const handleBox = await handle.boundingBox();
+    if (!handleBox) {
+        throw new Error('resize handle not found');
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2 + 80, { steps: 5 });
+    await page.mouse.up();
+
+    const endHeight = (await textarea.boundingBox())?.height ?? 0;
+    expect(endHeight).toBeGreaterThan(startHeight);
+});
+
 test('focus management', async ({ mount }) => {
     const onFocus = sinon.spy();
     const wrapper = await mount(<Textarea data-test-id={TEXTAREA_TEST_ID} focusOnMount onFocus={onFocus} />);

--- a/packages/components/src/components/Textarea/styles/textarea.module.scss
+++ b/packages/components/src/components/Textarea/styles/textarea.module.scss
@@ -59,6 +59,24 @@
     &[data-disabled='true'] {
         cursor: not-allowed;
     }
+
+}
+
+.resizeHandle {
+    position: absolute;
+    right: 2px;
+    bottom: 2px;
+    width: 12px;
+    height: 12px;
+    cursor: ns-resize;
+    touch-action: none;
+    background-color: var(--color-line-mid);
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Cline x1='9' y1='1' x2='1' y2='9' stroke='black' stroke-width='1'/%3E%3Cline x1='9' y1='5' x2='5' y2='9' stroke='black' stroke-width='1'/%3E%3C/svg%3E");
+    mask-repeat: no-repeat;
+    mask-position: bottom right;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Cline x1='9' y1='1' x2='1' y2='9' stroke='black' stroke-width='1'/%3E%3Cline x1='9' y1='5' x2='5' y2='9' stroke='black' stroke-width='1'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: bottom right;
 }
 
 .textareaWrapper {
@@ -103,13 +121,11 @@
     padding-top: sizeToken.get(2);
     padding-bottom: sizeToken.get(2);
     border-radius: calc(var(--border-radius-medium) - var(--border-width-default));
+    box-sizing: border-box;
+    // Always `none`: the resize interaction is driven by a custom handle
     resize: none;
     outline: 2px solid transparent;
     outline-offset: 2px;
-
-    [data-resizable='true'] & {
-        resize: vertical;
-    }
 
     [data-clearable='true'] & {
         padding-right: sizeToken.get(9);

--- a/packages/components/src/components/Textarea/styles/textarea.module.scss
+++ b/packages/components/src/components/Textarea/styles/textarea.module.scss
@@ -99,8 +99,8 @@
     content: attr(data-replicated-value) " ";
     white-space: pre-wrap;
     visibility: hidden;
-    padding-left: sizeToken.get(3);
-    padding-right: sizeToken.get(3);
+    padding-inline-start: sizeToken.get(3);
+    padding-inline-end: sizeToken.get(3);
     padding-top: sizeToken.get(2);
     padding-bottom: sizeToken.get(2);
     font: inherit;
@@ -116,8 +116,8 @@
     display: flex;
     align-items: center;
     text-align: inherit;
-    padding-left: sizeToken.get(3);
-    padding-right: sizeToken.get(3);
+    padding-inline-start: sizeToken.get(3);
+    padding-inline-end: sizeToken.get(3);
     padding-top: sizeToken.get(2);
     padding-bottom: sizeToken.get(2);
     border-radius: calc(var(--border-radius-medium) - var(--border-width-default));
@@ -128,7 +128,7 @@
     outline-offset: 2px;
 
     [data-clearable='true'] & {
-        padding-right: sizeToken.get(9);
+        padding-inline-end: sizeToken.get(9);
     }
 
     &::placeholder {
@@ -140,20 +140,20 @@
         outline-offset: 2px;
     }
 
-    // Remove border-radius and padding on the left if there's a left-side decorator or slot
+    // Remove border-radius and padding on the inline-start if there's a start-side decorator or slot
     [data-has-decorator="true"] &,
     .root:has(.slot:not([data-name='right'])) & {
-        padding-left: 0;
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
+        padding-inline-start: 0;
+        border-start-start-radius: 0px;
+        border-end-start-radius: 0px;
     }
 
-    // Remove border-radius and padding on the right if there's a right-side slot or tools
+    // Remove border-radius and padding on the inline-end if there's an end-side slot or tools
     [data-has-tools="true"] &,
     .root:has(.slot[data-name='right']) & {
-        padding-right: 0;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        padding-inline-end: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     // Readonly styles
@@ -191,11 +191,12 @@
 }
 
 .tools:not(:empty) {
-    padding-right: sizeToken.get(2);
-    padding-left: sizeToken.get(2);
+    padding-inline-end: sizeToken.get(1);
+    padding-inline-start: sizeToken.get(2);
+    padding-top: sizeToken.get(2);
     display: flex;
     gap: sizeToken.get(1);
-    align-items: center;
+    align-items: flex-start;
     order: 1;
 
     >* {
@@ -230,6 +231,7 @@
 .toolsButton {
     background-color: var(--color-surface-default);
     border-radius: var(--border-radius-medium);
+    color: var(--color-secondary-default);
 
     & {
         @include focusStyle.focus-outline;


### PR DESCRIPTION
Before:
<img width="485" height="142" alt="Screenshot 2026-07-01 at 08 59 24" src="https://github.com/user-attachments/assets/2166d118-32c2-4c32-87ec-a07b131bfb2f" />

Now:
<img width="328" height="110" alt="Screenshot 2026-07-01 at 08 58 02" src="https://github.com/user-attachments/assets/cd1a48bf-a615-4430-a32c-ef70da1cf292" />
