### PR TITLE
feat(Tree): allow an indeterminate checkbox on a collapsed, not-yet-loaded folder

### DIFF
--- a/.changeset/big-times-poke.md
+++ b/.changeset/big-times-poke.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat(Tree): allow an indeterminate checkbox on a collapsed, not-yet-loaded folder

--- a/packages/components/src/components/Tree/Tree.stories.tsx
+++ b/packages/components/src/components/Tree/Tree.stories.tsx
@@ -1055,6 +1055,155 @@ export const MultiSelectLazyLoading: Story = {
     },
 };
 
+export const MultiSelectLazyLoadingPartialRestore: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'Restoring a partial selection onto a collapsed, not-yet-loaded folder. Storage says only ' +
+                    '`Page 01` inside the still-collapsed `Documents` folder is selected, so the consumer seeds the ' +
+                    "childless folder with `isSelected='indeterminate'` and its checkbox renders mixed before any " +
+                    'child is fetched. Expanding it loads the children, the consumer carries the stored selection onto ' +
+                    'them and drops the placeholder, and from then on the folder derives the same mixed state from its ' +
+                    'contents (re-collapsing keeps it). The first click on the placeholder folder checks it.',
+            },
+        },
+    },
+    args: {
+        multiSelect: true,
+    },
+    render: (args) => {
+        type LazyNode = { id: string; name: string; isFolder: boolean };
+        type ChildrenState = { status: 'loading' } | { status: 'loaded'; children: LazyNode[] };
+
+        const rootNodes: LazyNode[] = [
+            { id: 'documents', name: 'Documents', isFolder: true },
+            { id: 'README.md', name: 'README.md', isFolder: false },
+        ];
+        const childrenByParent: Record<string, LazyNode[]> = {
+            documents: [
+                { id: 'documents/page-01', name: 'Page 01', isFolder: false },
+                { id: 'documents/page-02', name: 'Page 02', isFolder: false },
+            ],
+        };
+        // Persisted partial selection: only Page 01 is selected inside the still-collapsed
+        // Documents folder. The consumer knows this before the children load.
+        const storedSelection: Record<string, string[]> = {
+            documents: ['documents/page-01'],
+        };
+        const fetchChildren = (parentId: string): Promise<LazyNode[]> =>
+            new Promise((resolve) => {
+                setTimeout(() => resolve(childrenByParent[parentId] ?? []), 600);
+            });
+
+        const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+        const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+        // Collapsed folders whose stored selection is partial and not loaded yet: shown
+        // indeterminate until their children arrive and take over the derivation.
+        const [partialFolderIds, setPartialFolderIds] = useState<Set<string>>(() => new Set(['documents']));
+        const [childrenState, setChildrenState] = useState<Record<string, ChildrenState>>({});
+
+        const handleSelect = (id: string, isSelected: boolean) => {
+            setSelectedIds((prev) => {
+                const next = new Set(prev);
+                if (isSelected) {
+                    next.add(id);
+                } else {
+                    next.delete(id);
+                }
+                return next;
+            });
+            // A click on the placeholder folder resolves its indeterminate into a real state.
+            setPartialFolderIds((prev) => {
+                if (!prev.has(id)) {
+                    return prev;
+                }
+                const next = new Set(prev);
+                next.delete(id);
+                return next;
+            });
+        };
+
+        const handleExpand = (id: string, isExpanded: boolean) => {
+            setExpandedIds((prev) => {
+                const next = new Set(prev);
+                if (isExpanded) {
+                    next.add(id);
+                } else {
+                    next.delete(id);
+                }
+                return next;
+            });
+            if (isExpanded && !childrenState[id]) {
+                setChildrenState((prev) => ({ ...prev, [id]: { status: 'loading' } }));
+                fetchChildren(id)
+                    .then((children) => {
+                        setChildrenState((prev) => ({ ...prev, [id]: { status: 'loaded', children } }));
+                        // Carry the stored partial selection onto the loaded children, then
+                        // drop the placeholder so the folder derives from its contents.
+                        const restored = storedSelection[id] ?? [];
+                        if (restored.length > 0) {
+                            setSelectedIds((prev) => new Set([...prev, ...restored]));
+                        }
+                        setPartialFolderIds((prev) => {
+                            if (!prev.has(id)) {
+                                return prev;
+                            }
+                            const next = new Set(prev);
+                            next.delete(id);
+                            return next;
+                        });
+                        return children;
+                    })
+                    .catch(() => {});
+            }
+        };
+
+        const folderSelectedState = (id: string): boolean | 'indeterminate' =>
+            partialFolderIds.has(id) ? 'indeterminate' : selectedIds.has(id);
+
+        const renderNode = (n: LazyNode): ReactNode => {
+            if (!n.isFolder) {
+                return (
+                    <Tree.Item
+                        key={n.id}
+                        id={n.id}
+                        isSelected={selectedIds.has(n.id)}
+                        onSelectChange={(isSelected) => handleSelect(n.id, isSelected)}
+                    >
+                        <Tree.Icon>
+                            <IconDocument size={16} />
+                        </Tree.Icon>
+                        <Tree.Label>{n.name}</Tree.Label>
+                    </Tree.Item>
+                );
+            }
+            const entry = childrenState[n.id];
+            return (
+                <Tree.Folder
+                    key={n.id}
+                    id={n.id}
+                    isExpanded={expandedIds.has(n.id)}
+                    onExpandChange={(isExpanded) => handleExpand(n.id, isExpanded)}
+                    isSelected={folderSelectedState(n.id)}
+                    onSelectChange={(isSelected) => handleSelect(n.id, isSelected)}
+                >
+                    <Tree.FolderHeader>
+                        <Tree.Icon>
+                            <IconFolder size={16} />
+                        </Tree.Icon>
+                        <Tree.Label>{n.name}</Tree.Label>
+                    </Tree.FolderHeader>
+                    {entry?.status === 'loading' && <Tree.Loading />}
+                    {entry?.status === 'loaded' && entry.children.map(renderNode)}
+                </Tree.Folder>
+            );
+        };
+
+        return <Tree.Root {...args}>{rootNodes.map(renderNode)}</Tree.Root>;
+    },
+};
+
 export const LoadMore: Story = {
     parameters: {
         docs: {

--- a/packages/components/src/components/Tree/components/TreeRoot.tsx
+++ b/packages/components/src/components/Tree/components/TreeRoot.tsx
@@ -24,9 +24,10 @@ export type TreeRootProps = {
     /**
      * Renders a checkbox in each row. Folder checkboxes derive from their descendants
      * (indeterminate when partially checked) and cascade-toggle them on click. A folder
-     * with no loaded children is checkable as its own entity via `isSelected`; when its
-     * children load, the consumer has to carry the selected state over to the new items
-     * by passing `isSelected` to all of them.
+     * with no loaded children is checkable as its own entity via `isSelected`, including
+     * an explicit `'indeterminate'` to restore a partial selection before its descendants
+     * load. When its children load, the consumer has to carry the selected state over to
+     * the new items by passing `isSelected` to all of them.
      * @default false
      */
     multiSelect?: boolean;

--- a/packages/components/src/components/Tree/types.ts
+++ b/packages/components/src/components/Tree/types.ts
@@ -39,10 +39,12 @@ type TreeRowSharedProps = {
      * Selects the row: checks its checkbox (`multiSelect`) or highlights it (single-select).
      * In multi-select mode a folder's `isSelected` is honored only while it has no loaded
      * children (empty, or collapsed while lazy-loading) — then it is checkable as its own
-     * entity and counts as one unit toward its ancestors. Once children are present the
-     * prop is ignored and folder state is derived (`'indeterminate'` is output-only).
-     * When the children of a checked folder load, the consumer has to carry the selected
-     * state over to the new items by passing `isSelected` to all of them.
+     * entity and counts as one unit toward its ancestors. A childless folder also accepts
+     * an explicit `'indeterminate'` to restore a partial selection before its descendants
+     * load; the first click checks it. Once children are present the prop is ignored and
+     * folder state is derived (a derived `'indeterminate'` is output-only). When the
+     * children of a selected folder load, the consumer has to carry the selected state
+     * over to the new items by passing `isSelected` to all of them.
      */
     isSelected?: boolean | 'indeterminate';
     onSelectChange?: (isSelected: boolean) => void;

--- a/packages/components/src/components/Tree/utils/computeCheckedStates.spec.ts
+++ b/packages/components/src/components/Tree/utils/computeCheckedStates.spec.ts
@@ -96,4 +96,46 @@ describe('computeCheckedStates', () => {
         const items = [folder('f', ROOT_ID, ['missing'])];
         expect(computeCheckedStates(items, new Set()).get('f')).toBe(false);
     });
+
+    it('renders a childless folder with explicit indeterminate as mixed', () => {
+        const items = [folder('empty', ROOT_ID, [], { isSelected: 'indeterminate' as const })];
+        expect(computeCheckedStates(items, new Set()).get('empty')).toBe('indeterminate');
+    });
+
+    it('lets a live checked membership win over an explicit indeterminate', () => {
+        const items = [folder('empty', ROOT_ID, [], { isSelected: 'indeterminate' as const })];
+        expect(computeCheckedStates(items, new Set(['empty'])).get('empty')).toBe(true);
+    });
+
+    it('ignores explicit indeterminate on a leaf', () => {
+        const items = [leaf('a', ROOT_ID, { isSelected: 'indeterminate' as const })];
+        expect(computeCheckedStates(items, new Set()).get('a')).toBe(false);
+    });
+
+    it('ignores explicit indeterminate once the folder has children', () => {
+        const items = [folder('f', ROOT_ID, ['a'], { isSelected: 'indeterminate' as const }), leaf('a', 'f')];
+        expect(computeCheckedStates(items, new Set()).get('f')).toBe(false);
+        expect(computeCheckedStates(items, new Set(['a'])).get('f')).toBe(true);
+    });
+
+    it('bubbles a childless indeterminate folder up to every ancestor', () => {
+        const items = [
+            folder('group', ROOT_ID, ['branch']),
+            folder('branch', 'group', ['empty']),
+            folder('empty', 'branch', [], { isSelected: 'indeterminate' as const }),
+        ];
+        const states = computeCheckedStates(items, new Set());
+        expect(states.get('empty')).toBe('indeterminate');
+        expect(states.get('branch')).toBe('indeterminate');
+        expect(states.get('group')).toBe('indeterminate');
+    });
+
+    it('blocks an ancestor "all checked" while a childless sibling stays indeterminate', () => {
+        const items = [
+            folder('f', ROOT_ID, ['empty', 'a']),
+            folder('empty', 'f', [], { isSelected: 'indeterminate' as const }),
+            leaf('a', 'f'),
+        ];
+        expect(computeCheckedStates(items, new Set(['a'])).get('f')).toBe('indeterminate');
+    });
 });

--- a/packages/components/src/components/Tree/utils/computeCheckedStates.ts
+++ b/packages/components/src/components/Tree/utils/computeCheckedStates.ts
@@ -23,6 +23,12 @@ export const getCheckedUnitIds = (items: readonly TreeItemData[]): string[] =>
  * some. Single source of truth for `TreeRoot`'s rendering and `buildChangeState`'s
  * report, so checkboxes and the `onChange` payload can never disagree (headless-tree's
  * own `getCheckedState` counts only leaves and would render leafless folders unchecked).
+ *
+ * A childless folder may also carry an explicit `isSelected: 'indeterminate'` from props
+ * to restore a partial selection whose descendants have not loaded yet. That is a
+ * display-only state: a live `checked` membership always wins, and once children load the
+ * folder derives from them like any other. A childless indeterminate folder counts as a
+ * partial unit, so every ancestor reads `'indeterminate'` and none can reach fully-checked.
  */
 export const computeCheckedStates = (
     items: readonly TreeItemData[],
@@ -31,7 +37,7 @@ export const computeCheckedStates = (
     const byId = new Map(items.map((item) => [item.id, item]));
     const states = new Map<string, RowCheckedState>();
 
-    type UnitCount = { units: number; checkedUnits: number };
+    type UnitCount = { units: number; checkedUnits: number; hasIndeterminate: boolean };
     const counts = new Map<string, UnitCount>();
 
     const visit = (id: string): UnitCount => {
@@ -42,22 +48,32 @@ export const computeCheckedStates = (
         const item = byId.get(id);
         if (!item) {
             // Orphan ids in parent.children contribute nothing.
-            return { units: 0, checkedUnits: 0 };
+            return { units: 0, checkedUnits: 0, hasIndeterminate: false };
         }
         let count: UnitCount;
         if (isCheckableUnit(item)) {
             const isChecked = checkedIds.has(id);
-            count = { units: 1, checkedUnits: isChecked ? 1 : 0 };
-            states.set(id, isChecked);
+            // Only a childless folder honors an explicit indeterminate; leaves are binary.
+            const isIndeterminate = !isChecked && item.isFolder === true && item.isSelected === 'indeterminate';
+            count = { units: 1, checkedUnits: isChecked ? 1 : 0, hasIndeterminate: isIndeterminate };
+            states.set(id, isChecked ? true : isIndeterminate ? 'indeterminate' : false);
         } else {
-            count = { units: 0, checkedUnits: 0 };
+            count = { units: 0, checkedUnits: 0, hasIndeterminate: false };
             for (const childId of item.children ?? []) {
                 const childCount = visit(childId);
                 count.units += childCount.units;
                 count.checkedUnits += childCount.checkedUnits;
+                count.hasIndeterminate ||= childCount.hasIndeterminate;
             }
-            const allChecked = count.units > 0 && count.checkedUnits === count.units;
-            states.set(id, allChecked ? true : count.checkedUnits > 0 ? 'indeterminate' : false);
+            const allChecked = count.units > 0 && count.checkedUnits === count.units && !count.hasIndeterminate;
+            const isPartial = count.checkedUnits > 0 || count.hasIndeterminate;
+            if (allChecked) {
+                states.set(id, true);
+            } else if (isPartial) {
+                states.set(id, 'indeterminate');
+            } else {
+                states.set(id, false);
+            }
         }
         counts.set(id, count);
         return count;


### PR DESCRIPTION
In multi-select mode, a folder with no loaded children (collapsed while its contents are still unfetched, or empty) can now be shown with a mixed/indeterminate checkbox by passing `isSelected="indeterminate"`. Before, only a fully checked state was possible for such a folder; asking for indeterminate left it unchecked.

Once the folder's children load, nothing changes about how it behaves.
