### PR TITLE
feat(SegmentedControl & RadioList): add aria props for improved a11y handling

### DIFF
--- a/.changeset/dark-dancers-marry.md
+++ b/.changeset/dark-dancers-marry.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat(SegmentedControl & RadioList): add aria props for improved a11y handling

--- a/packages/components/src/components/RadioList/RadioList.metadata.json
+++ b/packages/components/src/components/RadioList/RadioList.metadata.json
@@ -1,7 +1,7 @@
 {
     "category": "input",
     "description": "A group of radio buttons for single-choice selection from a list of options. Use when users must pick exactly one option from a small, visible set.",
-    "instructions": "Compose as RadioList.Root > RadioList.RadioButton. Each RadioList.RadioButton requires a unique value prop. Use RadioList.Root with asChild and a Flex container to customize the layout. Pair each RadioButton with a Label for accessibility. Use SegmentedControl for compact 2–5 option toggles inline with other controls. Use Select for longer option lists that should be hidden in a dropdown.",
+    "instructions": "Compose as RadioList.Root > RadioList.RadioButton. Each RadioList.RadioButton requires a unique value prop. Use RadioList.Root with asChild and a Flex container to customize the layout. Pair each RadioButton with a Label for accessibility. The root renders a role=\"radiogroup\", which a Label htmlFor cannot name, so give the group an accessible name with aria-label or with aria-labelledby pointing at the group label, and associate hint or validation text with aria-describedby. Use SegmentedControl for compact 2–5 option toggles inline with other controls. Use Select for longer option lists that should be hidden in a dropdown.",
     "name": "RadioList",
     "relatedComponents": ["Checkbox", "SegmentedControl", "Select"],
     "storyFilePaths": ["src/components/RadioList/RadioList.stories.tsx"],

--- a/packages/components/src/components/RadioList/RadioList.stories.tsx
+++ b/packages/components/src/components/RadioList/RadioList.stories.tsx
@@ -6,6 +6,7 @@ import { useId } from 'react';
 
 import { Flex } from '../Flex/Flex';
 import { Label } from '../Label/Label';
+import { Text } from '../Text/Text';
 import { Tooltip } from '../Tooltip/Tooltip';
 
 import { RadioList, RadioListRoot } from './RadioList';
@@ -131,6 +132,43 @@ export const WithoutLabels: Story = {
                 <RadioList.RadioButton id={idOption2} value="2" />
                 <RadioList.RadioButton id={idOption3} value="3" />
             </RadioList.Root>
+        );
+    },
+};
+
+export const WithGroupLabelAndDescription: Story = {
+    render: (args) => {
+        const id = useId();
+
+        const idGroupLabel = `${id}-group-label`;
+        const idGroupDescription = `${id}-group-description`;
+        const idOption1 = `${id}-option-1`;
+        const idOption2 = `${id}-option-2`;
+
+        return (
+            <Flex direction="column" gap={2}>
+                <Text id={idGroupLabel} weight="strong" size="small">
+                    Visibility
+                </Text>
+
+                {/* The root renders a `role="radiogroup"`, which `label for` cannot name, so the
+                    group label and description are associated through the aria attributes. */}
+                <RadioList.Root {...args} aria-labelledby={idGroupLabel} aria-describedby={idGroupDescription}>
+                    <RadioList.RadioButton id={idOption1} value="1" />
+                    <Label htmlFor={idOption1} required={args.required}>
+                        Everyone
+                    </Label>
+
+                    <RadioList.RadioButton id={idOption2} value="2" />
+                    <Label htmlFor={idOption2} required={args.required}>
+                        Only me
+                    </Label>
+                </RadioList.Root>
+
+                <Text id={idGroupDescription} size="small" color="weak">
+                    Hint text associated with the group through `aria-describedby`.
+                </Text>
+            </Flex>
         );
     },
 };

--- a/packages/components/src/components/RadioList/RadioList.tsx
+++ b/packages/components/src/components/RadioList/RadioList.tsx
@@ -4,39 +4,48 @@ import * as RadioGroupPrimitve from '@radix-ui/react-radio-group';
 import { type ReactNode } from 'react';
 
 import { useFondueTheme } from '#/components/ThemeProvider/ThemeProvider';
+import { type OptionalCommonAriaAttrs } from '#/utilities/types';
 
 import styles from './styles/radiolist.module.scss';
 
-type RadioListRootProps = {
+export type RadioListRootProps = {
     asChild?: boolean;
     children?: ReactNode;
     className?: string;
     disabled?: boolean;
     emphasis?: 'default' | 'highlight';
+    id?: string;
     onValueChange?: (value: string) => void;
     orientation?: 'vertical' | 'horizontal';
     readOnly?: boolean;
     required?: boolean;
     value?: string;
     'data-test-id'?: string;
-};
+} & OptionalCommonAriaAttrs;
 export const RadioListRoot = ({
     asChild,
     children,
     className,
     disabled,
     emphasis = 'default',
+    id,
     onValueChange,
     orientation,
     readOnly,
     required,
     value,
     'data-test-id': dataTestId,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+    'aria-describedby': ariaDescribedby,
 }: RadioListRootProps) => {
     const { dir } = useFondueTheme();
 
     return (
         <RadioGroupPrimitve.Root
+            aria-describedby={ariaDescribedby}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
             aria-readonly={readOnly}
             asChild={asChild}
             className={[className, asChild ? undefined : styles.root].filter(Boolean).join(' ')}
@@ -45,6 +54,7 @@ export const RadioListRoot = ({
             data-test-id={dataTestId}
             dir={dir}
             disabled={disabled}
+            id={id}
             onValueChange={onValueChange}
             orientation={orientation}
             required={required}

--- a/packages/components/src/components/RadioList/__tests__/RadioList.spec.tsx
+++ b/packages/components/src/components/RadioList/__tests__/RadioList.spec.tsx
@@ -185,4 +185,60 @@ describe('RadioList component', () => {
 
         expect(container.querySelector('.custom-wrapper')).toBeInTheDocument();
     });
+
+    it('should name the group with aria-label', () => {
+        render(createRadioList({ 'aria-label': 'Visibility' }));
+
+        expect(screen.getByRole('radiogroup', { name: 'Visibility' })).toBeInTheDocument();
+    });
+
+    it('should name the group with aria-labelledby', () => {
+        render(
+            <>
+                <span id="visibility-label">Visibility</span>
+                {createRadioList({ 'aria-labelledby': 'visibility-label' })}
+            </>,
+        );
+
+        expect(screen.getByRole('radiogroup', { name: 'Visibility' })).toBeInTheDocument();
+    });
+
+    it('should describe the group with aria-describedby', () => {
+        render(
+            <>
+                {createRadioList({ 'aria-label': 'Visibility', 'aria-describedby': 'visibility-hint' })}
+                <span id="visibility-hint">Anyone with the link can view</span>
+            </>,
+        );
+
+        expect(screen.getByRole('radiogroup')).toHaveAccessibleDescription('Anyone with the link can view');
+    });
+
+    it('should not set aria-describedby when none is provided', () => {
+        render(createRadioList({ 'aria-label': 'Visibility' }));
+
+        expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('should forward id to the group', () => {
+        render(createRadioList({ id: 'visibility-group' }));
+
+        expect(screen.getByRole('radiogroup')).toHaveAttribute('id', 'visibility-group');
+    });
+
+    it('should forward the aria attributes when rendered with asChild', () => {
+        render(
+            <RadioList.Root asChild aria-label="Visibility" aria-describedby="visibility-hint">
+                <div>
+                    <RadioList.RadioButton id="option-1" value="1" />
+                    <Label htmlFor="option-1">Option 1</Label>
+                </div>
+            </RadioList.Root>,
+        );
+
+        expect(screen.getByRole('radiogroup', { name: 'Visibility' })).toHaveAttribute(
+            'aria-describedby',
+            'visibility-hint',
+        );
+    });
 });

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.metadata.json
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.metadata.json
@@ -1,7 +1,7 @@
 {
     "category": "input",
     "description": "A compact control for selecting one of 2–5 mutually exclusive options. Use it for view mode switches, layout changes, filter selections, or input choices where all options should remain visible and directly selectable.",
-    "instructions": "Compose as SegmentedControl.Root > SegmentedControl.Item. Each item requires a unique value prop. Use defaultValue for uncontrolled usage or value + onValueChange for controlled. Use hugWidth=false to stretch to container width. Pair with a Label for accessibility. Use Tabs when switching also changes the visible content panel below. Use RadioList for longer option sets.Use RadioList or Select for longer option sets.",
+    "instructions": "Compose as SegmentedControl.Root > SegmentedControl.Item. Each item requires a unique value prop. Use defaultValue for uncontrolled usage or value + onValueChange for controlled. Use hugWidth=false to stretch to container width. The root renders a role=\"radiogroup\", which a Label htmlFor cannot name, so give it an accessible name with aria-label or with aria-labelledby pointing at the Label, and associate hint or validation text with aria-describedby. Use Tabs when switching also changes the visible content panel below. Use RadioList or Select for longer option sets.",
     "name": "SegmentedControl",
     "relatedComponents": ["Tabs", "RadioList", "Select"],
     "storyFilePaths": ["src/components/SegmentedControl/SegmentedControl.stories.tsx"],

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -5,6 +5,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { action } from 'storybook/actions';
 
 import { Label } from '../Label/Label';
+import { Text } from '../Text/Text';
 import { Tooltip } from '../Tooltip/Tooltip';
 
 import { SegmentedControl, SegmentedControlItem, SegmentedControlRoot } from './SegmentedControl';
@@ -148,9 +149,13 @@ export const WithLabel: Story = {
     render: (args) => {
         return (
             <div className="tw-flex tw-flex-col tw-gap-2">
-                <Label htmlFor="segmented-control">Segmented Control</Label>
+                <Label htmlFor="segmented-control" id="segmented-control-label">
+                    Segmented Control
+                </Label>
 
-                <SegmentedControl.Root {...args} id="segmented-control">
+                {/* The root renders a `role="radiogroup"`, which `label for` cannot name, so point
+                    `aria-labelledby` at the label to give the group an accessible name. */}
+                <SegmentedControl.Root {...args} id="segmented-control" aria-labelledby="segmented-control-label">
                     <SegmentedControl.Item value="first">First</SegmentedControl.Item>
                     <SegmentedControl.Item value="second">Second</SegmentedControl.Item>
                     <SegmentedControl.Item value="third">Third</SegmentedControl.Item>
@@ -158,6 +163,38 @@ export const WithLabel: Story = {
             </div>
         );
     },
+};
+
+export const WithLabelAndDescription: Story = {
+    render: (args) => {
+        return (
+            <div className="tw-flex tw-flex-col tw-gap-2">
+                <Label htmlFor="segmented-control-described" id="segmented-control-described-label">
+                    Segmented Control
+                </Label>
+
+                <SegmentedControl.Root
+                    {...args}
+                    id="segmented-control-described"
+                    aria-labelledby="segmented-control-described-label"
+                    aria-describedby="segmented-control-described-hint"
+                >
+                    <SegmentedControl.Item value="first">First</SegmentedControl.Item>
+                    <SegmentedControl.Item value="second">Second</SegmentedControl.Item>
+                    <SegmentedControl.Item value="third">Third</SegmentedControl.Item>
+                </SegmentedControl.Root>
+
+                <Text id="segmented-control-described-hint" size="small" color="weak">
+                    Hint text associated with the group through `aria-describedby`.
+                </Text>
+            </div>
+        );
+    },
+    decorators: (Story) => (
+        <div className="tw-w-80">
+            <Story />
+        </div>
+    ),
 };
 
 export const FullWidth: Story = {

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -4,6 +4,7 @@ import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { forwardRef, type ForwardedRef, type ReactElement, type ReactNode } from 'react';
 
 import { useControllableState } from '#/hooks/useControllableState';
+import { type OptionalCommonAriaAttrs } from '#/utilities/types';
 
 import styles from './styles/segmentedControl.module.scss';
 
@@ -33,7 +34,8 @@ export type SegmentedControlRootProps<TValue extends string = string> = {
      * @default true
      */
     hugWidth?: boolean;
-};
+    'data-test-id'?: string;
+} & OptionalCommonAriaAttrs;
 
 export const SegmentedControlRoot = <TValue extends string = string>(
     {

--- a/packages/components/src/components/SegmentedControl/__tests__/SegmentedControl.ct.tsx
+++ b/packages/components/src/components/SegmentedControl/__tests__/SegmentedControl.ct.tsx
@@ -131,6 +131,76 @@ test('should render full width', async ({ mount }) => {
     expect(boundingBox?.width).toBe(550);
 });
 
+test('should name the group with `aria-label`', async ({ mount }) => {
+    const component = await mount(
+        <SegmentedControl.Root
+            data-test-id={SEGMENTED_CONTROL_TEST_ID}
+            defaultValue="first"
+            aria-label="Text alignment"
+        >
+            <SegmentedControl.Item value="first">First</SegmentedControl.Item>
+            <SegmentedControl.Item value="second">Second</SegmentedControl.Item>
+        </SegmentedControl.Root>,
+    );
+
+    await expect(component.getByRole('radiogroup')).toHaveAccessibleName('Text alignment');
+});
+
+test('should name the group with `aria-labelledby`', async ({ mount }) => {
+    const component = await mount(
+        <div>
+            <span id="alignment-label">Text alignment</span>
+
+            <SegmentedControl.Root
+                data-test-id={SEGMENTED_CONTROL_TEST_ID}
+                defaultValue="first"
+                aria-labelledby="alignment-label"
+            >
+                <SegmentedControl.Item value="first">First</SegmentedControl.Item>
+                <SegmentedControl.Item value="second">Second</SegmentedControl.Item>
+            </SegmentedControl.Root>
+        </div>,
+    );
+
+    await expect(component.getByRole('radiogroup')).toHaveAccessibleName('Text alignment');
+});
+
+test('should describe the group with `aria-describedby`', async ({ mount }) => {
+    const component = await mount(
+        <div>
+            <SegmentedControl.Root
+                data-test-id={SEGMENTED_CONTROL_TEST_ID}
+                defaultValue="first"
+                aria-label="Text alignment"
+                aria-describedby="alignment-hint"
+            >
+                <SegmentedControl.Item value="first">First</SegmentedControl.Item>
+                <SegmentedControl.Item value="second">Second</SegmentedControl.Item>
+            </SegmentedControl.Root>
+
+            <span id="alignment-hint">Applies to the whole paragraph</span>
+        </div>,
+    );
+
+    await expect(component.getByRole('radiogroup')).toHaveAccessibleDescription('Applies to the whole paragraph');
+});
+
+test('should forward `id` to the group', async ({ mount }) => {
+    const component = await mount(
+        <SegmentedControl.Root
+            data-test-id={SEGMENTED_CONTROL_TEST_ID}
+            defaultValue="first"
+            id="alignment-control"
+            aria-label="Text alignment"
+        >
+            <SegmentedControl.Item value="first">First</SegmentedControl.Item>
+            <SegmentedControl.Item value="second">Second</SegmentedControl.Item>
+        </SegmentedControl.Root>,
+    );
+
+    await expect(component.getByTestId(SEGMENTED_CONTROL_TEST_ID)).toHaveAttribute('id', 'alignment-control');
+});
+
 test('should work with enum values', async ({ mount }) => {
     // Define an enum for testing generic type functionality
     const enum TabOptions {

--- a/packages/components/src/utilities/types.ts
+++ b/packages/components/src/utilities/types.ts
@@ -12,3 +12,5 @@ export type AriaLabelAttrs = Pick<AriaAttributes, 'aria-label'> & Pick<AriaAttri
 export type AtLeastOneAriaLabelAttr = AtLeastOneAttr<AriaLabelAttrs>;
 
 export type CommonAriaAttrs = Pick<AriaAttributes, 'aria-describedby'> & AtLeastOneAriaLabelAttr;
+
+export type OptionalCommonAriaAttrs = Pick<AriaAttributes, 'aria-describedby'> & AriaLabelAttrs;


### PR DESCRIPTION
Both components render a group of radio buttons, and a group like that needs a name that assistive technology can announce. Neither accepted one. A plain label placed next to the control looks right but names nothing, so the group was silent, and there was no way at all to connect a hint or a validation message to it. Screen reader users never heard either. Consumers could not work around it.

`SegmentedControl.Root` and `RadioList.Root` now accept `aria-label`, `aria-labelledby` and `aria-describedby`. Naming stays optional, so nothing breaks for existing usage.

Also added along the way: `data-test-id` on `SegmentedControl.Root` and `id` on `RadioList.Root`, both of which were missing.
