### PR TITLE
feat(Accordion): add stickyBackground and caretAlignment options [DAMCRE-745]

### DIFF
--- a/packages/components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/components/Accordion/Accordion.stories.tsx
@@ -287,6 +287,63 @@ export const WithPillVariant: Story = {
     },
 };
 
+export const WithStickyPillVariant: Story = {
+    args: {
+        variant: 'pill',
+        padding: 'small',
+        sticky: true,
+        stickyBackground: true,
+        caretAlignment: 'end',
+        defaultValue: ['accordion-test-0', 'accordion-test-1', 'accordion-test-2'],
+    },
+    render: (args) => {
+        return (
+            <ScrollArea maxHeight={300} maxWidth={600}>
+                <Accordion.Root {...args}>
+                    <Accordion.Item value="accordion-test-0">
+                        <Accordion.Header>Item without slots, caret pinned to the end</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-1">
+                        <Accordion.Header>
+                            With action slot, caret stays inline
+                            <Accordion.Slot name="action">
+                                <Button size="small" emphasis="default">
+                                    Click Me
+                                </Button>
+                            </Accordion.Slot>
+                        </Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-2">
+                        <Accordion.Header>Item three</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+
+                    <Accordion.Item value="accordion-test-3">
+                        <Accordion.Header>Item four</Accordion.Header>
+                        <Accordion.Content>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                            invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </Accordion.Content>
+                    </Accordion.Item>
+                </Accordion.Root>
+            </ScrollArea>
+        );
+    },
+};
+
 export const InScrollArea: Story = {
     args: {
         sticky: true,

--- a/packages/components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/components/Accordion/Accordion.stories.tsx
@@ -310,7 +310,7 @@ export const WithStickyPillVariant: Story = {
 
                     <Accordion.Item value="accordion-test-1">
                         <Accordion.Header>
-                            With action slot, caret stays inline
+                            With action slot, caret still pinned to the end
                             <Accordion.Slot name="action">
                                 <Button size="small" emphasis="default">
                                     Click Me

--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -23,6 +23,7 @@ import styles from './styles/accordion.module.scss';
 
 type AccordionRootContextValue = {
     registerItem: (value: string, element: HTMLDivElement | null) => void;
+    caretAlignment: AccordionCaretAlignment;
 };
 
 const AccordionRootContext = createContext<AccordionRootContextValue | null>(null);
@@ -76,6 +77,8 @@ const restoreScrollForClosingItem = (itemEl: HTMLElement) => {
 
 type AccordionPadding = 'none' | 'small' | 'medium' | 'large';
 
+type AccordionCaretAlignment = 'inline' | 'end';
+
 export type AccordionRootProps = {
     'data-test-id'?: string;
     /**
@@ -117,6 +120,20 @@ export type AccordionRootProps = {
      */
     sticky?: boolean;
     /**
+     * When `true` and `variant` is `'pill'`, a sticky header keeps its pill background
+     * (including hover/active states) instead of switching to the default surface background.
+     * Has no effect when `sticky` is `false` or `variant` is `'default'`.
+     * @default false
+     */
+    stickyBackground?: boolean;
+    /**
+     * Controls where the caret icon sits within `Accordion.Header`. `'end'` pushes the caret
+     * to the far right of the header, but only for headers that render no `Accordion.Slot`.
+     * Headers with slots are unaffected.
+     * @default 'inline'
+     */
+    caretAlignment?: AccordionCaretAlignment;
+    /**
      * Callback function that is called when the value of the accordion changes.
      */
     onValueChange?: (value: string[]) => void;
@@ -134,6 +151,8 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
             padding = 'large',
             variant = 'default',
             sticky = false,
+            stickyBackground = false,
+            caretAlignment = 'inline',
             onValueChange,
         }: AccordionRootProps,
         forwardedRef: ForwardedRef<HTMLDivElement>,
@@ -200,7 +219,10 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
             }
         }, []);
 
-        const contextValue = useMemo<AccordionRootContextValue>(() => ({ registerItem }), [registerItem]);
+        const contextValue = useMemo<AccordionRootContextValue>(
+            () => ({ registerItem, caretAlignment }),
+            [registerItem, caretAlignment],
+        );
 
         const handleValueChange = useCallback(
             (newValue: string[]) => {
@@ -241,6 +263,7 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>(
                     data-accordion-padding={padding}
                     data-accordion-variant={variant}
                     data-sticky={sticky}
+                    data-sticky-background={stickyBackground}
                     onValueChange={handleValueChange}
                 >
                     {children}
@@ -332,6 +355,9 @@ export const AccordionHeader = forwardRef<HTMLHeadingElement, AccordionHeaderPro
         { 'data-test-id': dataTestId = 'fondue-accordion-header', asChild, onClick, children }: AccordionHeaderProps,
         ref: ForwardedRef<HTMLHeadingElement>,
     ) => {
+        const rootContext = useContext(AccordionRootContext);
+        const caretAlignment = rootContext?.caretAlignment ?? 'inline';
+
         const { slots, triggerContent } = useMemo(
             () =>
                 Children.toArray(children).reduce<{ slots: ReactNode[]; triggerContent: ReactNode[] }>(
@@ -350,7 +376,12 @@ export const AccordionHeader = forwardRef<HTMLHeadingElement, AccordionHeaderPro
 
         return (
             <RadixAccordion.Header ref={ref} asChild={asChild} className={styles.accordionHeader} onClick={onClick}>
-                <RadixAccordion.Trigger className={styles.accordionTrigger} data-test-id={dataTestId}>
+                <RadixAccordion.Trigger
+                    className={styles.accordionTrigger}
+                    data-test-id={dataTestId}
+                    data-caret-alignment={caretAlignment}
+                    data-has-slots={slots.length > 0}
+                >
                     <div className={styles.accordionTriggerContent}>{triggerContent}</div>
                     <IconCaretDown className={styles.accordionCaret} size="16" />
                 </RadixAccordion.Trigger>

--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -128,8 +128,7 @@ export type AccordionRootProps = {
     stickyBackground?: boolean;
     /**
      * Controls where the caret icon sits within `Accordion.Header`. `'end'` pushes the caret
-     * to the far right of the header, but only for headers that render no `Accordion.Slot`.
-     * Headers with slots are unaffected.
+     * to the far right of the header, after any `Accordion.Slot` content.
      * @default 'inline'
      */
     caretAlignment?: AccordionCaretAlignment;
@@ -380,7 +379,6 @@ export const AccordionHeader = forwardRef<HTMLHeadingElement, AccordionHeaderPro
                     className={styles.accordionTrigger}
                     data-test-id={dataTestId}
                     data-caret-alignment={caretAlignment}
-                    data-has-slots={slots.length > 0}
                 >
                     <div className={styles.accordionTriggerContent}>{triggerContent}</div>
                     <IconCaretDown className={styles.accordionCaret} size="16" />

--- a/packages/components/src/components/Accordion/__tests__/Accordion.spec.tsx
+++ b/packages/components/src/components/Accordion/__tests__/Accordion.spec.tsx
@@ -43,4 +43,55 @@ describe('Accordion Component', () => {
         );
         expect(screen.getByTestId(ACCORDION_TEST_ID)).toHaveAttribute('data-accordion-variant', 'pill');
     });
+
+    it('should default stickyBackground to false', () => {
+        render(
+            <Accordion.Root data-test-id={ACCORDION_TEST_ID} variant="pill" sticky>
+                <Accordion.Item value="1">
+                    <Accordion.Header>{ACCORDION_TEXT}</Accordion.Header>
+                </Accordion.Item>
+            </Accordion.Root>,
+        );
+        expect(screen.getByTestId(ACCORDION_TEST_ID)).toHaveAttribute('data-sticky-background', 'false');
+    });
+
+    it('should apply stickyBackground when enabled', () => {
+        render(
+            <Accordion.Root data-test-id={ACCORDION_TEST_ID} variant="pill" sticky stickyBackground>
+                <Accordion.Item value="1">
+                    <Accordion.Header>{ACCORDION_TEXT}</Accordion.Header>
+                </Accordion.Item>
+            </Accordion.Root>,
+        );
+        expect(screen.getByTestId(ACCORDION_TEST_ID)).toHaveAttribute('data-sticky-background', 'true');
+    });
+
+    it('should default caretAlignment to inline and mark headers without slots', () => {
+        render(
+            <Accordion.Root data-test-id={ACCORDION_TEST_ID}>
+                <Accordion.Item value="1">
+                    <Accordion.Header>{ACCORDION_TEXT}</Accordion.Header>
+                </Accordion.Item>
+            </Accordion.Root>,
+        );
+        const trigger = screen.getByTestId('fondue-accordion-header');
+        expect(trigger).toHaveAttribute('data-caret-alignment', 'inline');
+        expect(trigger).toHaveAttribute('data-has-slots', 'false');
+    });
+
+    it('should mark headers that render slots as having slots', () => {
+        render(
+            <Accordion.Root data-test-id={ACCORDION_TEST_ID} caretAlignment="end">
+                <Accordion.Item value="1">
+                    <Accordion.Header>
+                        {ACCORDION_TEXT}
+                        <Accordion.Slot>slot content</Accordion.Slot>
+                    </Accordion.Header>
+                </Accordion.Item>
+            </Accordion.Root>,
+        );
+        const trigger = screen.getByTestId('fondue-accordion-header');
+        expect(trigger).toHaveAttribute('data-caret-alignment', 'end');
+        expect(trigger).toHaveAttribute('data-has-slots', 'true');
+    });
 });

--- a/packages/components/src/components/Accordion/__tests__/Accordion.spec.tsx
+++ b/packages/components/src/components/Accordion/__tests__/Accordion.spec.tsx
@@ -66,7 +66,7 @@ describe('Accordion Component', () => {
         expect(screen.getByTestId(ACCORDION_TEST_ID)).toHaveAttribute('data-sticky-background', 'true');
     });
 
-    it('should default caretAlignment to inline and mark headers without slots', () => {
+    it('should default caretAlignment to inline', () => {
         render(
             <Accordion.Root data-test-id={ACCORDION_TEST_ID}>
                 <Accordion.Item value="1">
@@ -74,12 +74,10 @@ describe('Accordion Component', () => {
                 </Accordion.Item>
             </Accordion.Root>,
         );
-        const trigger = screen.getByTestId('fondue-accordion-header');
-        expect(trigger).toHaveAttribute('data-caret-alignment', 'inline');
-        expect(trigger).toHaveAttribute('data-has-slots', 'false');
+        expect(screen.getByTestId('fondue-accordion-header')).toHaveAttribute('data-caret-alignment', 'inline');
     });
 
-    it('should mark headers that render slots as having slots', () => {
+    it('should apply caretAlignment to headers regardless of whether they render slots', () => {
         render(
             <Accordion.Root data-test-id={ACCORDION_TEST_ID} caretAlignment="end">
                 <Accordion.Item value="1">
@@ -90,8 +88,6 @@ describe('Accordion Component', () => {
                 </Accordion.Item>
             </Accordion.Root>,
         );
-        const trigger = screen.getByTestId('fondue-accordion-header');
-        expect(trigger).toHaveAttribute('data-caret-alignment', 'end');
-        expect(trigger).toHaveAttribute('data-has-slots', 'true');
+        expect(screen.getByTestId('fondue-accordion-header')).toHaveAttribute('data-caret-alignment', 'end');
     });
 });

--- a/packages/components/src/components/Accordion/styles/accordion.module.scss
+++ b/packages/components/src/components/Accordion/styles/accordion.module.scss
@@ -143,9 +143,9 @@
         box-shadow: 0 1px 0 var(--color-line-subtle);
     }
 
-    &:has(.accordionTrigger[data-caret-alignment='end'][data-has-slots='false']) {
-        grid-template-columns: 1fr max-content;
-        grid-template-areas: "content caret";
+    &:has(.accordionTrigger[data-caret-alignment='end']) {
+        grid-template-columns: auto 1fr max-content max-content;
+        grid-template-areas: "content slot actions caret";
     }
 }
 
@@ -161,10 +161,6 @@
     text-align: start;
     width: 100%;
     padding: var(--accordion-vertical-padding) var(--accordion-horizontal-padding);
-
-    &[data-caret-alignment='end'][data-has-slots='false'] {
-        grid-column: 1 / 3;
-    }
 
     &[data-state='open'],
     &:hover {

--- a/packages/components/src/components/Accordion/styles/accordion.module.scss
+++ b/packages/components/src/components/Accordion/styles/accordion.module.scss
@@ -62,6 +62,14 @@
             background-color: var(--color-surface-active);
         }
 
+        &[data-sticky='true'][data-sticky-background='true'] .accordionHeader {
+            background-color: var(--color-surface-dim);
+        }
+
+        &[data-sticky='true'][data-sticky-background='true'] .accordionItem[data-state='open'] .accordionHeader {
+            background-color: var(--color-surface-active);
+        }
+
         .accordionSlot[data-name='action'] {
             padding-inline-end: var(--pill-header-horizontal-padding);
         }
@@ -134,6 +142,11 @@
     .accordionItem[data-stuck='true'] & {
         box-shadow: 0 1px 0 var(--color-line-subtle);
     }
+
+    &:has(.accordionTrigger[data-caret-alignment='end'][data-has-slots='false']) {
+        grid-template-columns: 1fr max-content;
+        grid-template-areas: "content caret";
+    }
 }
 
 .accordionTrigger {
@@ -148,6 +161,10 @@
     text-align: start;
     width: 100%;
     padding: var(--accordion-vertical-padding) var(--accordion-horizontal-padding);
+
+    &[data-caret-alignment='end'][data-has-slots='false'] {
+        grid-column: 1 / 3;
+    }
 
     &[data-state='open'],
     &:hover {


### PR DESCRIPTION
**Need to ask designer input still how basic component should work!** will adapt pr based on this.

## What changed
Adds two opt-in `Accordion.Root` props for the pill variant:
- `stickyBackground` — keeps the pill header's background (instead of falling back to the plain surface background) while it's sticky.
- `caretAlignment: 'end'` — pushes the caret icon flush to the right edge of the header when it has no slots (headers with slots are unaffected).

Both default to the current behavior, so existing usages are unchanged.

<img width="706" height="368" alt="image" src="https://github.com/user-attachments/assets/e120b7cd-6141-4cf5-829c-0b7102c81d91" />

## How to test
In Storybook, open `Components/Accordion` → `WithStickyPillVariant` and scroll the accordion — the header background stays pill-styled while pinned, and the caret on the slot-less item sits at the far right.

## Related
https://linear.app/frontify/issue/DAMCRE-745/use-standard-accordion-for-improved-keyboard-navigation-and-animations