### PR TITLE
fix(Dialog): stack portaled overlays above host page content

### DIFF
--- a/.changeset/heavy-dialogs-stack.md
+++ b/.changeset/heavy-dialogs-stack.md
@@ -1,0 +1,18 @@
+---
+"@frontify/fondue-components": patch
+"@frontify/fondue-rte": patch
+"@frontify/fondue": patch
+---
+
+fix(Dialog): stack portaled overlays above host page content
+
+`Dialog` rendered its portal with no `z-index` of its own, so it landed at `auto` and
+lost to any positioned sibling carrying even `z-index: 1` -- for example the
+RichTextEditor's floating link modal, which left the internal LinkChooser rendering
+behind the modal that opened it.
+
+`Dialog` now sits at 20, and `Dropdown`, `Flyout`, `Select` and `Tooltip` at 30 so they
+stay above a `Dialog` they are opened from. The scale lives in
+`utilities/zIndex.module.scss`. Also drops the unused `floatingModal: 1000` entry from
+the RichTextEditor's `zIndexLayers`, which would have re-broken this the moment it was
+wired up.

--- a/packages/components/src/components/Dialog/styles/dialog.module.scss
+++ b/packages/components/src/components/Dialog/styles/dialog.module.scss
@@ -4,6 +4,7 @@
 @use '../../../utilities/focusStyle.module.scss';
 @use '../../../utilities/transitions.module.scss';
 @use '../../../utilities/mediaQuery.module.scss';
+@use '../../../utilities/zIndex.module.scss';
 
 .content {
     display: block;
@@ -270,6 +271,7 @@
 .underlay {
     position: fixed;
     inset: 0;
+    z-index: zIndex.get(dialog);
     background-color: rgb(from var(--color-primary-default) r g b / 0);
     pointer-events: auto;
 

--- a/packages/components/src/components/Dropdown/styles/dropdown.module.scss
+++ b/packages/components/src/components/Dropdown/styles/dropdown.module.scss
@@ -5,10 +5,12 @@
 @use '../../../utilities/mediaQuery.module.scss';
 @use '../../../utilities/shadow.module.scss';
 @use '../../../utilities/focusStyle.module.scss';
+@use '../../../utilities/zIndex.module.scss';
 
 .content,
 .subContent {
     display: block;
+    z-index: zIndex.get(popover);
     border-radius: var(--border-radius-medium);
     background-color: var(--color-surface-default);
     border: var(--border-width-default) solid var(--color-line-subtle);

--- a/packages/components/src/components/Flyout/styles/flyout.module.scss
+++ b/packages/components/src/components/Flyout/styles/flyout.module.scss
@@ -4,8 +4,10 @@
 @use '../../../utilities/sizeToken.module.scss';
 @use '../../../utilities/shadow.module.scss';
 @use '../../../utilities/focusStyle.module.scss';
+@use '../../../utilities/zIndex.module.scss';
 
 .root {
+    z-index: zIndex.get(popover);
     display: flex;
     flex-direction: column;
     background-color: var(--color-surface-default);
@@ -60,6 +62,7 @@
 .overlay {
     content: '';
     position: fixed;
+    z-index: zIndex.get(popover);
     top: 0;
     left: 0;
     width: 100dvw;

--- a/packages/components/src/components/Select/styles/select.module.scss
+++ b/packages/components/src/components/Select/styles/select.module.scss
@@ -5,6 +5,7 @@
 @use '../../../utilities/transitions.module.scss';
 @use '../../../utilities/mediaQuery.module.scss';
 @use '../../../utilities/shadow.module.scss';
+@use '../../../utilities/zIndex.module.scss';
 
 .root {
     position: relative;
@@ -283,7 +284,7 @@
 }
 
 .portal {
-    z-index: 30;
+    z-index: zIndex.get(popover);
 
     &[data-side='bottom'] {
         margin-block-start: sizeToken.get(2);

--- a/packages/components/src/components/Tooltip/styles/tooltip.module.scss
+++ b/packages/components/src/components/Tooltip/styles/tooltip.module.scss
@@ -2,8 +2,10 @@
 
 @use '../../../utilities/sizeToken.module.scss';
 @use '../../../utilities/text.module.scss';
+@use '../../../utilities/zIndex.module.scss';
 
 .root {
+    z-index: zIndex.get(popover);
     background-color: var(--color-primary-default);
     color: var(--color-primary-on-primary);
     border-radius: var(--border-radius-medium);

--- a/packages/components/src/utilities/zIndex.module.scss
+++ b/packages/components/src/utilities/zIndex.module.scss
@@ -1,0 +1,34 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+@use 'sass:map';
+
+/*
+ * Stacking order for portaled overlays.
+ *
+ * Every overlay in this package portals to `document.body`, and the outermost node of
+ * each portal is a `position: static` ThemeProvider wrapper -- which cannot carry a
+ * z-index. The value therefore belongs on the positioned element inside the portal:
+ * the `Dialog` underlay, or the Radix `Content` class for popper-based overlays (Radix
+ * copies the content's computed z-index onto `[data-radix-popper-content-wrapper]`).
+ *
+ * `dialog` has to clear host page content. Without a value here it lands at `auto` and
+ * loses to literally any positioned sibling carrying `z-index: 1`.
+ *
+ * `popover` covers Dropdown, Flyout, Select and Tooltip. These can be opened from
+ * inside a Dialog, so they must stay above it -- do not lower them below `dialog`.
+ *
+ * Keep this in sync with the RichTextEditor's own scale in
+ * `packages/rte/src/components/RichTextEditor/helpers/zIndexLayers.ts`.
+ */
+$layers: (
+    dialog: 20,
+    popover: 30,
+);
+
+@function get($layer) {
+    @if not map.has-key($layers, $layer) {
+        @error "Unknown z-index layer `#{$layer}`. Known layers: #{map.keys($layers)}.";
+    }
+
+    @return map.get($layers, $layer);
+}

--- a/packages/rte/src/components/RichTextEditor/helpers/zIndexLayers.ts
+++ b/packages/rte/src/components/RichTextEditor/helpers/zIndexLayers.ts
@@ -6,5 +6,4 @@ export const zIndexLayers = {
     textStyleDropdown: 52,
     combobox: 100,
     emojiPopover: 100,
-    floatingModal: 1000,
 };


### PR DESCRIPTION
## Problem

`Dialog` renders its portal with no `z-index` of its own. The `.content` rule carries `z-index: 1`, but `.underlay` is `position: fixed` and therefore its own stacking context, so that `1` is scoped and invisible from the outside — the whole dialog competes at `z-index: auto`.

That means it loses to any positioned sibling carrying even `z-index: 1`. Confirmed on a production guideline: the RichTextEditor's floating link modal sits at `z-index: 1` / `position: absolute`, the LinkChooser dialog root at `auto` / `position: static`, so the chooser renders *behind* the modal that opened it. Notably the dialog was later in the DOM — DOM order favoured it, and the single `z-index: 1` overrode that.

## Fix

The value has to go on the positioned element *inside* each portal. The outermost node is a `position: static` `ThemeProvider` wrapper where `z-index` is inert; for the popper-based overlays that means the Radix `Content` class, whose computed `z-index` Radix copies onto `[data-radix-popper-content-wrapper]` — the mechanism `Select` was already relying on at 30.

| Layer | Value | Components |
| --- | --- | --- |
| `dialog` | 20 | `Dialog` underlay |
| `popover` | 30 | `Dropdown`, `Flyout`, `Select`, `Tooltip` |

All four popovers portal to `document.body` with no container, so today they clear an open `Dialog` only by DOM order. Once the dialog has a layer they must be lifted too, or a dropdown opened *inside* a dialog falls behind it. The scale and that constraint are documented in `utilities/zIndex.module.scss`.

Also drops the unused `floatingModal: 1000` from the RTE's `zIndexLayers` — nothing references it, and it would have re-broken this the moment it was wired up.

## Verification

- All five Sass modules compile; emitted output confirmed as `.underlay{z-index:20}` and `z-index:30` on the four popover classes.
- No remaining references to `floatingModal`.
- ⚠️ **Test suite not run.** `pnpm install` fails in my checkout for a pre-existing, unrelated reason (`EACCES` — root-owned `node_modules` from an earlier `sudo` install), which leaves `@vitejs/plugin-react` unresolvable and blocks both `pnpm build` and `vitest`. **The Playwright snapshot tests in particular need a run before merge.**

## Notes for review

- The value choice is deliberately conservative to limit blast radius against consumer chrome. The trade-off: the RTE's own `floatingToolbar` (50) and `combobox`/`emojiPopover` (100) still paint above an open dialog. That is pre-existing, not introduced here — but if we'd rather clear the whole RTE range it is a one-line change to `dialog: 200` / `popover: 300`.
- `Select`'s bare `30` became `zIndex.get(popover)` with no behaviour change.
- Needs a companion web-app change: its Themes RTE hardcodes `zIndex: 50` inline, which still beats `dialog: 20`. PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)