### PR TITLE
feat: adjust card styles to match figma design

### DIFF
--- a/.changeset/many-candles-return.md
+++ b/.changeset/many-candles-return.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+feat: minor style adjustments in card component

--- a/packages/components/src/components/Card/styles/card.module.scss
+++ b/packages/components/src/components/Card/styles/card.module.scss
@@ -70,7 +70,10 @@
         'thumbnail  title        badges   actions'
         'thumbnail  description  badges   actions';
     grid-template-columns: auto 1fr auto auto;
-    grid-template-rows: auto minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto) minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto);
+    grid-template-rows: auto minmax(calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)), auto) minmax(
+            calc(#{sizeToken.get(10)} / 2 + var(--spacing-small)),
+            auto
+        );
     border-radius: var(--border-radius-large);
     box-sizing: border-box;
     background-color: var(--color-surface-default);
@@ -103,27 +106,18 @@
         // Hover state (also when a dropdown is open inside the card)
         &:hover,
         &:has([data-state='open']) {
-            @include card-state(
-                $card-shadow: inset 0 0 0 1px var(--color-line-subtle),
-                $root-bg: 'surface-hover'
-            );
+            @include card-state($card-shadow: inset 0 0 0 1px var(--color-line-subtle), $root-bg: 'surface-hover');
         }
 
         // Selected state
         &[data-selected='true'] {
-            @include card-state(
-                $card-shadow: inset 0 0 0 1px var(--color-line-strong),
-                $root-bg: 'surface-dim'
-            );
+            @include card-state($card-shadow: inset 0 0 0 1px var(--color-line-strong), $root-bg: 'surface-default');
         }
 
         // Hover + Selected state (also when a dropdown is open inside the card)
         &[data-selected='true']:hover,
         &[data-selected='true']:has([data-state='open']) {
-            @include card-state(
-                $card-shadow: inset 0 0 0 1px var(--color-line-strong),
-                $root-bg: 'surface-hover'
-            );
+            @include card-state($card-shadow: inset 0 0 0 1px var(--color-line-strong), $root-bg: 'surface-hover');
         }
 
         // Pressed state (while actively clicking, via :active)
@@ -260,17 +254,12 @@
     justify-content: center;
     width: 100%;
     height: 100%;
-    color: var(--color-secondary-default);
+    color: var(--color-low-contrast-default);
     @include transitions.transition-colors;
 
     > svg {
         width: sizeToken.get(10);
         height: sizeToken.get(10);
-    }
-
-    .root[data-interactive='true']:hover &,
-    .root[data-interactive='true']:has([data-state='open']) & {
-        color: var(--color-primary-default);
     }
 
     // Inverted banner tone forces a white icon on the dark background, winning
@@ -366,10 +355,6 @@
     align-self: center;
     margin: var(--spacing-small) 0 var(--spacing-small) var(--spacing-small);
     pointer-events: none;
-
-    .root[data-interactive='true'][data-selected='true'] & {
-        background-color: var(--color-surface-default);
-    }
 }
 
 .thumbnailImage {
@@ -380,6 +365,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    color: var(--color-low-contrast-default);
     @include transitions.transition-colors;
 }
 


### PR DESCRIPTION
- Adjust icon color to `low-contrast-default`
- Adjust card background in selected state to `surface-default`