### PR TITLE
feat(Tree): change the default behavior of folder selection with disabled items

### DIFF
--- a/.changeset/four-spiders-wish.md
+++ b/.changeset/four-spiders-wish.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat(Tree): change the default behavior of folder selection with disabled items

--- a/packages/components/src/components/Tree/Tree.stories.tsx
+++ b/packages/components/src/components/Tree/Tree.stories.tsx
@@ -1130,10 +1130,12 @@ export const DisabledRows: Story = {
                 story:
                     '`isDisabled` freezes a row at its prop-driven state: its checkbox cannot be toggled — ' +
                     'not even by checking an ancestor folder — it cannot be dragged or take the selection, ' +
-                    'and drops into a disabled folder are rejected. The frozen state still counts toward ' +
-                    "folder checkboxes, so a folder holding a disabled-unchecked leaf caps at 'indeterminate'. " +
-                    'Disabled folders stay expandable, and only their own row is frozen — their children ' +
-                    'remain interactive unless disabled themselves.',
+                    'and drops into a disabled folder are rejected. A folder derives its checkbox from its ' +
+                    'selectable descendants only, so a disabled leaf never blocks it: the folder reads ' +
+                    "'checked' once every enabled leaf is checked and its checkbox can always be toggled back " +
+                    'off. Set `countDisabledInFolderState` to keep disabled descendants counting instead, so ' +
+                    "such a folder caps at 'indeterminate'. Disabled folders stay expandable, and only their " +
+                    'own row is frozen, so their children remain interactive unless disabled themselves.',
             },
         },
     },

--- a/packages/components/src/components/Tree/components/TreeRoot.tsx
+++ b/packages/components/src/components/Tree/components/TreeRoot.tsx
@@ -37,18 +37,41 @@ export type TreeRootProps = {
      */
     reorderable?: boolean;
     /**
-     * Gates drops onto the top level — same semantics as `accepts` on `<Tree.Folder>`.
+     * Controls whether disabled descendants count toward a folder's checkbox state. By
+     * default they are excluded, so a folder reads `'checked'` once all of its selectable
+     * descendants are checked and its checkbox can always be toggled back off. Set this to
+     * keep disabled descendants counting, so a folder with an unchecked disabled
+     * descendant stays at `'indeterminate'` and cannot be fully checked.
+     * @default false
+     */
+    countDisabledInFolderState?: boolean;
+    /**
+     * Gates drops onto the top level, same semantics as `accepts` on `<Tree.Folder>`.
      * Returning `false` suppresses the drop indicator and prevents `onMove`/`onChange`.
      * Omitted = the root accepts anything.
      */
     accepts?: (items: TreeDropCandidate[]) => boolean;
 };
 
-export const TreeRoot = ({ children, onChange, multiSelect = false, reorderable = false, accepts }: TreeRootProps) => {
+export const TreeRoot = ({
+    children,
+    onChange,
+    multiSelect = false,
+    reorderable = false,
+    countDisabledInFolderState = false,
+    accepts,
+}: TreeRootProps) => {
     const { t } = useTranslation();
     const rowHintId = useId();
     const { items, parentIsLoading: rootIsLoading } = useMemo(() => parseChildren(children), [children]);
-    const tree = useTreeController({ items, onChange, multiSelect, reorderable, rootAccepts: accepts });
+    const tree = useTreeController({
+        items,
+        onChange,
+        multiSelect,
+        reorderable,
+        countDisabledInFolderState,
+        rootAccepts: accepts,
+    });
 
     const visibleItems = tree.getItems();
     const loadingInsertions = useMemo(
@@ -59,8 +82,11 @@ export const TreeRoot = ({ children, onChange, multiSelect = false, reorderable 
     // Shared derivation (not headless-tree's leaf-only `getCheckedState`) so leafless
     // folders and their ancestors render the same state that `onChange` reports.
     const checkedStates = useMemo(
-        () => (multiSelect ? computeCheckedStates(items, new Set(getCheckedUnitIds(items))) : undefined),
-        [multiSelect, items],
+        () =>
+            multiSelect
+                ? computeCheckedStates(items, new Set(getCheckedUnitIds(items)), { countDisabledInFolderState })
+                : undefined,
+        [multiSelect, items, countDisabledInFolderState],
     );
 
     const rowHint = [multiSelect && t('Tree_checkboxHint'), reorderable && t('Tree_reorderHint')]

--- a/packages/components/src/components/Tree/hooks/useTreeController.spec.tsx
+++ b/packages/components/src/components/Tree/hooks/useTreeController.spec.tsx
@@ -322,8 +322,9 @@ describe('useTreeController disabled rows', () => {
         const folder = last.find((node) => node.id === 'folder');
         expect(folder?.children?.find((node) => node.id === 'a')?.isSelected).toBe(false);
         expect(folder?.children?.find((node) => node.id === 'b')?.isSelected).toBe(true);
-        // The frozen leaf still counts toward the folder's derived state.
-        expect(folder?.isSelected).toBe('indeterminate');
+        // The disabled leaf is excluded from the folder's totals, so with its only
+        // selectable child checked the folder reads fully checked.
+        expect(folder?.isSelected).toBe(true);
         expect(onSelectDisabled).not.toHaveBeenCalled();
     });
 
@@ -353,7 +354,7 @@ describe('useTreeController disabled rows', () => {
         const folder = last.find((node) => node.id === 'folder');
         expect(folder?.children?.find((node) => node.id === 'a')?.isSelected).toBe(true);
         expect(folder?.children?.find((node) => node.id === 'b')?.isSelected).toBe(false);
-        expect(folder?.isSelected).toBe('indeterminate');
+        expect(folder?.isSelected).toBe(false);
         expect(onSelectDisabled).not.toHaveBeenCalled();
     });
 
@@ -545,6 +546,6 @@ describe('useTreeController leafless folders', () => {
 
         expect(onSelectDisabled).not.toHaveBeenCalled();
         const last = onChange.mock.calls[onChange.mock.calls.length - 1]?.[0] ?? [];
-        expect(last.find((node) => node.id === 'group')?.isSelected).toBe('indeterminate');
+        expect(last.find((node) => node.id === 'group')?.isSelected).toBe(true);
     });
 });

--- a/packages/components/src/components/Tree/hooks/useTreeController.ts
+++ b/packages/components/src/components/Tree/hooks/useTreeController.ts
@@ -28,6 +28,7 @@ type UseTreeControllerOptions = {
     onChange?: (state: TreeChangeState) => void;
     multiSelect?: boolean;
     reorderable?: boolean;
+    countDisabledInFolderState?: boolean;
     rootAccepts?: (items: TreeDropCandidate[]) => boolean;
 };
 
@@ -63,6 +64,7 @@ export const useTreeController = ({
     onChange,
     multiSelect = false,
     reorderable = false,
+    countDisabledInFolderState = false,
     rootAccepts,
 }: UseTreeControllerOptions): TreeInstance<TreeItemData> => {
     const itemsWithRoot = useMemo<TreeItemData[]>(
@@ -142,7 +144,7 @@ export const useTreeController = ({
                 sameIds(pendingState.checkedItems, treeState.checkedItems) &&
                 sameIds(pendingState.selectedItems ?? [], treeState.selectedItems ?? []);
             if (!isUnchanged) {
-                onChange?.(buildChangeState(itemsWithRoot, pendingState, ROOT_ID));
+                onChange?.(buildChangeState(itemsWithRoot, pendingState, ROOT_ID, { countDisabledInFolderState }));
             }
         });
     };
@@ -232,13 +234,21 @@ export const useTreeController = ({
         }
         data.onRename?.(nextName);
         const nextItems = itemsWithRoot.map((entry) => (entry.id === data.id ? { ...entry, name: nextName } : entry));
-        onChange?.(buildChangeState(nextItems, pendingState, ROOT_ID));
+        onChange?.(buildChangeState(nextItems, pendingState, ROOT_ID, { countDisabledInFolderState }));
     };
 
     const canDrop = useMemo(() => createCanDrop({ itemsById }), [itemsById]);
     const onDrop = useMemo(
-        () => createDropHandler({ items: itemsWithRoot, itemsById, treeState, rootId: ROOT_ID, onChange }),
-        [itemsWithRoot, itemsById, treeState, onChange],
+        () =>
+            createDropHandler({
+                items: itemsWithRoot,
+                itemsById,
+                treeState,
+                rootId: ROOT_ID,
+                onChange,
+                countDisabledInFolderState,
+            }),
+        [itemsWithRoot, itemsById, treeState, onChange, countDisabledInFolderState],
     );
 
     const tree = useTree<TreeItemData>({

--- a/packages/components/src/components/Tree/utils/buildChangeState.ts
+++ b/packages/components/src/components/Tree/utils/buildChangeState.ts
@@ -2,7 +2,7 @@
 
 import { type TreeChangeState, type TreeItemData, type TreeNodeState } from '../types';
 
-import { computeCheckedStates } from './computeCheckedStates';
+import { computeCheckedStates, type ComputeCheckedStatesOptions } from './computeCheckedStates';
 
 /** Flat state mirror of the headless-tree internal model. */
 export type FlatTreeState = {
@@ -25,11 +25,12 @@ export const buildChangeState = (
     items: readonly TreeItemData[],
     state: FlatTreeState,
     rootId: string,
+    options: ComputeCheckedStatesOptions = {},
 ): TreeChangeState => {
     const byId = new Map(items.map((item) => [item.id, item]));
     const expanded = new Set(state.expandedItems);
     const selected = new Set(state.selectedItems ?? []);
-    const checkedStates = computeCheckedStates(items, new Set(state.checkedItems));
+    const checkedStates = computeCheckedStates(items, new Set(state.checkedItems), options);
 
     const buildNode = (id: string): TreeNodeState | null => {
         const item = byId.get(id);

--- a/packages/components/src/components/Tree/utils/computeCheckedStates.spec.ts
+++ b/packages/components/src/components/Tree/utils/computeCheckedStates.spec.ts
@@ -96,4 +96,63 @@ describe('computeCheckedStates', () => {
         const items = [folder('f', ROOT_ID, ['missing'])];
         expect(computeCheckedStates(items, new Set()).get('f')).toBe(false);
     });
+
+    it('derives folder state from selectable descendants only, ignoring disabled leaves', () => {
+        const items = [
+            folder('f', ROOT_ID, ['a', 'b']),
+            leaf('a', 'f', { isDisabled: true }),
+            leaf('b', 'f'),
+        ];
+        expect(computeCheckedStates(items, new Set(['b'])).get('f')).toBe(true);
+        expect(computeCheckedStates(items, new Set()).get('f')).toBe(false);
+    });
+
+    it('does not let a checked disabled leaf hold a folder at indeterminate', () => {
+        const items = [
+            folder('f', ROOT_ID, ['a', 'b']),
+            leaf('a', 'f', { isDisabled: true, isSelected: true }),
+            leaf('b', 'f'),
+        ];
+        expect(computeCheckedStates(items, new Set(['a'])).get('f')).toBe(false);
+        expect(computeCheckedStates(items, new Set(['a', 'b'])).get('f')).toBe(true);
+    });
+
+    it('reports a disabled leaf with its own frozen membership', () => {
+        const items = [folder('f', ROOT_ID, ['a']), leaf('a', 'f', { isDisabled: true })];
+        const states = computeCheckedStates(items, new Set(['a']));
+        expect(states.get('a')).toBe(true);
+    });
+
+    it('marks a folder whose children are all disabled as unchecked', () => {
+        const items = [
+            folder('f', ROOT_ID, ['a', 'b']),
+            leaf('a', 'f', { isDisabled: true, isSelected: true }),
+            leaf('b', 'f', { isDisabled: true }),
+        ];
+        expect(computeCheckedStates(items, new Set(['a'])).get('f')).toBe(false);
+    });
+
+    describe('with countDisabledInFolderState', () => {
+        it('counts disabled leaves toward the folder, capping it at indeterminate', () => {
+            const items = [
+                folder('f', ROOT_ID, ['a', 'b']),
+                leaf('a', 'f', { isDisabled: true }),
+                leaf('b', 'f'),
+            ];
+            expect(computeCheckedStates(items, new Set(['b']), { countDisabledInFolderState: true }).get('f')).toBe(
+                'indeterminate',
+            );
+        });
+
+        it('reads the folder as checked once the disabled leaf is also checked', () => {
+            const items = [
+                folder('f', ROOT_ID, ['a', 'b']),
+                leaf('a', 'f', { isDisabled: true, isSelected: true }),
+                leaf('b', 'f'),
+            ];
+            expect(computeCheckedStates(items, new Set(['a', 'b']), { countDisabledInFolderState: true }).get('f')).toBe(
+                true,
+            );
+        });
+    });
 });

--- a/packages/components/src/components/Tree/utils/computeCheckedStates.ts
+++ b/packages/components/src/components/Tree/utils/computeCheckedStates.ts
@@ -23,10 +23,25 @@ export const getCheckedUnitIds = (items: readonly TreeItemData[]): string[] =>
  * some. Single source of truth for `TreeRoot`'s rendering and `buildChangeState`'s
  * report, so checkboxes and the `onChange` payload can never disagree (headless-tree's
  * own `getCheckedState` counts only leaves and would render leafless folders unchecked).
+ *
+ * By default disabled units are excluded from their ancestor folders' totals. A frozen
+ * descendant can never be toggled by a cascade, so counting it would trap the folder at
+ * `'indeterminate'` and make its checkbox impossible to switch off. Set
+ * `countDisabledInFolderState` to include them, so the folder reads `'indeterminate'`
+ * while any disabled descendant stays unchecked.
  */
+export type ComputeCheckedStatesOptions = {
+    /**
+     * Count disabled descendants toward a folder's checkbox state. Off by default so a
+     * frozen descendant never traps its ancestor folder at `'indeterminate'`.
+     */
+    countDisabledInFolderState?: boolean;
+};
+
 export const computeCheckedStates = (
     items: readonly TreeItemData[],
     checkedIds: ReadonlySet<string>,
+    { countDisabledInFolderState = false }: ComputeCheckedStatesOptions = {},
 ): Map<string, RowCheckedState> => {
     const byId = new Map(items.map((item) => [item.id, item]));
     const states = new Map<string, RowCheckedState>();
@@ -47,7 +62,10 @@ export const computeCheckedStates = (
         let count: UnitCount;
         if (isCheckableUnit(item)) {
             const isChecked = checkedIds.has(id);
-            count = { units: 1, checkedUnits: isChecked ? 1 : 0 };
+            count =
+                item.isDisabled && !countDisabledInFolderState
+                    ? { units: 0, checkedUnits: 0 }
+                    : { units: 1, checkedUnits: isChecked ? 1 : 0 };
             states.set(id, isChecked);
         } else {
             count = { units: 0, checkedUnits: 0 };

--- a/packages/components/src/components/Tree/utils/createDropHandler.ts
+++ b/packages/components/src/components/Tree/utils/createDropHandler.ts
@@ -13,6 +13,7 @@ type DropHandlerDeps = {
     treeState: FlatTreeState;
     rootId: string;
     onChange?: (state: TreeChangeState) => void;
+    countDisabledInFolderState?: boolean;
 };
 
 /**
@@ -21,7 +22,7 @@ type DropHandlerDeps = {
  * No-op when the target parent is missing (defensive against racy updates).
  */
 export const createDropHandler =
-    ({ items, itemsById, treeState, rootId, onChange }: DropHandlerDeps) =>
+    ({ items, itemsById, treeState, rootId, onChange, countDisabledInFolderState = false }: DropHandlerDeps) =>
     (draggedItems: ItemInstance<TreeItemData>[], target: DragTarget<TreeItemData>): void => {
         const targetParentId = target.item.getId();
         const targetParent = itemsById.get(targetParentId);
@@ -43,5 +44,5 @@ export const createDropHandler =
             }
         }
 
-        onChange?.(buildChangeState(nextItems, treeState, rootId));
+        onChange?.(buildChangeState(nextItems, treeState, rootId, { countDisabledInFolderState }));
     };


### PR DESCRIPTION
In multi-select mode, a folder that contains a disabled (non-selectable) item could get stuck. Selecting the folder would check all of its selectable children, but the folder checkbox would show as partially selected and clicking it again did nothing. There was no way to uncheck the folder from its own row. In the extreme case, where every child was disabled, the folder checkbox did nothing at all.

This change makes a folder's checkbox look only at the items that can actually be selected. Once all of those are checked, the folder shows as fully checked and clicking it clears them again. Disabled items are left untouched throughout, exactly as before.

