### PR TITLE
fix(SegmentedControl): prevent Firefox from collapsing icon only widths

### DIFF
--- a/.changeset/brown-queens-shop.md
+++ b/.changeset/brown-queens-shop.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix(SegmentedControl): prevent Firefox from collapsing icon only widths

--- a/packages/components/src/components/SegmentedControl/styles/segmentedControl.module.scss
+++ b/packages/components/src/components/SegmentedControl/styles/segmentedControl.module.scss
@@ -51,6 +51,7 @@ $radius-without-border: calc(var(--border-radius-medium) - var(--border-width-de
 
     &[data-icon-only='true'] {
         aspect-ratio: 1;
+        width: sizeToken.get(9);
     }
 
     &[data-icon-only='true'] .itemLabel {


### PR DESCRIPTION
Before:
<img width="96" height="68" alt="Screenshot 2026-09-01 at 14 36 11" src="https://github.com/user-attachments/assets/7f000e33-456b-44c4-9556-1fdb53a46862" />

Now:
<img width="263" height="96" alt="Screenshot 2026-09-01 at 14 36 42" src="https://github.com/user-attachments/assets/fbc63ca2-782b-4a1a-969c-6d10de1a6c3d" />
