### PR TITLE
fix: add patch for the bug in radix' scroll area

### DIFF
--- a/.changeset/lazy-eyes-peel.md
+++ b/.changeset/lazy-eyes-peel.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix: add patch for radix scrollarea to avoid bug during minification

--- a/packages/components/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -1,6 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { LoadingCircle } from '../LoadingCircle/LoadingCircle';
 
 import { ScrollArea } from './ScrollArea';
 
@@ -296,3 +299,68 @@ export const WithStableGutter: Story = {
         );
     },
 };
+
+const PAGE_SIZE = 30;
+const LOAD_DELAY_MS = 800;
+
+export const LazyLoading: Story = {
+    render: (args) => {
+        const [items, setItems] = useState<number[]>(() => Array.from({ length: PAGE_SIZE }, (_, i) => i));
+        const [isLoading, setIsLoading] = useState(false);
+        const viewportRef = useRef<HTMLDivElement>(null);
+        const isLoadingRef = useRef(false);
+
+        const loadMore = useCallback(() => {
+            if (isLoadingRef.current) {
+                return;
+            }
+            isLoadingRef.current = true;
+            setIsLoading(true);
+
+            setTimeout(() => {
+                setItems((previousItems) =>
+                    previousItems.concat(
+                        Array.from({ length: PAGE_SIZE }, (_, i) => previousItems.length + i),
+                    ),
+                );
+                isLoadingRef.current = false;
+                setIsLoading(false);
+            }, LOAD_DELAY_MS);
+        }, []);
+
+        useEffect(() => {
+            const viewport = viewportRef.current;
+            if (!viewport) {
+                return;
+            }
+
+            const handleScroll = () => {
+                const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+                if (distanceFromBottom < 100) {
+                    loadMore();
+                }
+            };
+
+            viewport.addEventListener('scroll', handleScroll);
+            return () => viewport.removeEventListener('scroll', handleScroll);
+        }, [loadMore]);
+
+        return (
+            <ScrollArea {...args} ref={viewportRef} maxHeight={300} maxWidth={400} type="always">
+                <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+                    {items.map((item) => (
+                        <li key={item} style={{ padding: '8px 12px', borderBottom: '1px solid #e5e5e5' }}>
+                            Item #{item + 1}
+                        </li>
+                    ))}
+                </ul>
+                {isLoading && (
+                    <div style={{ display: 'flex', justifyContent: 'center', padding: '12px' }}>
+                        <LoadingCircle />
+                    </div>
+                )}
+            </ScrollArea>
+        );
+    },
+};
+

--- a/packages/components/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/components/src/components/ScrollArea/ScrollArea.tsx
@@ -67,6 +67,7 @@ const ScrollAreaComponent = (
             style={{ maxWidth }}
             data-component="scroll-area"
             data-test-id={dataTestId}
+            data-reproduction-identifier="patched"
         >
             <RadixScrollArea.Viewport
                 ref={ref}

--- a/patches/@radix-ui__react-scroll-area@1.2.18.patch
+++ b/patches/@radix-ui__react-scroll-area@1.2.18.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/index.js b/dist/index.js
+index 54e1bd29d062ad8cab1568bf43905ee3371faa87..515bc106d51aeace1b4301d7306e51baf3b3aea3 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -748,14 +748,16 @@ var addUnlinkedScrollListener = /* @__PURE__ */ __name((node, handler = () => {
+ }) => {
+   let prevPosition = { left: node.scrollLeft, top: node.scrollTop };
+   let rAF = 0;
+-  (/* @__PURE__ */ __name((function loop() {
++  function loop() {
+     const position = { left: node.scrollLeft, top: node.scrollTop };
+     const isHorizontalScroll = prevPosition.left !== position.left;
+     const isVerticalScroll = prevPosition.top !== position.top;
+     if (isHorizontalScroll || isVerticalScroll) handler();
+     prevPosition = position;
+     rAF = window.requestAnimationFrame(loop);
+-  }), "loop"))();
++  }
++  __name(loop, "loop");
++  loop();
+   return () => window.cancelAnimationFrame(rAF);
+ }, "addUnlinkedScrollListener");
+ function useDebounceCallback(callback, delay) {
+diff --git a/dist/index.mjs b/dist/index.mjs
+index b98d4bc14ad4184b2f46b28679fb5f8d55767782..4662ba3050eccd6711a508769fc6f42f6e33706e 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -704,14 +704,16 @@ var addUnlinkedScrollListener = /* @__PURE__ */ __name((node, handler = () => {
+ }) => {
+   let prevPosition = { left: node.scrollLeft, top: node.scrollTop };
+   let rAF = 0;
+-  (/* @__PURE__ */ __name((function loop() {
++  function loop() {
+     const position = { left: node.scrollLeft, top: node.scrollTop };
+     const isHorizontalScroll = prevPosition.left !== position.left;
+     const isVerticalScroll = prevPosition.top !== position.top;
+     if (isHorizontalScroll || isVerticalScroll) handler();
+     prevPosition = position;
+     rAF = window.requestAnimationFrame(loop);
+-  }), "loop"))();
++  }
++  __name(loop, "loop");
++  loop();
+   return () => window.cancelAnimationFrame(rAF);
+ }, "addUnlinkedScrollListener");
+ function useDebounceCallback(callback, delay) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@radix-ui/react-scroll-area@1.2.18': 19ef437e506ca1bc96f6a891736c3a9725b7544c603a65fc476ada4d556863ed
+
 importers:
 
   .:
@@ -236,7 +239,7 @@ importers:
         version: 1.4.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.18
-        version: 1.2.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.2.18(patch_hash=19ef437e506ca1bc96f6a891736c3a9725b7544c603a65fc476ada4d556863ed)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-select':
         specifier: ^2.3.7
         version: 2.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12941,7 +12944,7 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
-  '@radix-ui/react-scroll-area@1.2.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-scroll-area@1.2.18(patch_hash=19ef437e506ca1bc96f6a891736c3a9725b7544c603a65fc476ada4d556863ed)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/number': 1.1.3
       '@radix-ui/primitive': 1.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,6 @@ publicHoistPattern:
     - "*tailwind*"
 
 confirmModulesPurge: false
+
+patchedDependencies:
+    "@radix-ui/react-scroll-area@1.2.18": patches/@radix-ui__react-scroll-area@1.2.18.patch


### PR DESCRIPTION
In the latest version of the radix packages, a change in function annotations caused a bug which causes a loop for refreshing the thumb position of a scroll area to be deleted during minification.

Open PRs on the radix repo:
https://github.com/radix-ui/primitives/pull/4132
https://github.com/radix-ui/primitives/issues/4097

Until these changes are merged, i added a patch that fixes the accidental removal by swc.

Before:

https://github.com/user-attachments/assets/4b472506-94e3-4e70-8bb7-e3dfcd1d9f69

After:

https://github.com/user-attachments/assets/2cc58a88-e828-4f83-a3d4-914efbc07f85

Fixes FP-554

