### PR TITLE
chore(Select): improve error a11y

### DIFF
--- a/.changeset/strong-lizards-tickle.md
+++ b/.changeset/strong-lizards-tickle.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+chore(Select): improve error a11y

--- a/packages/components/src/components/Select/__tests__/ComboboxMultiple.a11y.spec.tsx
+++ b/packages/components/src/components/Select/__tests__/ComboboxMultiple.a11y.spec.tsx
@@ -104,6 +104,33 @@ describe('ComboboxMultiple - Accessibility', () => {
             expect(input).not.toHaveAttribute('aria-describedby');
         });
 
+        it('keeps a caller provided aria-describedby alongside the selection description', () => {
+            render(
+                <>
+                    <Select.Combobox.Multiple
+                        aria-label="Fruit picker"
+                        value={['apple']}
+                        aria-describedby="fruit-error"
+                    >
+                        <Select.Slot name="menu">
+                            <Select.Item value="apple">Apple</Select.Item>
+                        </Select.Slot>
+                    </Select.Combobox.Multiple>
+                    <span id="fruit-error">Please pick at least two fruits</span>
+                </>,
+            );
+
+            const input = screen.getByRole('combobox');
+            expect(input.getAttribute('aria-describedby')?.split(' ')).toContain('fruit-error');
+            expect(input).toHaveAccessibleDescription('1 selected: Apple Please pick at least two fruits');
+        });
+
+        it('sets aria-invalid when the status is error', () => {
+            renderMultiCombobox({ 'aria-label': 'Fruit picker', status: 'error' });
+
+            expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+        });
+
         it('sets aria-autocomplete="list" on the input', () => {
             renderMultiCombobox({ 'aria-label': 'Fruit picker' });
 

--- a/packages/components/src/components/Select/__tests__/ComboboxSingle.a11y.spec.tsx
+++ b/packages/components/src/components/Select/__tests__/ComboboxSingle.a11y.spec.tsx
@@ -88,6 +88,45 @@ describe('ComboboxSingle - Accessibility', () => {
 
             expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-describedby');
         });
+
+        it('passes a caller provided aria-describedby to the input', () => {
+            render(
+                <>
+                    <Select.Combobox aria-label="Fruit picker" value="apple" aria-describedby="fruit-error">
+                        <Select.Slot name="menu">
+                            <Select.Item value="apple">Apple</Select.Item>
+                        </Select.Slot>
+                    </Select.Combobox>
+                    <span id="fruit-error">Please pick a fruit</span>
+                </>,
+            );
+
+            expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Please pick a fruit');
+        });
+
+        it('does not set aria-invalid when the status is neutral', () => {
+            renderSingleCombobox({ 'aria-label': 'Fruit picker', value: 'apple' });
+
+            expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-invalid');
+        });
+
+        it('sets aria-invalid when the status is error', () => {
+            renderSingleCombobox({ 'aria-label': 'Fruit picker', value: 'apple', status: 'error' });
+
+            expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+        });
+
+        it('does not toggle aria-invalid while typing a filter that matches no item', async () => {
+            const user = userEvent.setup();
+            renderSingleCombobox({ 'aria-label': 'Fruit picker' });
+
+            const input = screen.getByRole('combobox');
+            await user.type(input, 'zzz');
+
+            expect(input).toHaveValue('zzz');
+            expect(screen.getByTestId('fondue-select-combobox-error-icon')).toBeInTheDocument();
+            expect(input).not.toHaveAttribute('aria-invalid');
+        });
     });
 
     describe('menu ARIA attributes', () => {

--- a/packages/components/src/components/Select/__tests__/SelectMultiple.a11y.spec.tsx
+++ b/packages/components/src/components/Select/__tests__/SelectMultiple.a11y.spec.tsx
@@ -110,6 +110,29 @@ describe('SelectMultiple - Accessibility', () => {
             const trigger = screen.getByRole('combobox');
             expect(trigger).not.toHaveAttribute('aria-describedby');
         });
+
+        it('keeps a caller provided aria-describedby alongside the selection description', () => {
+            render(
+                <>
+                    <Select.Multiple aria-label="Fruit picker" value={['apple']} aria-describedby="fruit-error">
+                        <Select.Slot name="menu">
+                            <Select.Item value="apple">Apple</Select.Item>
+                        </Select.Slot>
+                    </Select.Multiple>
+                    <span id="fruit-error">Please pick at least two fruits</span>
+                </>,
+            );
+
+            const trigger = screen.getByRole('combobox');
+            expect(trigger.getAttribute('aria-describedby')?.split(' ')).toContain('fruit-error');
+            expect(trigger).toHaveAccessibleDescription('1 selected: Apple Please pick at least two fruits');
+        });
+
+        it('sets aria-invalid when the status is error', () => {
+            renderMultiSelect({ 'aria-label': 'Fruit picker', status: 'error' });
+
+            expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+        });
     });
 
     describe('menu ARIA attributes', () => {

--- a/packages/components/src/components/Select/__tests__/SelectSingle.a11y.spec.tsx
+++ b/packages/components/src/components/Select/__tests__/SelectSingle.a11y.spec.tsx
@@ -91,6 +91,33 @@ describe('SelectSingle - Accessibility', () => {
             expect(trigger).not.toHaveAttribute('aria-describedby');
         });
 
+        it('passes a caller provided aria-describedby to the trigger', () => {
+            render(
+                <>
+                    <Select aria-label="Fruit picker" aria-describedby="fruit-error">
+                        <Select.Slot name="menu">
+                            <Select.Item value="apple">Apple</Select.Item>
+                        </Select.Slot>
+                    </Select>
+                    <span id="fruit-error">Please pick a fruit</span>
+                </>,
+            );
+
+            expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Please pick a fruit');
+        });
+
+        it('does not set aria-invalid when the status is neutral', () => {
+            renderSingleSelect({ 'aria-label': 'Fruit picker' });
+
+            expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-invalid');
+        });
+
+        it('sets aria-invalid when the status is error', () => {
+            renderSingleSelect({ 'aria-label': 'Fruit picker', status: 'error' });
+
+            expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+        });
+
         it('does not strip aria attributes when disabled', () => {
             const { container } = renderSingleSelect({ 'aria-label': 'Fruit picker', disabled: true });
 

--- a/packages/components/src/components/Select/components/ComboboxBase.tsx
+++ b/packages/components/src/components/Select/components/ComboboxBase.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react';
 
 import { LoadingCircle } from '#/components/LoadingCircle/LoadingCircle.tsx';
-import { type CommonAriaProps, type CommonGlobalProps } from '#/helpers/aria';
+import { mergeAriaIds, type CommonAriaProps, type CommonGlobalProps } from '#/helpers/aria';
 import { useTranslation } from '#/hooks/useTranslation';
 
 import { useBadgeItems } from '../hooks/useBadgeItems';
@@ -251,7 +251,8 @@ const ComboboxBaseInput = (
         return !getAsyncItems && !items.find((item) => item.label.toLowerCase().includes(inputValue.toLowerCase()));
     }, [inputValue, items, getAsyncItems, multiple]);
 
-    const hasError = valueInvalid || !!asyncItemStatus.error || status === 'error';
+    const hasStatusError = status === 'error';
+    const hasError = valueInvalid || !!asyncItemStatus.error || hasStatusError;
 
     const handleDismissBadge = (value: string, preventFocusRing: boolean): void => {
         const item = getItemByValue(value);
@@ -324,7 +325,11 @@ const ComboboxBaseInput = (
                                             'aria-labelledby' in props && props['aria-labelledby']
                                                 ? props['aria-labelledby']
                                                 : undefined,
-                                        'aria-describedby': selectionDescription ? selectionDescriptionId : undefined,
+                                        'aria-describedby': mergeAriaIds(
+                                            selectionDescription && selectionDescriptionId,
+                                            props['aria-describedby'],
+                                        ),
+                                        'aria-invalid': hasStatusError || undefined,
                                     })}
                                     data-test-id={dataTestId}
                                     lang={lang}
@@ -351,6 +356,8 @@ const ComboboxBaseInput = (
                                     'aria-labelledby' in props && props['aria-labelledby']
                                         ? props['aria-labelledby']
                                         : undefined,
+                                'aria-describedby': props['aria-describedby'],
+                                'aria-invalid': hasStatusError || undefined,
                             })}
                             data-test-id={dataTestId}
                             lang={lang}

--- a/packages/components/src/components/Select/components/SelectBase.tsx
+++ b/packages/components/src/components/Select/components/SelectBase.tsx
@@ -5,7 +5,7 @@ import * as RadixPopover from '@radix-ui/react-popover';
 import { useSelect } from 'downshift';
 import { forwardRef, useCallback, useMemo, useRef, useState, type ForwardedRef, type ReactNode } from 'react';
 
-import { type CommonAriaProps } from '#/helpers/aria';
+import { mergeAriaIds, type CommonAriaProps } from '#/helpers/aria';
 
 import { useBadgeItems } from '../hooks/useBadgeItems';
 import { useFocusRing } from '../hooks/useFocusRing';
@@ -215,7 +215,11 @@ const SelectBaseInput = (
                         ? {}
                         : getToggleButtonProps({
                               'aria-label': 'aria-label' in props ? props['aria-label'] : undefined,
-                              'aria-describedby': selectionDescription ? selectionDescriptionId : undefined,
+                              'aria-describedby': mergeAriaIds(
+                                  selectionDescription && selectionDescriptionId,
+                                  props['aria-describedby'],
+                              ),
+                              'aria-invalid': hasError || undefined,
                               ref: triggerRef,
                               onKeyDown: (event) => {
                                   if (event.metaKey || event.ctrlKey) {

--- a/packages/components/src/helpers/aria.spec.ts
+++ b/packages/components/src/helpers/aria.spec.ts
@@ -1,0 +1,43 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it } from 'vitest';
+
+import { mergeAriaIds } from './aria';
+
+describe('mergeAriaIds', () => {
+    it('should join multiple ids into a single space separated token list', () => {
+        expect(mergeAriaIds('internal-description', 'caller-error-message')).toBe(
+            'internal-description caller-error-message',
+        );
+    });
+
+    it('should keep the given order so the component id is announced first', () => {
+        expect(mergeAriaIds('a', 'b', 'c')).toBe('a b c');
+    });
+
+    it('should return the single remaining id when the others are absent', () => {
+        expect(mergeAriaIds(undefined, 'caller-error-message')).toBe('caller-error-message');
+        expect(mergeAriaIds('internal-description', undefined)).toBe('internal-description');
+    });
+
+    it('should return undefined when nothing is left, so the attribute is omitted', () => {
+        expect(mergeAriaIds()).toBeUndefined();
+        expect(mergeAriaIds(undefined, undefined)).toBeUndefined();
+    });
+
+    it('should drop `false`, which is what a conditional id expression evaluates to', () => {
+        const selectionDescription = '';
+        expect(mergeAriaIds(selectionDescription && 'internal-description', 'caller-error-message')).toBe(
+            'caller-error-message',
+        );
+    });
+
+    it('should drop empty and whitespace only ids', () => {
+        expect(mergeAriaIds('', '   ', 'caller-error-message')).toBe('caller-error-message');
+        expect(mergeAriaIds('', '   ')).toBeUndefined();
+    });
+
+    it('should deduplicate repeated ids', () => {
+        expect(mergeAriaIds('same-id', 'same-id')).toBe('same-id');
+    });
+});

--- a/packages/components/src/helpers/aria.ts
+++ b/packages/components/src/helpers/aria.ts
@@ -26,6 +26,18 @@ export type CommonAriaProps = Pick<
 };
 
 /**
+ * Merges ID-list ARIA attributes (`aria-describedby`, `aria-labelledby`, ...) so a
+ * component's own internal ID can coexist with one provided by the caller. Falsy and
+ * duplicate entries are dropped; returns `undefined` when nothing is left, so the
+ * attribute is omitted rather than rendered empty.
+ */
+export const mergeAriaIds = (...ids: (string | undefined | false)[]): string | undefined => {
+    const merged = [...new Set(ids.filter((id): id is string => typeof id === 'string' && id.trim() !== ''))];
+
+    return merged.length > 0 ? merged.join(' ') : undefined;
+};
+
+/**
  * Global HTML attributes with accessibility semantics that are not part of ARIA.
  *
  * `lang` is exposed so consumers can satisfy WCAG 3.1.2 (Language of Parts) when a


### PR DESCRIPTION
## Select and Combobox now announce their error state

A `Select` or `Combobox` in an error state showed a red border and a warning icon, but said nothing to a screen reader. To someone using one, a broken field looked exactly like a valid one.

Two things were missing, and both are fixed:

- **The error is now announced.** An error state is exposed to assistive technology, not just drawn on screen.
- **Validation messages can be attached.** A form can point the field at its own error text, and that text is now read out when the field is focused. Previously the field silently ignored it.

Nothing changes visually, and no existing usage needs updating. Forms that already wire up their validation messages will simply start working for `Select` fields the way they already do for text inputs.
