### PR TITLE
fix: add missing title attribute on table header

### DIFF
--- a/.changeset/fair-peas-behave.md
+++ b/.changeset/fair-peas-behave.md
@@ -1,0 +1,6 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue": patch
+---
+
+fix: missing title attribute on table header

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -278,8 +278,10 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
         const { t } = useTranslation();
         const cellRef = useRef<HTMLTableCellElement>(null);
         useSyncRefs<HTMLTableCellElement>(cellRef, ref);
+        const textRef = useRef<HTMLSpanElement>(null);
 
         useTextTruncation(cellRef);
+        useTextTruncation(textRef);
 
         const sortLabel = useMemo(() => {
             if (typeof children === 'string') {
@@ -319,7 +321,9 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
                 {state === 'loading' ? (
                     <div className={styles.cellContent} aria-live="polite" aria-label={loadingStateAriaLabel}>
                         {typeof children === 'string' && truncate ? (
-                            <span className={styles.buttonText}>{children}</span>
+                            <span ref={textRef} className={styles.buttonText}>
+                                {children}
+                            </span>
                         ) : (
                             children
                         )}
@@ -334,7 +338,9 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
                         type="button"
                     >
                         {typeof children === 'string' && truncate ? (
-                            <span className={styles.buttonText}>{children}</span>
+                            <span ref={textRef} className={styles.buttonText}>
+                                {children}
+                            </span>
                         ) : (
                             children
                         )}

--- a/packages/components/src/components/Table/__tests__/Table.ct.tsx
+++ b/packages/components/src/components/Table/__tests__/Table.ct.tsx
@@ -457,6 +457,34 @@ test('should set title when content is truncated', async ({ mount }) => {
     );
 });
 
+test('should set title on sortable header cell when content is truncated', async ({ mount }) => {
+    const wrapper = await mount(
+        <div style={{ width: '200px' }}>
+            <Table.Root layout="fixed" aria-label="Table" data-test-id="table-root">
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell width="100px" truncate onSortChange={() => {}}>
+                            This is a very long header cell content that should definitely get truncated
+                        </Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    <Table.Row>
+                        <Table.RowCell>Test</Table.RowCell>
+                    </Table.Row>
+                </Table.Body>
+            </Table.Root>
+        </div>,
+    );
+    const component = wrapper.getByTestId('table-root');
+
+    const headerCellText = component.locator('th button span');
+    await expect(headerCellText).toHaveAttribute(
+        'title',
+        'This is a very long header cell content that should definitely get truncated',
+    );
+});
+
 test('should support legacy sticky="head" prop', async ({ mount }) => {
     const wrapper = await mount(
         <Table.Root sticky="head" aria-label="Table" data-test-id="table-root">


### PR DESCRIPTION
Add title attribute on table header cell if it is truncated and sortable

Fixes FP-555