### PR TITLE
fix: add missing accordion background & fix disabled state

### DIFF
--- a/.changeset/twelve-seas-rhyme.md
+++ b/.changeset/twelve-seas-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix: adjust styling to have background when sticky and pill are combined

--- a/packages/components/src/components/Accordion/__tests__/Accordion.ct.tsx
+++ b/packages/components/src/components/Accordion/__tests__/Accordion.ct.tsx
@@ -393,4 +393,20 @@ test.describe('Accordion Component', () => {
         await expect(componentSmall.locator(ACCORDION_ITEM_TRIGGER_ID)).toHaveCSS('padding-top', '0px');
         await expect(componentSmall.locator(ACCORDION_ITEM_TRIGGER_ID)).toHaveCSS('padding-bottom', '0px');
     });
+
+    test('keeps the pill variant header background when the accordion is also sticky', async ({ mount }) => {
+        const component = await mount(
+            <Accordion.Root variant="pill" sticky>
+                <Accordion.Item value="1">
+                    <Accordion.Header>Header Content</Accordion.Header>
+                    <Accordion.Content>Content</Accordion.Content>
+                </Accordion.Item>
+            </Accordion.Root>,
+        );
+
+        const header = component.getByRole('heading', { name: 'Header Content' });
+
+        await expect(header).toHaveCSS('background-color', 'rgb(248, 248, 245)');
+        await expect(header).not.toHaveCSS('background-color', 'rgb(255, 255, 255)');
+    });
 });

--- a/packages/components/src/components/Accordion/styles/accordion.module.scss
+++ b/packages/components/src/components/Accordion/styles/accordion.module.scss
@@ -154,7 +154,7 @@
     padding: var(--accordion-vertical-padding) var(--accordion-horizontal-padding);
 
     &[data-state='open'],
-    &:hover {
+    &:not([data-disabled]):hover {
         color: var(--color-primary-default);
     }
 

--- a/packages/components/src/components/Accordion/styles/accordion.module.scss
+++ b/packages/components/src/components/Accordion/styles/accordion.module.scss
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 .root {
-    &[data-accordion-padding="none"] {
+    &[data-accordion-padding='none'] {
         --accordion-vertical-padding: 0px;
         --accordion-horizontal-padding: 0px;
     }
@@ -21,7 +21,7 @@
         --accordion-horizontal-padding: var(--spacing-x-large);
     }
 
-    &[data-border="true"] {
+    &[data-border='true'] {
         border-bottom: var(--border-width-default) solid var(--color-line-subtle);
         border-top: var(--border-width-default) solid var(--color-line-subtle);
     }
@@ -52,6 +52,10 @@
             border-radius: var(--border-radius-large);
             background-color: var(--color-surface-dim);
             transition: background-color 150ms ease;
+        }
+
+        &[data-sticky='true'] .accordionHeader {
+            background-color: var(--color-surface-dim);
         }
 
         .accordionItem:not([data-disabled]) .accordionHeader:hover {
@@ -108,7 +112,7 @@
     min-width: fit-content;
     display: grid;
     grid-template-columns: auto 1rem 1fr max-content;
-    grid-template-areas: "content caret slot actions";
+    grid-template-areas: 'content caret slot actions';
     gap: 0.75rem;
 
     & > .accordionSlot {


### PR DESCRIPTION
When `variant="pill"` and `sticky` were combined, the background on the accordion header was missing

- Added styles to apply the correct background color
- Removed hover state (text color) on disabled items