### PR TITLE
feat: prepare react 19 compatibility

### DIFF
--- a/.changeset/tall-mangos-arrive.md
+++ b/.changeset/tall-mangos-arrive.md
@@ -1,0 +1,8 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue-tokens": patch
+"@frontify/fondue-icons": patch
+"@frontify/fondue": patch
+---
+
+chore: prepare for react 19 compatibility

--- a/.github/workflows/react-19-compat.yaml
+++ b/.github/workflows/react-19-compat.yaml
@@ -63,4 +63,6 @@ jobs:
       - name: Typecheck
         run: |
           pnpm --stream --filter {packages/icons} --filter {packages/tokens} typecheck
-          pnpm --filter {packages/components} exec tsgo -p tsconfig.react19.json --noEmit
+          echo "packages/components typecheck (tsconfig.react19.json, stories excluded)"
+          pnpm --fail-if-no-match --filter {packages/components} exec tsgo -p tsconfig.react19.json --noEmit
+          echo "packages/components typecheck: Done"

--- a/.github/workflows/react-19-compat.yaml
+++ b/.github/workflows/react-19-compat.yaml
@@ -1,0 +1,60 @@
+# The workspace develops against React 18. This workflow re-installs with React 19
+# (runtime + types) forced via pnpm overrides and re-runs the typecheck for the
+# packages being prepared for React 19 support, so the preparation work cannot
+# silently regress before the actual peer-range bump.
+#
+# Story files are excluded for components (see packages/components/tsconfig.react19.json):
+# they reference raw render components for react-docgen and only typecheck against
+# @types/react@18. Packages still limited to React 18 (rte, fondue, charts) are not
+# exercised here.
+name: React 19 Compatibility
+
+on:
+  pull_request:
+    paths:
+      - packages/**
+      - .npmrc
+      - .nvmrc
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: Typecheck against React 19
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Override React to v19
+        run: |
+          cat >> pnpm-workspace.yaml <<'EOF'
+
+          overrides:
+              react: ^19.0.0
+              react-dom: ^19.0.0
+              "@types/react": ^19.0.0
+              "@types/react-dom": ^19.0.0
+          EOF
+          pnpm install --no-frozen-lockfile
+
+      - name: Build Fondue Icons
+        run: pnpm build:icons
+
+      - name: Typecheck
+        run: |
+          pnpm --stream --filter {packages/icons} --filter {packages/tokens} typecheck
+          pnpm --filter {packages/components} exec tsgo -p tsconfig.react19.json --noEmit

--- a/.github/workflows/react-19-compat.yaml
+++ b/.github/workflows/react-19-compat.yaml
@@ -51,8 +51,14 @@ jobs:
           EOF
           pnpm install --no-frozen-lockfile
 
+      # The dist types of icons and components are consumed by the other
+      # packages' typechecks (components imports fondue-icons, the tokens
+      # Storybook stories import fondue-components).
       - name: Build Fondue Icons
         run: pnpm build:icons
+
+      - name: Build Fondue Components
+        run: pnpm build:components
 
       - name: Typecheck
         run: |

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -102,6 +102,7 @@
     "@tony.ganchev/eslint-plugin-header": "^3.4.4",
     "@types/node": "^24.10.9",
     "@types/react": "^18.3.27",
+    "@types/react-dom": "^18.3.7",
     "@types/sinon": "^21.0.1",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@vitejs/plugin-react": "^5.1.2",

--- a/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
+++ b/packages/components/src/components/DatePicker/DatePickerCalendar.tsx
@@ -2,7 +2,7 @@
 
 import { IconCaretLeft, IconCaretLeftDouble, IconCaretRight, IconCaretRightDouble } from '@frontify/fondue-icons';
 import { addYears, format, subYears } from 'date-fns';
-import { forwardRef, useEffect, useMemo, useRef } from 'react';
+import { forwardRef, type ReactElement, useEffect, useMemo, useRef } from 'react';
 import {
     getDefaultClassNames,
     DayPicker,
@@ -60,7 +60,7 @@ export const DatePickerCalendar = forwardRef<HTMLDivElement, DatePickerCalendarP
     (
         { 'data-test-id': dataTestId = 'fondue-date-picker-calendar', disabledDates, minMonth, maxMonth, ...modeProps },
         ref,
-    ): JSX.Element => {
+    ): ReactElement => {
         const defaultClassNames = getDefaultClassNames();
         const {
             dir,
@@ -120,7 +120,7 @@ export const DatePickerCalendar = forwardRef<HTMLDivElement, DatePickerCalendarP
 DatePickerCalendar.displayName = 'DatePickerCalendar';
 
 const getCustomComponents = (): Partial<CustomComponents> => ({
-    CaptionLabel: ({ children }: CaptionLabelProps): JSX.Element => {
+    CaptionLabel: ({ children }: CaptionLabelProps): ReactElement => {
         const { months } = useDayPicker();
         const {
             locale: { dateLocale },
@@ -147,7 +147,7 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
             </span>
         );
     },
-    DayButton: ({ day, modifiers, onClick, onMouseEnter, onMouseLeave, ...props }: DayButtonProps): JSX.Element => {
+    DayButton: ({ day, modifiers, onClick, onMouseEnter, onMouseLeave, ...props }: DayButtonProps): ReactElement => {
         const buttonRef = useRef<HTMLButtonElement>(null);
 
         useEffect(() => {
@@ -174,7 +174,7 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
         onClick,
         'aria-label': ariaLabel,
         'aria-disabled': ariaDisabled,
-    }: PreviousMonthButtonProps): JSX.Element => {
+    }: PreviousMonthButtonProps): ReactElement => {
         const { months, goToMonth, previousMonth } = useDayPicker();
         const currentMonth = months[0]?.date;
         const isYearDisabled = !previousMonth;
@@ -217,7 +217,7 @@ const getCustomComponents = (): Partial<CustomComponents> => ({
         onClick,
         'aria-label': ariaLabel,
         'aria-disabled': ariaDisabled,
-    }: NextMonthButtonProps): JSX.Element => {
+    }: NextMonthButtonProps): ReactElement => {
         const { months, goToMonth, nextMonth } = useDayPicker();
         const currentMonth = months[0]?.date;
         const isYearDisabled = !nextMonth;

--- a/packages/components/src/components/DatePicker/RangeDatePicker.tsx
+++ b/packages/components/src/components/DatePicker/RangeDatePicker.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { forwardRef, type ForwardedRef } from 'react';
+import { forwardRef, type ReactElement, type ForwardedRef } from 'react';
 
 import { type DatePickerBaseProps, DatePickerCalendar } from './DatePickerCalendar';
 import { useDateRange } from './hooks/useDateRange';
@@ -15,7 +15,7 @@ type RangeDatePickerProps = {
 export const RangeDatePicker = (
     { 'data-test-id': dataTestId, onChange, selected, ...props }: RangeDatePickerProps,
     ref: ForwardedRef<HTMLDivElement>,
-): JSX.Element => {
+): ReactElement => {
     const { selectedDateRange, handleSelect } = useDateRange(selected, onChange);
     const { hoverModifiers } = useRangeHover(selectedDateRange);
 

--- a/packages/components/src/components/DatePicker/SingleDatePicker.tsx
+++ b/packages/components/src/components/DatePicker/SingleDatePicker.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { forwardRef, type ForwardedRef } from 'react';
+import { forwardRef, type ReactElement, type ForwardedRef } from 'react';
 
 import { type DatePickerBaseProps, DatePickerCalendar } from './DatePickerCalendar';
 import { useSingleDate } from './hooks/useSingleDate';
@@ -14,7 +14,7 @@ type SingleDatePickerProps = {
 export const SingleDatePicker = (
     { 'data-test-id': dataTestId, onChange, selected, ...props }: SingleDatePickerProps,
     ref: ForwardedRef<HTMLDivElement>,
-): JSX.Element => {
+): ReactElement => {
     const { selectedDate, handleSelect } = useSingleDate(selected, onChange);
     return (
         <DatePickerCalendar

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -5,6 +5,7 @@ import * as RadixDialog from '@radix-ui/react-dialog';
 import {
     createContext,
     forwardRef,
+    isValidElement,
     useContext,
     useMemo,
     useRef,
@@ -416,7 +417,7 @@ export const DialogTitle = ({ children, asChild, screenReaderOnly = false }: Dia
         // When using asChild with screenReaderOnly, apply className to the child
         return (
             <RadixDialog.Title asChild>
-                {typeof children === 'object' && children && 'props' in children
+                {isValidElement<{ className?: string }>(children)
                     ? {
                           ...children,
                           props: {
@@ -446,7 +447,7 @@ export const DialogDescription = ({ children, asChild, screenReaderOnly = false 
         // When using asChild with screenReaderOnly, apply className to the child
         return (
             <RadixDialog.Description asChild>
-                {typeof children === 'object' && children && 'props' in children
+                {isValidElement<{ className?: string }>(children)
                     ? {
                           ...children,
                           props: {

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type ForwardedRef, forwardRef, type ReactNode } from 'react';
+import { type ForwardedRef, forwardRef, type ReactElement, type ReactNode } from 'react';
 
 import { type CommonAriaProps } from '#/helpers/aria';
 
@@ -77,6 +77,6 @@ export const Heading = forwardRef(
     },
 ) as (<TTag extends TagType = 'span'>(
     props: HeadingProps<TTag> & { ref?: ForwardedRef<HeadingElementType<TTag>> },
-) => JSX.Element) & { displayName: string };
+) => ReactElement) & { displayName: string };
 
 Heading.displayName = 'Heading';

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -208,7 +208,7 @@ export const TabsTrigger = ({ children, ...props }: TabsTriggerProps, ref: Forwa
     const { addTrigger } = useContext(TabTriggerContext);
 
     const localRef = useRef<HTMLButtonElement>(null);
-    const previousElement = useRef<ReactNode>();
+    const previousElement = useRef<ReactNode>(undefined);
 
     useEffect(() => {
         addTrigger({

--- a/packages/components/src/components/Tabs/hooks/useTabTriggers.ts
+++ b/packages/components/src/components/Tabs/hooks/useTabTriggers.ts
@@ -18,7 +18,10 @@ const getOverflowingTriggers = (triggers: TabTrigger[], triggerListElement: HTML
     });
 };
 
-const moveActiveIndicator = (triggerListElement: HTMLDivElement, activeIndicatorRef: RefObject<HTMLSpanElement>) => {
+const moveActiveIndicator = (
+    triggerListElement: HTMLDivElement,
+    activeIndicatorRef: RefObject<HTMLSpanElement | null>,
+) => {
     const activeIndicatorElement = activeIndicatorRef.current;
     const activeTriggerElement = triggerListElement?.querySelector('[data-state="active"]');
 
@@ -72,8 +75,10 @@ export const useTabTriggers = ({
 }: {
     activeTab?: string;
 }): {
-    triggerListRef: RefObject<HTMLDivElement>;
-    activeIndicatorRef: RefObject<HTMLSpanElement>;
+    // Structural ref types so the annotation is valid for both @types/react@18
+    // (useRef returns MutableRefObject) and @types/react@19 (RefObject<T | null>).
+    triggerListRef: { current: HTMLDivElement | null };
+    activeIndicatorRef: { current: HTMLSpanElement | null };
     triggers: TabTrigger[];
     triggersOutOfView: TabTrigger[];
     addTrigger: (trigger: TabTrigger) => void;

--- a/packages/components/src/components/Tabs/types.ts
+++ b/packages/components/src/components/Tabs/types.ts
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type HTMLAttributes, type ReactNode, type RefObject } from 'react';
+import { type HTMLAttributes, type ReactNode } from 'react';
 
 export type TabTrigger = {
-    ref?: RefObject<HTMLButtonElement>;
+    ref?: { current: HTMLButtonElement | null };
     element: ReactNode;
     previousElement?: ReactNode;
     props: HTMLAttributes<HTMLButtonElement>;

--- a/packages/components/src/components/Tag/Tag.tsx
+++ b/packages/components/src/components/Tag/Tag.tsx
@@ -84,7 +84,7 @@ const TagRoot = forwardRef<HTMLButtonElement | HTMLDivElement, TagProps>(
         // Extract hover content from slots
         let extractedHoverContent: ReactNode = null;
         const processedChildren = Children.map(children, (child) => {
-            if (isValidElement(child) && child.type === TagHoverContent) {
+            if (isValidElement<{ children?: ReactNode }>(child) && child.type === TagHoverContent) {
                 extractedHoverContent = child.props.children;
                 return null;
             }
@@ -162,11 +162,10 @@ const TagMainContent = forwardRef<HTMLButtonElement | HTMLDivElement, TagMainCon
         // Process children to handle secondary content slots in their natural position
         let secondaryIndex = 0;
         const processedChildren = Children.map(children, (child) => {
-            if (isValidElement(child) && child.type === TagSecondaryContent) {
+            if (isValidElement<{ children?: ReactNode }>(child) && child.type === TagSecondaryContent) {
                 const currentIndex = secondaryIndex++;
                 return (
                     <div className={styles.secondaryContent} key={`secondary-${currentIndex}`}>
-                        {/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */}
                         {child.props.children}
                     </div>
                 );

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -1,6 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type ReactNode, forwardRef, type ForwardedRef, type HTMLAttributeAnchorTarget } from 'react';
+import {
+    type ReactNode,
+    forwardRef,
+    type ForwardedRef,
+    type HTMLAttributeAnchorTarget,
+    type ReactElement,
+} from 'react';
 
 import { type CommonAriaProps } from '#/helpers/aria';
 
@@ -115,6 +121,6 @@ export const Text = forwardRef(
     ),
 ) as (<TTag extends TagType = 'span'>(
     props: TextProps<TTag> & { ref?: ForwardedRef<TextElementType<TTag>> },
-) => JSX.Element) & { displayName: string };
+) => ReactElement) & { displayName: string };
 
 Text.displayName = 'FondueText';

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -205,7 +205,7 @@ TextFieldSlot.displayName = 'TextField.Slot';
 const ForwardedRefTextFieldRoot = forwardRef<HTMLInputElement, TextInputProps>(TextFieldRoot);
 const ForwardedRefTextFieldSlot = forwardRef<HTMLDivElement, TextFieldSlotProps>(TextFieldSlot);
 // @ts-expect-error We support both single component (without slots) and compound components (with slots)
-export const TextInput: typeof TextFieldRoot & {
+export const TextInput: typeof ForwardedRefTextFieldRoot & {
     Root: typeof ForwardedRefTextFieldRoot;
     Slot: typeof ForwardedRefTextFieldSlot;
 } = ForwardedRefTextFieldRoot;

--- a/packages/components/src/components/Textarea/Textarea.tsx
+++ b/packages/components/src/components/Textarea/Textarea.tsx
@@ -347,7 +347,7 @@ const ForwardedRefTextareaRoot = forwardRef<HTMLTextAreaElement, TextareaProps>(
 const ForwardedRefTextareaSlot = forwardRef<HTMLDivElement, TextareaSlotProps>(TextareaSlot);
 
 // @ts-expect-error We support both single component (without slots) and compound components (with slots)
-export const Textarea: typeof TextareaRoot & {
+export const Textarea: typeof ForwardedRefTextareaRoot & {
     Root: typeof ForwardedRefTextareaRoot;
     Slot: typeof ForwardedRefTextareaSlot;
 } = ForwardedRefTextareaRoot;

--- a/packages/components/src/hooks/useSyncRefs.ts
+++ b/packages/components/src/hooks/useSyncRefs.ts
@@ -24,7 +24,7 @@ import { syncRefs } from '#/utilities/domUtilities';
  * ```
  */
 export const useSyncRefs = <TElement = HTMLElement>(
-    localRef: RefObject<TElement>,
+    localRef: RefObject<TElement | null>,
     forwardedRef: ForwardedRef<TElement>,
 ) => {
     useEffect(() => {

--- a/packages/components/src/hooks/useTextTruncation.ts
+++ b/packages/components/src/hooks/useTextTruncation.ts
@@ -19,7 +19,7 @@ import { useEffect, type RefObject } from 'react';
  * });
  * ```
  */
-export const useTextTruncation = (ref: RefObject<HTMLElement>) => {
+export const useTextTruncation = (ref: RefObject<HTMLElement | null>) => {
     useEffect(() => {
         if (!ref.current) {
             return;

--- a/packages/components/src/utilities/domUtilities.ts
+++ b/packages/components/src/utilities/domUtilities.ts
@@ -64,7 +64,10 @@ export function isElementVisible(element: HTMLElement) {
  * @param {RefObject<HTMLDivElement>} localRef - The local React reference to an HTMLDivElement.
  * @param {ForwardedRef<HTMLDivElement>} forwardedRef - The ref forwarded from a parent component.
  */
-export function syncRefs<TElement = HTMLElement>(localRef: RefObject<TElement>, forwardedRef: ForwardedRef<TElement>) {
+export function syncRefs<TElement = HTMLElement>(
+    localRef: RefObject<TElement | null>,
+    forwardedRef: ForwardedRef<TElement>,
+) {
     if (!forwardedRef) {
         return;
     }

--- a/packages/components/tsconfig.react19.json
+++ b/packages/components/tsconfig.react19.json
@@ -1,0 +1,10 @@
+{
+    // Used by the react-19-compat workflow. Storybook story files intentionally
+    // reference the raw two-argument render components (e.g. `CheckboxComponent`)
+    // because react-docgen only attaches prop documentation to those named
+    // exports — but @types/react@19 no longer accepts two-argument functions as
+    // components, so stories only typecheck against @types/react@18. Stories are
+    // dev-only and never shipped, so the React 19 check covers everything else.
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.stories.tsx"]
+}

--- a/packages/icons/src/createFondueIcon.ts
+++ b/packages/icons/src/createFondueIcon.ts
@@ -1,20 +1,74 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import {
-    createElement,
-    forwardRef,
-    type ForwardRefExoticComponent,
-    type ReactSVG,
-    type RefAttributes,
-    type SVGProps,
-} from 'react';
+import { createElement, forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVGProps } from 'react';
 
 import { defaultAttributes } from './constants';
 import styles from './icons.module.scss';
 import { htmlKeysToJsxKeys } from './utilities/jsxKeyFormat';
 import { kebabCase } from './utilities/stringCasing';
 
-export type IconNode = [elementName: keyof ReactSVG, attrs: Record<string, string>, children?: IconNode][];
+// Mirrors `SVGElementType` from @types/react@19, defined locally so the emitted
+// declarations stay compatible with both @types/react@18 and @types/react@19.
+// Because the type is exported we cannot use the modern SVGElementTagName type directly
+// When the icon pipeline is refactored we can remove this type and use the modern SVGElementTagName type directly.
+export type SVGElementTagName =
+    | 'animate'
+    | 'circle'
+    | 'clipPath'
+    | 'defs'
+    | 'desc'
+    | 'ellipse'
+    | 'feBlend'
+    | 'feColorMatrix'
+    | 'feComponentTransfer'
+    | 'feComposite'
+    | 'feConvolveMatrix'
+    | 'feDiffuseLighting'
+    | 'feDisplacementMap'
+    | 'feDistantLight'
+    | 'feDropShadow'
+    | 'feFlood'
+    | 'feFuncA'
+    | 'feFuncB'
+    | 'feFuncG'
+    | 'feFuncR'
+    | 'feGaussianBlur'
+    | 'feImage'
+    | 'feMerge'
+    | 'feMergeNode'
+    | 'feMorphology'
+    | 'feOffset'
+    | 'fePointLight'
+    | 'feSpecularLighting'
+    | 'feSpotLight'
+    | 'feTile'
+    | 'feTurbulence'
+    | 'filter'
+    | 'foreignObject'
+    | 'g'
+    | 'image'
+    | 'line'
+    | 'linearGradient'
+    | 'marker'
+    | 'mask'
+    | 'metadata'
+    | 'path'
+    | 'pattern'
+    | 'polygon'
+    | 'polyline'
+    | 'radialGradient'
+    | 'rect'
+    | 'stop'
+    | 'svg'
+    | 'switch'
+    | 'symbol'
+    | 'text'
+    | 'textPath'
+    | 'tspan'
+    | 'use'
+    | 'view';
+
+export type IconNode = [elementName: SVGElementTagName, attrs: Record<string, string>, children?: IconNode][];
 
 export type SVGAttributes = Partial<SVGProps<SVGSVGElement>>;
 type ComponentAttributes = RefAttributes<SVGSVGElement> & SVGAttributes;

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -55,9 +55,6 @@
     "peerDependencies": {
         "tailwindcss": "^3.4.17"
     },
-    "dependencies": {
-        "react": "^18.3.1"
-    },
     "devDependencies": {
         "@frontify/fondue-components": "workspace:*",
         "@frontify/fondue-icons": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@types/react':
         specifier: ^18.3.27
         version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       '@types/sinon':
         specifier: ^21.0.1
         version: 21.0.1
@@ -1263,10 +1266,6 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(@vitest/ui@3.2.4)(happy-dom@20.9.0)(sass@1.99.0)(supports-color@8.1.1)
 
   packages/tokens:
-    dependencies:
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
     devDependencies:
       '@frontify/fondue-components':
         specifier: workspace:*
@@ -1325,6 +1324,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.23.0
         version: 0.23.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)


### PR DESCRIPTION
Prepares the packages `components`, `icons` and `tokens` to be compatible with react 19

- Added CI script that runs a v19 typecheck on the repository to flag additions that would break v19 compatibility (while fondue uses v18 for development)

## Code changes for v19 compatibility

- **`useRef()` without argument → explicit initial value** 
`@types/react@19` will make the argument required.
```
useRef<ReactNode>()  →  useRef<ReactNode>(undefined)
```

-  **Ref-accepting parameters: `RefObject<T> → RefObject<T | null>`** 
In react 19 `useRef<T>(null)` returns `RefObject<T | null>;` parameters must accept it. Backward-compatible in v18.
```
(ref: RefObject<HTMLElement>)  →  (ref: RefObject<HTMLElement | null>)
```

- **Refs in output positions: `RefObject<T> → structural { current: T | null }`**
Same nullability, but in return types/props the generic spelling fails react 18's covariance check, so the plain structural type is the only form valid under both.
```
triggerListRef: RefObject<HTMLDivElement>  →  triggerListRef: { current: HTMLDivElement | null }
```

**- Duck-typed element narrowing → `isValidElement<Props>()`**
react 19 changes `ReactElement`'s default props from `any` to `unknown`, breaking `.props` access after manual checks.
```
typeof children === 'object' && children && 'props' in children  // then children.props.className
→  isValidElement<{ className?: string }>(children)
```

- **Bare `JSX.Element` annotations → `ReactElement`**
react 19 removes the global JSX namespace (now React.JSX / importable only).
```
(): JSX.Element =>  →  (): ReactElement
```

- **Removed ReactSVG type → self-contained local union**
react 19 deleted `ReactSVG`; its replacement `SVGElementType` in 18, and the type is publicly exported, so neither import works for both majors.
```
keyof ReactSVG  →  SVGElementTagName  // local union mirroring 19's SVGElementType
```

- **Public exports typed as raw (props, ref) functions → typed as the `forwardRef` result**
react 19's `FunctionComponent` lost its legacy `context?: any` second parameter, so two-argument functions are no longer valid component types
```
export const TextInput: typeof TextFieldRoot & {…}  →  typeof ForwardedRefTextFieldRoot & {…}
```