### PR TITLE
fix(Badge): font weight should not inherit from parent containers

### DIFF
--- a/.changeset/badge-font-weight-normal.md
+++ b/.changeset/badge-font-weight-normal.md
@@ -1,5 +1,6 @@
 ---
 '@frontify/fondue-components': patch
+'@frontify/fondue': patch
 ---
 
 Pin the `Badge` text to the regular font weight so it no longer inherits a bold weight from an ancestor with `font-weight: bold`.

--- a/.changeset/badge-font-weight-normal.md
+++ b/.changeset/badge-font-weight-normal.md
@@ -1,0 +1,5 @@
+---
+'@frontify/fondue-components': patch
+---
+
+Pin the `Badge` text to the regular font weight so it no longer inherits a bold weight from an ancestor with `font-weight: bold`.

--- a/packages/components/src/components/Badge/styles/badge.module.scss
+++ b/packages/components/src/components/Badge/styles/badge.module.scss
@@ -34,6 +34,7 @@
 
 .root {
     font-size: var(--typography-font-size-small);
+    font-weight: var(--typography-font-weight-regular);
     line-height: var(--typography-line-height-tight);
     padding-block: var(--spacing-xx-small);
     padding-inline: var(--spacing-x-small);
@@ -114,26 +115,26 @@
         color: CanvasText !important;
 
         // Use different border styles to distinguish variants
-        &[data-variant="default"] {
+        &[data-variant='default'] {
             border-style: solid;
         }
 
-        &[data-variant="positive"] {
+        &[data-variant='positive'] {
             border-style: solid;
             border-color: LinkText;
         }
 
-        &[data-variant="highlight"] {
+        &[data-variant='highlight'] {
             border-style: double;
             border-color: Highlight;
         }
 
-        &[data-variant="warning"] {
+        &[data-variant='warning'] {
             border-style: dashed;
             border-color: CanvasText;
         }
 
-        &[data-variant="negative"] {
+        &[data-variant='negative'] {
             border-style: solid;
             border-width: 3px;
             border-color: CanvasText;
@@ -146,7 +147,7 @@
             border-color: HighlightText;
         }
 
-        &[data-disabled="true"] {
+        &[data-disabled='true'] {
             border-color: GrayText;
             border-style: solid;
             color: GrayText !important;

--- a/packages/components/src/components/Badge/tests/Badge.ct.tsx
+++ b/packages/components/src/components/Badge/tests/Badge.ct.tsx
@@ -113,3 +113,14 @@ test('should render correct cross icon size', async ({ mount }) => {
     const icon = await component.locator('svg').getAttribute('width');
     expect(icon).toBe('12');
 });
+
+test('should keep regular font weight when wrapped in a bold ancestor', async ({ mount }) => {
+    const wrapper = await mount(
+        <div style={{ fontWeight: 'bold' }}>
+            <Badge data-test-id="badge-root">{BADGE_TEXT}</Badge>
+        </div>,
+    );
+    const component = wrapper.getByTestId('badge-root');
+    const fontWeight = await component.evaluate((element) => getComputedStyle(element).fontWeight);
+    expect(fontWeight).toBe('400');
+});


### PR DESCRIPTION
https://frontify.slack.com/archives/C06D0LAQFB4/p1784057776578259